### PR TITLE
Add China plugin for iOS to product-meun-items file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## Master
 
-- Add Atlas to `ProductMenuItems`. ((#48)[https://github.com/mapbox/dr-ui/pull/48/])
-- Show scroll bar automatically in `PageLayout` when the sidebar contents overflow vertically. ((#54)[https://github.com/mapbox/dr-ui/pull/54])
-- In `PageLayout`, remove `activeClass` from the `Sticky` component to prevent temporary faint gray background when `sidebarTheme` is set to something other than the default. ((#54)[https://github.com/mapbox/dr-ui/pull/54])
-- Add new `LevelIndicator` component. ((#55)[https://github.com/mapbox/dr-ui/pull/55])
-- Add optional `level` and `language` props to `Card`. ((#55)[https://github.com/mapbox/dr-ui/pull/55])
+- Add Atlas to `ProductMenuItems`. ([#48](https://github.com/mapbox/dr-ui/pull/48/))
+- Show scroll bar automatically in `PageLayout` when the sidebar contents overflow vertically. ([#54](https://github.com/mapbox/dr-ui/pull/54))
+- In `PageLayout`, remove `activeClass` from the `Sticky` component to prevent temporary faint gray background when `sidebarTheme` is set to something other than the default. ([#54](https://github.com/mapbox/dr-ui/pull/54))
+- Add new `LevelIndicator` component. ([#55](https://github.com/mapbox/dr-ui/pull/55))
+- Add optional `level` and `language` props to `Card`. ([#55](https://github.com/mapbox/dr-ui/pull/55))
+- Add China Plugin for iOS to `ProductMenuItems`. ([#56](https://github.com/mapbox/dr-ui/pull/56))
 
 ## 0.0.7
 

--- a/src/data/product-menu-items.js
+++ b/src/data/product-menu-items.js
@@ -68,6 +68,10 @@ const ProductMenuItems = [
       {
         url: '/android-docs/core/',
         name: 'Android Core library'
+      },
+      {
+        url: '/ios-sdk/plugins/',
+        name: 'China plugin for iOS'
       }
     ]
   }


### PR DESCRIPTION
Adds a link to the new Mapbox China plugin for iOS docs in the `+ More` section. 

![image](https://user-images.githubusercontent.com/10479155/45060902-ee826880-b056-11e8-9445-83cf48ce65c2.png)
