### PR TITLE
Add exception for style-spec

### DIFF
--- a/src/components/product-menu-dropdown/product-menu-dropdown.js
+++ b/src/components/product-menu-dropdown/product-menu-dropdown.js
@@ -32,6 +32,7 @@ class ProductMenuDropdown extends React.PureComponent {
         ) {
           isActive = true;
         } else if (
+          location.pathname.indexOf('/mapbox-gl-js/style-spec/') < 0 &&
           product.url &&
           locationTest &&
           location.pathname.indexOf(product.url) > -1


### PR DESCRIPTION
#62 didn't actually do the trick. As @mollymerp mentioned in https://github.com/mapbox/mapbox-gl-js/pull/7530#pullrequestreview-175626884, both Mapbox GL JS and Mapbox Style Specification are highlighted. 

@danswick this seems hacky, but seems to work -- do you have any other suggestions? 