### PR TITLE
Add Mapbox style spec to product dropdown menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Master
 
-- Fixes a bug where the sidebar in `PageLayout` was sticking when navigating directly to a hash at the bottom of the page. ([#63](https://github.com/mapbox/dr-ui/pull/63))
-- Fixes a bug where the arrow icon in `BackToTopButton` was not centered. ([#63](https://github.com/mapbox/dr-ui/pull/63))
+- Add Mapbox Style Specification to `ProductMenuItems`. ([#62](https://github.com/mapbox/dr-ui/pull/62))
+- Fix a bug where the sidebar in `PageLayout` was sticking when navigating directly to a hash at the bottom of the page. ([#63](https://github.com/mapbox/dr-ui/pull/63))
+- Fix a bug where the arrow icon in `BackToTopButton` was not centered. ([#63](https://github.com/mapbox/dr-ui/pull/63))
 - Add the option to include a filter bar to `SectionedNavigation` via the `includeFilterBar` prop. ([#60](https://github.com/mapbox/dr-ui/pull/60))
 - Add a third level of headings (`thirdLevelItems`) to `NavigationAccordion`. ([#58](https://github.com/mapbox/dr-ui/pull/58))
 

--- a/src/components/product-menu-dropdown/product-menu-dropdown.js
+++ b/src/components/product-menu-dropdown/product-menu-dropdown.js
@@ -24,7 +24,14 @@ class ProductMenuDropdown extends React.PureComponent {
           : false;
 
         let isActive;
+        /* Exception for Mapbox Style Spec since it lives in the
+        mapbox-gl-js repo, but is treated as its own product. */
         if (
+          product.url === '/mapbox-gl-js/style-spec/' &&
+          location.pathname.indexOf('/mapbox-gl-js/style-spec/') > -1
+        ) {
+          isActive = true;
+        } else if (
           product.url &&
           locationTest &&
           location.pathname.indexOf(product.url) > -1

--- a/src/data/product-menu-items.js
+++ b/src/data/product-menu-items.js
@@ -22,6 +22,10 @@ const ProductMenuItems = [
       {
         url: '/studio-manual/',
         name: 'Mapbox Studio'
+      },
+      {
+        url: '/mapbox-gl-js/style-spec/',
+        name: 'Mapbox Style Specification'
       }
     ]
   },


### PR DESCRIPTION
Prepares the docs product menu for https://github.com/mapbox/mapbox-gl-js/pull/7530. Adds Mapbox Style Specification to `src/data/product-menu-items.js` and adds an exception to `ProductDropdownMenu` to account for the page path for the Style Spec being in the /mapbox-gl-js repo. 