### PR TITLE
Update PageLayout component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 
-- Add Atlas to `ProductMenuItems`. ((#48)[https://github.com/mapbox/dr-ui/pull/48/]) 
+- Add Atlas to `ProductMenuItems`. ((#48)[https://github.com/mapbox/dr-ui/pull/48/])
+- In `PageLayout`, show scroll bar automatically when the sidebar contents overflow vertically and remove `activeClass` from the `Sticky` component to prevent temporary faint gray background when `sidebarTheme` is set to something other than the default. ((#54)[https://github.com/mapbox/dr-ui/pull/54])
 
 ## 0.0.7
 

--- a/src/components/page-layout/__tests__/page-layout-test-cases.js
+++ b/src/components/page-layout/__tests__/page-layout-test-cases.js
@@ -4,6 +4,18 @@ import NavigationAccordion from '../../navigation-accordion/navigation-accordion
 
 const testCases = {};
 
+testCases.basic = {
+  description: 'Basic',
+  component: PageLayout,
+  props: {
+    sidebarContent: <div>Some content</div>,
+    sidebarTitle: 'Some title',
+    sidebarContentStickyTop: 0,
+    sidebarContentStickyTopNarrow: 0,
+    children: <div>Doc content</div>
+  }
+};
+
 testCases.commonUseCase = {
   description: 'Common use case',
   component: PageLayout,
@@ -77,15 +89,108 @@ testCases.commonUseCase = {
   }
 };
 
-testCases.basic = {
-  description: 'Basic',
+testCases.manyItems = {
+  description: 'Many first level items',
   component: PageLayout,
   props: {
-    sidebarContent: <div>Some content</div>,
-    sidebarTitle: 'Some title',
-    sidebarContentStickyTop: 0,
+    sidebarTitle: <div className="ml36">Section title</div>,
+    sidebarContent: (
+      <NavigationAccordion
+        currentPath="page-one"
+        contents={{
+          firstLevelItems: [
+            {
+              title: 'Title one',
+              path: 'page-one'
+            },
+            {
+              title: 'Title two',
+              path: 'page-two'
+            },
+            {
+              title: 'Title three',
+              path: 'page-three'
+            },
+            {
+              title: 'Title four',
+              path: 'page-four'
+            },
+            {
+              title: 'Title five',
+              path: 'page-five'
+            },
+            {
+              title: 'Title six',
+              path: 'page-six'
+            },
+            {
+              title: 'Title seven',
+              path: 'page-seven'
+            },
+            {
+              title: 'Title eight',
+              path: 'page-eight'
+            },
+            {
+              title: 'Title nine',
+              path: 'page-nine'
+            },
+            {
+              title: 'Title ten',
+              path: 'page-ten'
+            }
+          ],
+          secondLevelItems: [
+            {
+              title: 'Heading one',
+              path: 'heading-one'
+            },
+            {
+              title: 'Heading two',
+              path: 'heading-two'
+            }
+          ]
+        }}
+        onDropdownChange={() => {}}
+      />
+    ),
+    children: (
+      <div>
+        <p className="mb24">
+          Vestibulum id ligula porta felis euismod semper. Cum sociis natoque
+          penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id
+          ligula porta felis euismod semper.
+        </p>
+        <p className="mb24">
+          Aenean lacinia bibendum nulla sed consectetur. Maecenas sed diam eget
+          risus varius blandit sit amet non magna. Vestibulum id ligula porta
+          felis euismod semper. Lorem ipsum dolor sit amet, consectetur
+          adipiscing elit. Cras justo odio, dapibus ac facilisis in, egestas
+          eget quam. Donec id elit non mi porta gravida at eget metus. Duis
+          mollis, est non commodo luctus, nisi erat porttitor ligula, eget
+          lacinia odio sem nec elit.
+        </p>
+        <p className="mb24">
+          Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas
+          eget quam. Curabitur blandit tempus porttitor. Duis mollis, est non
+          commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec
+          elit. Nullam quis risus eget urna mollis ornare vel eu leo. Praesent
+          commodo cursus magna, vel scelerisque nisl consectetur et. Duis
+          mollis, est non commodo luctus, nisi erat porttitor ligula, eget
+          lacinia odio sem nec elit.
+        </p>
+        <p className="mb24">
+          Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Donec
+          sed odio dui. Aenean eu leo quam. Pellentesque ornare sem lacinia quam
+          venenatis vestibulum. Integer posuere erat a ante venenatis dapibus
+          posuere velit aliquet.
+        </p>
+      </div>
+    ),
+    sidebarContentStickyTop: 60,
     sidebarContentStickyTopNarrow: 0,
-    children: <div>Doc content</div>
+    sidebarStackedOnNarrowScreens: true
   }
 };
 

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -61,10 +61,9 @@ class PageLayout extends React.Component {
             bottomBoundary={state.bottomBoundaryValue}
             innerZ={1}
             top={state.topValue}
-            activeClass="bg-gray-faint"
           >
             <div
-              className={`pt24-mm pt0 viewport-almost-mm scroll-auto ${sidebarNarrowClasses}`}
+              className={`pt24-mm pt0 viewport-almost-mm scroll-auto scroll-styled ${sidebarNarrowClasses}`}
             >
               {title}
               {props.sidebarContent}


### PR DESCRIPTION
This includes two updates to the `PageLayout` component: 

1️⃣ Show scroll bar automatically (not just when scrolling) when the sidebar contents overflow vertically. 

![image](https://user-images.githubusercontent.com/10479155/45060642-a6167b00-b055-11e8-8097-312dae12821d.png)

2️⃣ Removes `activeClass="bg-gray-faint"` from the sticky sidebar to prevent this from happening when the `sidebarTheme` is set to something other than the default (`bg-gray-faint`):

![sidebar-bug-on-stick](https://user-images.githubusercontent.com/10479155/45060692-f7266f00-b055-11e8-9868-8a6629364e20.gif)
