### PR TITLE
[ExamplesPage] remove pt60 class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Master
+
+- Remove `pt60` class from `ExamplesPage` component. ([#70](https://github.com/mapbox/dr-ui/pull/70))
+
 ## 0.0.9
 
 - Add missing `index.js` file for the `LevelIndicator` component.

--- a/src/components/examples-page/examples-page.js
+++ b/src/components/examples-page/examples-page.js
@@ -5,11 +5,7 @@ class ExamplesPage extends React.PureComponent {
   render() {
     const { props } = this;
     const renderedContainers = props.cardContainers.map((container, index) => {
-      return (
-        <div key={index} className="pt60">
-          {container}
-        </div>
-      );
+      return <div key={index}>{container}</div>;
     });
     return <div>{renderedContainers}</div>;
   }


### PR DESCRIPTION
I think we should remove the `pt60` class from `ExamplesPage` component. I'm noticing that it can add too much spacing between elements:

![image](https://user-images.githubusercontent.com/2180540/49670755-b44cac80-fa33-11e8-91ea-e431b0d6c287.png)

If a particular page requires more padding, then we should wrap it this component in a div with the desired classes.