### PR TITLE
Update NavigationAccordion to show level 3 headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Master
+
+- Add a third level of headings (`thirdLevelItems`) to `NavigationAccordion`. ([#58](https://github.com/mapbox/dr-ui/pull/58))
+
 ## 0.0.8
 
 - Add Atlas to `ProductMenuItems`. ([#48](https://github.com/mapbox/dr-ui/pull/48/))

--- a/src/components/navigation-accordion/__tests__/navigation-accordion-test-cases.js
+++ b/src/components/navigation-accordion/__tests__/navigation-accordion-test-cases.js
@@ -54,4 +54,45 @@ testCases.noSecondLevelItems = {
   }
 };
 
+testCases.withThirdLevelItems = {
+  description: 'Shows third level items',
+  component: NavigationAccordion,
+  props: {
+    currentPath: 'page-one',
+    contents: {
+      firstLevelItems: [
+        {
+          title: 'Title one',
+          path: 'page-one'
+        },
+        {
+          title: 'Title two',
+          path: 'page-two'
+        }
+      ],
+      secondLevelItems: [
+        {
+          title: 'Heading one',
+          path: 'heading-one',
+          thirdLevelItems: [
+            {
+              title: 'Subheading one',
+              path: 'subheading-one'
+            },
+            {
+              title: 'Subheading two',
+              path: 'subheading-two'
+            }
+          ]
+        },
+        {
+          title: 'Heading two',
+          path: 'heading-two'
+        }
+      ]
+    },
+    onDropdownChange: () => {}
+  }
+};
+
 export { testCases };

--- a/src/components/navigation-accordion/navigation-accordion.js
+++ b/src/components/navigation-accordion/navigation-accordion.js
@@ -10,6 +10,20 @@ class NavigationAccordion extends React.PureComponent {
     const secondLevelContent =
       props.contents.secondLevelItems &&
       props.contents.secondLevelItems.map(item => {
+        const subItems =
+          item.thirdLevelItems &&
+          item.thirdLevelItems.map(subItem => {
+            return (
+              <li key={subItem.path} className="mt6">
+                <a
+                  href={`#${subItem.path}`}
+                  className="color-blue-on-hover text-decoration-none unprose"
+                >
+                  {subItem.title}
+                </a>
+              </li>
+            );
+          });
         return (
           <li key={item.path} className="mb6">
             <a
@@ -18,6 +32,7 @@ class NavigationAccordion extends React.PureComponent {
             >
               {item.title}
             </a>
+            <ul className="pl12 color-darken75">{subItems}</ul>
           </li>
         );
       });
@@ -99,7 +114,13 @@ NavigationAccordion.propTypes = {
     secondLevelItems: PropTypes.arrayOf(
       PropTypes.shape({
         title: PropTypes.string.isRequired,
-        path: PropTypes.string.isRequired
+        path: PropTypes.string.isRequired,
+        thirdLevelItems: PropTypes.arrayOf(
+          PropTypes.shape({
+            title: PropTypes.string.isRequired,
+            path: PropTypes.string.isRequired
+          })
+        )
       })
     )
   }),


### PR DESCRIPTION
I want to be able to show third-level items in the API documentation. (It could also be useful to show third-level items in the Studio Manual.) @colleenmcginnis helped me update the NavigationAccordion component and update the tests file 🙇‍♀️ 

![screen shot 2018-10-24 at 1 10 59 pm](https://user-images.githubusercontent.com/8186438/47458431-5ec38580-d78e-11e8-88ea-a51e89f5a707.png)
