### PR TITLE
Add test case for Card with no image

### DIFF
--- a/src/components/card/__tests__/card-test-cases.js
+++ b/src/components/card/__tests__/card-test-cases.js
@@ -6,7 +6,7 @@ const noRenderCases = {};
 
 testCases.basic = {
   component: Card,
-  description: 'Plain ol card',
+  description: 'Card with image',
   props: {
     title: 'Title',
     path: 'url',
@@ -21,6 +21,16 @@ testCases.basic = {
         }}
       />
     ),
+    description: 'described.'
+  }
+};
+
+testCases.noImage = {
+  component: Card,
+  description: 'Card with no image',
+  props: {
+    title: 'Title',
+    path: 'url',
     description: 'described.'
   }
 };


### PR DESCRIPTION
When I merged the two card types into one in #17, I forgot to add a test case for a `Card` without an image.

![image](https://user-images.githubusercontent.com/10479155/42790193-87f7e2f2-891e-11e8-956f-0e5091d4cb23.png)
