### PR TITLE
Remove product menu class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2644,11 +2644,6 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@mapbox/react-icon": "^0.2.2",
     "@mapbox/react-icon-button": "^0.3.9",
     "@mapbox/react-popover-trigger": "^0.5.6",
-    "extend": "^3.0.1"
+    "extend": "^3.0.1",
     "classnames": "^2.2.6",
     "debounce": "^1.1.0",
     "react-stickynode": "^2.0.1"

--- a/src/components/product-menu/product-menu.js
+++ b/src/components/product-menu/product-menu.js
@@ -6,13 +6,12 @@ import Icon from '@mapbox/react-icon';
 const popoverUserStyle = {
   style: {
     maxHeight: '90vh',
-    minHeight: '100%',
-    backgroundColor: '#fff'
+    minHeight: '100%'
   }
 };
 const popoverProps = {
   placement: 'bottom',
-  themePopover: 'round shadow-darken25 scroll-auto scroll-styled',
+  themePopover: 'round shadow-darken25 scroll-auto scroll-styled bg-white',
   contentElementAttributes: popoverUserStyle
 };
 

--- a/src/components/product-menu/product-menu.js
+++ b/src/components/product-menu/product-menu.js
@@ -3,10 +3,17 @@ import PropTypes from 'prop-types';
 import PopoverTrigger from '@mapbox/react-popover-trigger';
 import Icon from '@mapbox/react-icon';
 
+const popoverUserStyle = {
+  style: {
+    maxHeight: '90vh',
+    minHeight: '100%',
+    backgroundColor: '#fff'
+  }
+};
 const popoverProps = {
   placement: 'bottom',
-  themePopover:
-    'round shadow-darken25 viewport-almost-but-not-always scroll-auto scroll-styled'
+  themePopover: 'round shadow-darken25 scroll-auto scroll-styled',
+  contentElementAttributes: popoverUserStyle
 };
 
 class ProductMenu extends React.PureComponent {


### PR DESCRIPTION
After chatting with @davidtheclark, it seems that the best way to handle the custom class in this component is by inlining the style we need instead of relying on a class from some external CSS. Thankfully, `react-popover` has a handy `contentElementAttributes` we can use to do just that! 

It looks like `react-popover` also sets a default `backgroundColor` and setting your own `contentElementAttributes` overwrites that default. I am setting the `backgroundColor` explicitly here and may be missing some other, more crafty way to keep that default value! 

Also noticed that I broke package.json with my last PR, so _this_ PR fixes it 😓 