### PR TITLE
Add filter option to SectionedNavigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 
 - Add a third level of headings (`thirdLevelItems`) to `NavigationAccordion`. ([#58](https://github.com/mapbox/dr-ui/pull/58))
+- Add the option to include a filter bar to `SectionedNavigation` via the `includeFilterBar` prop. ([#60](https://github.com/mapbox/dr-ui/pull/60))
 
 ## 0.0.8
 

--- a/src/components/sectioned-navigation/__tests__/sectioned-navigation-test-cases.js
+++ b/src/components/sectioned-navigation/__tests__/sectioned-navigation-test-cases.js
@@ -105,4 +105,58 @@ testCases.minimal = {
   }
 };
 
+testCases.filter = {
+  description: 'With a title, linked section headings, counts, and filter',
+  component: SectionedNavigation,
+  props: {
+    title: 'Examples',
+    includeFilterBar: true,
+    sections: [
+      {
+        title: 'Getting started',
+        url: '#getting-started',
+        items: [
+          {
+            text: 'Camera animation',
+            url: '#foo'
+          },
+          {
+            text: 'Mark a place',
+            url: '#footoo',
+            active: true
+          },
+          {
+            text: 'Apply a style',
+            url: '#fooandyou'
+          }
+        ]
+      },
+      {
+        title: 'Markers and callouts',
+        url: '#markers',
+        items: [
+          {
+            text: 'Annotation models',
+            url: '#fooboo'
+          },
+          {
+            text: 'Callouts',
+            url: '#foocrew'
+          }
+        ]
+      },
+      {
+        title: 'Getting started again',
+        url: '#getting-started-again',
+        items: [
+          {
+            text: 'Apply a style',
+            url: '#fooblue'
+          }
+        ]
+      }
+    ]
+  }
+};
+
 export { testCases };

--- a/src/components/sectioned-navigation/sectioned-navigation.js
+++ b/src/components/sectioned-navigation/sectioned-navigation.js
@@ -93,7 +93,8 @@ SectionedNavigation.propTypes = {
 };
 
 SectionedNavigation.defaultProps = {
-  includeCount: true
+  includeCount: true,
+  includeFilterBar: false
 };
 
 export default SectionedNavigation;

--- a/src/components/sectioned-navigation/sectioned-navigation.js
+++ b/src/components/sectioned-navigation/sectioned-navigation.js
@@ -36,9 +36,9 @@ class SectionedNavigation extends React.Component {
             this.setState({ filter: e.target.value }, this.filterResults)
           }
           type="text"
-          className="px6 py6 w-full round border border--gray-light"
+          className="px6 py6 w-full border border--gray-light"
           name="filter"
-          placeholder="Filter examples"
+          placeholder="Filter list"
         />
       </div>
     );

--- a/src/components/sectioned-navigation/sectioned-navigation.js
+++ b/src/components/sectioned-navigation/sectioned-navigation.js
@@ -3,6 +3,14 @@ import PropTypes from 'prop-types';
 import SectionedNavigationSection from './sectioned-navigation-section';
 
 class SectionedNavigation extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      filter: '',
+      visibleSections: this.props.sections
+    };
+  }
+
   renderTitle() {
     const { props } = this;
     if (!props.title) {
@@ -16,12 +24,55 @@ class SectionedNavigation extends React.Component {
     );
   }
 
+  renderFilterBar() {
+    const { props } = this;
+    if (!props.includeFilterBar) {
+      return null;
+    }
+    return (
+      <div className="wmax360 mb24">
+        <input
+          onChange={e =>
+            this.setState({ filter: e.target.value }, this.filterResults())
+          }
+          type="text"
+          className="px6 py6 w-full round border border--gray-light"
+          name="filter"
+          placeholder="Filter examples"
+        />
+      </div>
+    );
+  }
+
+  filterResults() {
+    const filter = this.state.filter.toLowerCase().trim();
+    const visibleSections = this.props.sections
+      .filter(section => {
+        const matchedItems = section.items.filter(item => {
+          return item.text.toLowerCase().indexOf(filter) > -1;
+        });
+        return matchedItems.length > 0;
+      })
+      .map(filteredSection => {
+        const filteredItems = filteredSection.items.filter(item => {
+          return item.text.toLowerCase().indexOf(filter) > -1;
+        });
+        return {
+          title: filteredSection.title,
+          url: filteredSection.url,
+          items: filteredItems
+        };
+      });
+    this.setState({ visibleSections: visibleSections });
+  }
+
   render() {
     const { props } = this;
     return (
       <div>
         {this.renderTitle()}
-        {props.sections.map((section, i) => (
+        {this.renderFilterBar()}
+        {this.state.visibleSections.map((section, i) => (
           <div key={i} className="mb24">
             <SectionedNavigationSection
               includeCount={props.includeCount}
@@ -37,7 +88,8 @@ class SectionedNavigation extends React.Component {
 SectionedNavigation.propTypes = {
   sections: PropTypes.arrayOf(PropTypes.object).isRequired,
   title: PropTypes.string,
-  includeCount: PropTypes.bool
+  includeCount: PropTypes.bool,
+  includeFilterBar: PropTypes.bool
 };
 
 SectionedNavigation.defaultProps = {

--- a/src/components/sectioned-navigation/sectioned-navigation.js
+++ b/src/components/sectioned-navigation/sectioned-navigation.js
@@ -33,7 +33,7 @@ class SectionedNavigation extends React.Component {
       <div className="wmax360 mb24">
         <input
           onChange={e =>
-            this.setState({ filter: e.target.value }, this.filterResults())
+            this.setState({ filter: e.target.value }, this.filterResults)
           }
           type="text"
           className="px6 py6 w-full round border border--gray-light"


### PR DESCRIPTION
Adds the option to add a filter bar that allows you to filter items listed. This attempts to recreate what is done in the Mapbox GL JS docs ([code](https://github.com/mapbox/mapbox-gl-js/blob/master/docs/components/example.js#L87-L104) / [see it in action](https://www.mapbox.com/mapbox-gl-js/examples/)). 

@davidtheclark very open to suggestions if you have any. 

![i-did-it](https://user-images.githubusercontent.com/10479155/48223153-44bba280-e34b-11e8-92e2-b6815b3bddc4.gif)
