### PR TITLE
Add Atlas Server to product menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+- Add Atlas to `ProductMenuItems`. ((#48)[https://github.com/mapbox/dr-ui/pull/48/]) 
+
 ## 0.0.7
 
 - Change the `sidebarTitle` prop type in the `PageLayout` component from string to string or node. ([#43](https://github.com/mapbox/dr-ui/pull/43))

--- a/src/data/product-menu-items.js
+++ b/src/data/product-menu-items.js
@@ -58,6 +58,10 @@ const ProductMenuItems = [
     icon: 'plus',
     products: [
       {
+        url: '/atlas-server/',
+        name: 'Atlas Server'
+      },
+      {
         url: '/android-docs/plugins/',
         name: 'Android Plugins'
       },

--- a/src/data/product-menu-items.js
+++ b/src/data/product-menu-items.js
@@ -59,7 +59,7 @@ const ProductMenuItems = [
     products: [
       {
         url: '/atlas-server/',
-        name: 'Atlas Server'
+        name: 'Atlas'
       },
       {
         url: '/android-docs/plugins/',


### PR DESCRIPTION
Closes #47.

![2018-08-10 at 9 16 am](https://user-images.githubusercontent.com/628431/43969220-4431603e-9c7e-11e8-9272-8cc6dccf014b.png)

Do you like it in "More"? Or did you have another place in mind?

@HeyStenson for review, please. We shouldn't merge too eagerly, though, since we don't want this out before the Atlas Server docs page.

cc @mapbox/atlas 