### PR TITLE
Prevent extra whitespace in NavigationAccordion for pages with no headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## Master
+
+- Prevent an empty array from being passed to `secondLevelItems` in `NavigationAccordion`. ([#44](https://github.com/mapbox/dr-ui/pull/44))

--- a/src/components/navigation-accordion/navigation-accordion.js
+++ b/src/components/navigation-accordion/navigation-accordion.js
@@ -46,7 +46,7 @@ class NavigationAccordion extends React.PureComponent {
           );
         }
         let renderedSecondLevelContent = '';
-        if (isActive && secondLevelContent) {
+        if (isActive && secondLevelContent && secondLevelContent.length > 0) {
           renderedSecondLevelContent = (
             <div className="ml24 pt0">
               <ul className="txt-m pb12 inline-block-mm none unprose">


### PR DESCRIPTION
Fixes #40 

@davidtheclark this was happening because I was feeding the `secondLevelItems` prop an empty array. I'm not sure if this is something that should be prevented here or in the documentation style guide itself. 