### PR TITLE
Add LevelIndicator component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## Master
 
 - Add Atlas to `ProductMenuItems`. ((#48)[https://github.com/mapbox/dr-ui/pull/48/])
-- In `PageLayout`, show scroll bar automatically when the sidebar contents overflow vertically and remove `activeClass` from the `Sticky` component to prevent temporary faint gray background when `sidebarTheme` is set to something other than the default. ((#54)[https://github.com/mapbox/dr-ui/pull/54])
+- Show scroll bar automatically in `PageLayout` when the sidebar contents overflow vertically. ((#54)[https://github.com/mapbox/dr-ui/pull/54])
+- In `PageLayout`, remove `activeClass` from the `Sticky` component to prevent temporary faint gray background when `sidebarTheme` is set to something other than the default. ((#54)[https://github.com/mapbox/dr-ui/pull/54])
+- Add new `LevelIndicator` component. ((#55)[https://github.com/mapbox/dr-ui/pull/55])
+- Add optional `level` and `language` props to `Card`. ((#55)[https://github.com/mapbox/dr-ui/pull/55])
 
 ## 0.0.7
 

--- a/src/components/card/__tests__/card-test-cases.js
+++ b/src/components/card/__tests__/card-test-cases.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Card from '../card';
+import LevelIndicator from '../../level-indicator/level-indicator';
 
 const testCases = {};
 const noRenderCases = {};
@@ -32,6 +33,18 @@ testCases.noImage = {
     title: 'Title',
     path: 'url',
     description: 'described.'
+  }
+};
+
+testCases.withLevelAndLanguage = {
+  component: Card,
+  description: 'Card with level and language',
+  props: {
+    title: 'This is a full-length title',
+    path: 'url',
+    description: "Here's a reasonable length for a description.",
+    level: <LevelIndicator level={2} />,
+    language: 'JavaScript'
   }
 };
 

--- a/src/components/card/__tests__/card-test-cases.js
+++ b/src/components/card/__tests__/card-test-cases.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Card from '../card';
-import LevelIndicator from '../../level-indicator/level-indicator';
 
 const testCases = {};
 const noRenderCases = {};
@@ -43,7 +42,7 @@ testCases.withLevelAndLanguage = {
     title: 'This is a full-length title',
     path: 'url',
     description: "Here's a reasonable length for a description.",
-    level: <LevelIndicator level={2} />,
+    level: 2,
     language: 'JavaScript'
   }
 };

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Icon from '@mapbox/mr-ui/icon';
+import LevelIndicator from '../level-indicator/level-indicator';
 
 class Card extends React.Component {
   render() {
@@ -14,7 +15,11 @@ class Card extends React.Component {
       );
     }
     if (props.level) {
-      renderedLevel = <div className="inline-block mr18">{props.level}</div>;
+      renderedLevel = (
+        <div className="inline-block mr18">
+          <LevelIndicator level={props.level} />
+        </div>
+      );
     }
     if (props.language) {
       renderedLanguage = (

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -1,13 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Icon from '@mapbox/mr-ui/icon';
 
 class Card extends React.Component {
   render() {
     const { props } = this;
     let renderedThumbnail = '';
+    let renderedLevel = '';
+    let renderedLanguage = '';
     if (props.thumbnail) {
       renderedThumbnail = (
         <div className="relative h120 mb12">{props.thumbnail}</div>
+      );
+    }
+    if (props.level) {
+      renderedLevel = <div className="inline-block mr18">{props.level}</div>;
+    }
+    if (props.language) {
+      renderedLanguage = (
+        <div className="inline-block color-gray-light txt-s txt-bold">
+          <Icon name="code" inline={true} /> {props.language}
+        </div>
       );
     }
     return (
@@ -17,6 +30,8 @@ class Card extends React.Component {
       >
         {renderedThumbnail}
         <div className="px6 pb6">
+          {renderedLevel}
+          {renderedLanguage}
           <div className="mb6 txt-m">{this.props.title}</div>
           <div className="txt-s opacity75">{this.props.description}</div>
         </div>
@@ -29,7 +44,9 @@ Card.propTypes = {
   title: PropTypes.string.isRequired,
   path: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
-  thumbnail: PropTypes.node
+  thumbnail: PropTypes.node,
+  level: PropTypes.node,
+  language: PropTypes.string
 };
 
 export default Card;

--- a/src/components/level-indicator/__tests__/level-indicator-test-cases.js
+++ b/src/components/level-indicator/__tests__/level-indicator-test-cases.js
@@ -1,0 +1,29 @@
+import LevelIndicator from '../level-indicator';
+
+const testCases = {};
+
+testCases.levelOne = {
+  component: LevelIndicator,
+  description: 'Level one',
+  props: {
+    level: 1
+  }
+};
+
+testCases.levelTwo = {
+  component: LevelIndicator,
+  description: 'Level two',
+  props: {
+    level: 2
+  }
+};
+
+testCases.levelThree = {
+  component: LevelIndicator,
+  description: 'Level three',
+  props: {
+    level: 3
+  }
+};
+
+export default { testCases };

--- a/src/components/level-indicator/level-indicator.js
+++ b/src/components/level-indicator/level-indicator.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const levels = {
+  1: {
+    label: 'beginner',
+    color: 'green',
+    opacity: 50
+  },
+  2: {
+    label: 'intermediate',
+    color: 'orange',
+    opacity: 75
+  },
+  3: {
+    label: 'advanced',
+    color: 'red',
+    opacity: 100
+  }
+};
+
+class LevelIndicator extends React.Component {
+  render() {
+    const { props } = this;
+    // Get supplies in order for constructing the difficulty level bits
+    const levelColor = levels[props.level].color;
+    const levelLabel = levels[props.level].label;
+    const squareStyles = {
+      height: '8px',
+      borderRadius: '1px'
+    };
+
+    // Make the "difficulty level" squares
+    let levelSquares = [];
+    [1, 2, 3].forEach((num, i) => {
+      let squareColor = '';
+      num > this.props.level
+        ? (squareColor = 'gray-light')
+        : (squareColor = levelColor);
+      levelSquares.push(
+        <div
+          key={i}
+          style={squareStyles}
+          className={`inline-block w6 bg-${squareColor} align-middle mr3`}
+        />
+      );
+    });
+    return (
+      <div className={`txt-s color-${levelColor}`}>
+        {levelSquares}
+        <div
+          className={`inline-block color-${levelColor} ml3 txt-bold txt-capitalize`}
+        >
+          {levelLabel}
+        </div>
+      </div>
+    );
+  }
+}
+
+LevelIndicator.propTypes = {
+  level: PropTypes.oneOf([1, 2, 3]).isRequired
+};
+
+export default LevelIndicator;

--- a/src/components/level-indicator/level-indicator.js
+++ b/src/components/level-indicator/level-indicator.js
@@ -4,52 +4,44 @@ import PropTypes from 'prop-types';
 const levels = {
   1: {
     label: 'beginner',
-    color: 'green',
-    opacity: 50
+    color: 'green'
   },
   2: {
     label: 'intermediate',
-    color: 'orange',
-    opacity: 75
+    color: 'orange'
   },
   3: {
     label: 'advanced',
-    color: 'red',
-    opacity: 100
+    color: 'red'
   }
 };
 
 class LevelIndicator extends React.Component {
   render() {
     const { props } = this;
-    // Get supplies in order for constructing the difficulty level bits
+    // // Get supplies in order for constructing the difficulty level bits
     const levelColor = levels[props.level].color;
     const levelLabel = levels[props.level].label;
-    const squareStyles = {
-      height: '8px',
-      borderRadius: '1px'
-    };
 
     // Make the "difficulty level" squares
-    let levelSquares = [];
-    [1, 2, 3].forEach((num, i) => {
-      let squareColor = '';
-      num > this.props.level
-        ? (squareColor = 'gray-light')
-        : (squareColor = levelColor);
-      levelSquares.push(
+    const levelSquares = Object.keys(levels).map(level => {
+      const squareColor = level > props.level ? 'gray-light' : levelColor;
+      return (
         <div
-          key={i}
-          style={squareStyles}
+          key={level}
+          style={{
+            height: '8px',
+            borderRadius: '1px'
+          }}
           className={`inline-block w6 bg-${squareColor} align-middle mr3`}
         />
       );
     });
     return (
-      <div className={`txt-s color-${levelColor}`}>
+      <div>
         {levelSquares}
         <div
-          className={`inline-block color-${levelColor} ml3 txt-bold txt-capitalize`}
+          className={`inline-block txt-s color-${levelColor} ml3 txt-bold txt-capitalize`}
         >
           {levelLabel}
         </div>


### PR DESCRIPTION
This PR does two things: 

1️⃣ Adds a new `LevelIndicator` component based on the work done in /help (ty @danswick). 

![image](https://user-images.githubusercontent.com/10479155/45060806-787e0180-b056-11e8-95e6-e2c050dc5100.png)

2️⃣ Adds optional `level` and `language` props to `Card` (to be used for /help tutorials).

![image](https://user-images.githubusercontent.com/10479155/45060828-95b2d000-b056-11e8-8392-052c9e8ec925.png)

Closes #53 
