### PR TITLE
Add option to make an item active in SectionedNavigtion

### DIFF
--- a/src/components/sectioned-navigation/__tests__/sectioned-navigation-test-cases.js
+++ b/src/components/sectioned-navigation/__tests__/sectioned-navigation-test-cases.js
@@ -18,7 +18,8 @@ testCases.standard = {
           },
           {
             text: 'Mark a place',
-            url: '#footoo'
+            url: '#footoo',
+            active: true
           },
           {
             text: 'Apply a style',

--- a/src/components/sectioned-navigation/sectioned-navigation-section.js
+++ b/src/components/sectioned-navigation/sectioned-navigation-section.js
@@ -22,8 +22,12 @@ class SectionedNavigationSection extends React.Component {
 
   renderItems() {
     return this.props.items.map(item => {
+      let activeClass = '';
+      if (item.active === true) {
+        activeClass = 'txt-bold';
+      }
       return (
-        <li key={item.url} className="mt6">
+        <li key={item.url} className={`mt6 ${activeClass}`}>
           <a href={item.url} className="color-blue-on-hover">
             {item.text}
           </a>
@@ -48,7 +52,8 @@ SectionedNavigationSection.propTypes = {
   items: PropTypes.arrayOf(
     PropTypes.shape({
       text: PropTypes.string.isRequired,
-      url: PropTypes.string.isRequired
+      url: PropTypes.string.isRequired,
+      active: PropTypes.bool
     })
   ).isRequired,
   includeCount: PropTypes.bool


### PR DESCRIPTION
Adds an active class to items so we can display the SectionedNavigation on individual examples pages and have a way to indicate which example you're currently viewing. 

![image](https://user-images.githubusercontent.com/10479155/43729880-7c3f6480-995e-11e8-926b-719f2c24120d.png)
