### PR TITLE
Improve existing components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -983,6 +983,12 @@
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
       "dev": true
     },
+    "babel-plugin-syntax-class-properties": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+      "dev": true
+    },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
@@ -1016,6 +1022,18 @@
         "babel-helper-remap-async-to-generator": "^6.24.1",
         "babel-plugin-syntax-async-functions": "^6.8.0",
         "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-class-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-plugin-syntax-class-properties": "^6.8.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -1320,6 +1338,15 @@
       "dev": true,
       "requires": {
         "regenerator-transform": "^0.10.0"
+      }
+    },
+    "babel-plugin-transform-runtime": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
+      "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-strict-mode": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.5",
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
     "babelify": "^8.0.0",

--- a/src/components/examples-page/examples-page.js
+++ b/src/components/examples-page/examples-page.js
@@ -11,12 +11,7 @@ class ExamplesPage extends React.PureComponent {
         </div>
       );
     });
-    return (
-      <div>
-        <h1 className="txt-h1 txt-fancy mb24">{props.frontMatter.title}</h1>
-        {renderedContainers}
-      </div>
-    );
+    return <div>{renderedContainers}</div>;
   }
 }
 

--- a/src/components/page-layout/__tests__/page-layout-test-cases.js
+++ b/src/components/page-layout/__tests__/page-layout-test-cases.js
@@ -1,7 +1,79 @@
 import React from 'react';
 import PageLayout from '../page-layout';
+import NavigationAccordion from '../../navigation-accordion/navigation-accordion';
 
 const testCases = {};
+
+testCases.commonUseCase = {
+  description: 'Common use case',
+  component: PageLayout,
+  props: {
+    sidebarContent: (
+      <NavigationAccordion
+        currentPath="page-one"
+        contents={{
+          firstLevelItems: [
+            {
+              title: 'Title one',
+              path: 'page-one'
+            },
+            {
+              title: 'Title two',
+              path: 'page-two'
+            }
+          ],
+          secondLevelItems: [
+            {
+              title: 'Heading one',
+              path: 'heading-one'
+            },
+            {
+              title: 'Heading two',
+              path: 'heading-two'
+            }
+          ]
+        }}
+      />
+    ),
+    children: (
+      <div>
+        <p className="mb24">
+          Vestibulum id ligula porta felis euismod semper. Cum sociis natoque
+          penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id
+          ligula porta felis euismod semper.
+        </p>
+        <p className="mb24">
+          Aenean lacinia bibendum nulla sed consectetur. Maecenas sed diam eget
+          risus varius blandit sit amet non magna. Vestibulum id ligula porta
+          felis euismod semper. Lorem ipsum dolor sit amet, consectetur
+          adipiscing elit. Cras justo odio, dapibus ac facilisis in, egestas
+          eget quam. Donec id elit non mi porta gravida at eget metus. Duis
+          mollis, est non commodo luctus, nisi erat porttitor ligula, eget
+          lacinia odio sem nec elit.
+        </p>
+        <p className="mb24">
+          Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas
+          eget quam. Curabitur blandit tempus porttitor. Duis mollis, est non
+          commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec
+          elit. Nullam quis risus eget urna mollis ornare vel eu leo. Praesent
+          commodo cursus magna, vel scelerisque nisl consectetur et. Duis
+          mollis, est non commodo luctus, nisi erat porttitor ligula, eget
+          lacinia odio sem nec elit.
+        </p>
+        <p className="mb24">
+          Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Donec
+          sed odio dui. Aenean eu leo quam. Pellentesque ornare sem lacinia quam
+          venenatis vestibulum. Integer posuere erat a ante venenatis dapibus
+          posuere velit aliquet.
+        </p>
+      </div>
+    ),
+    sidebarContentStickyTop: 60,
+    sidebarContentStickyTopNarrow: 0,
+    sidebarStackedOnNarrowScreens: true
+  }
+};
 
 testCases.basic = {
   description: 'Basic',
@@ -9,19 +81,9 @@ testCases.basic = {
   props: {
     sidebarContent: <div>Some content</div>,
     sidebarTitle: 'Some title',
+    sidebarContentStickyTop: 0,
+    sidebarContentStickyTopNarrow: 0,
     children: <div>Doc content</div>
-  }
-};
-
-testCases.allTheOptions = {
-  description: 'All the options',
-  component: PageLayout,
-  props: {
-    sidebarContent: <div>Some content</div>,
-    children: <div>Doc content</div>,
-    sidebarTheme: 'bg-white',
-    sidebarContentStickyTop: 10,
-    sidebarStackedOnNarrowScreens: true
   }
 };
 

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -8,9 +8,19 @@ class PageLayout extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      height: 0
+      bottomBoundaryValue: 0
     };
     this.debounceHandleWindowResize = debounce(() => {
+      const width = document.body.clientWidth;
+      if (width < 640) {
+        this.setState({
+          topValue: this.props.sidebarContentStickyTopNarrow
+        });
+      } else {
+        this.setState({
+          topValue: this.props.sidebarContentStickyTop
+        });
+      }
       const height = document.body.clientHeight;
       this.setState({
         bottomBoundaryValue: height - 450
@@ -50,11 +60,11 @@ class PageLayout extends React.Component {
             enabled={true}
             bottomBoundary={state.bottomBoundaryValue}
             innerZ={1}
-            top={props.sidebarContentStickyTop}
+            top={state.topValue}
             activeClass="bg-gray-faint"
           >
             <div
-              className={`pt24-mm pt0 viewport-almost-mm scroll-auto ml36 ${sidebarNarrowClasses}`}
+              className={`pt24-mm pt0 viewport-almost-mm scroll-auto ${sidebarNarrowClasses}`}
             >
               {title}
               {props.sidebarContent}
@@ -76,14 +86,14 @@ PageLayout.propTypes = {
   sidebarContent: PropTypes.node.isRequired,
   sidebarTitle: PropTypes.string,
   sidebarTheme: PropTypes.string,
-  sidebarContentStickyTop: PropTypes.number,
+  sidebarContentStickyTop: PropTypes.number.isRequired,
+  sidebarContentStickyTopNarrow: PropTypes.number.isRequired,
   sidebarStackedOnNarrowScreens: PropTypes.bool,
   children: PropTypes.node.isRequired
 };
 
 PageLayout.defaultProps = {
   sidebarTheme: 'bg-gray-faint',
-  sidebarContentStickyTop: 50,
   sidebarStackedOnNarrowScreens: false
 };
 

--- a/src/data/product-menu-items.js
+++ b/src/data/product-menu-items.js
@@ -18,6 +18,10 @@ const ProductMenuItems = [
       {
         url: '/unity-sdk/',
         name: 'Maps SDK for Unity'
+      },
+      {
+        url: '/help/studio-manual/',
+        name: 'Mapbox Studio'
       }
     ]
   },
@@ -46,16 +50,6 @@ const ProductMenuItems = [
       {
         url: '/android-docs/java/',
         name: 'Java SDK'
-      }
-    ]
-  },
-  {
-    productCategory: 'Mapbox Studio',
-    icon: 'palette',
-    products: [
-      {
-        url: '/help/studio-manual/',
-        name: 'Mapbox Studio manual'
       }
     ]
   },


### PR DESCRIPTION
Closes #32 

1️⃣ `PageLayout` allows different `top` props for wide and narrow screens. 

![better-sticky-top](https://user-images.githubusercontent.com/10479155/43101415-3478d8a2-8e7d-11e8-8694-4e5eb8a25fac.gif)

2️⃣ `ExamplesPage` no longer includes a title. That should be the responsibility of the PageShell. 

3️⃣ "Mapbox Studio manual" --> "Mapbox Studio" and move to the Maps section of the `ProductMenu`.

![image](https://user-images.githubusercontent.com/10479155/43101912-851a9470-8e7e-11e8-8d39-2e2fa1e1a3cc.png)
