### PR TITLE
[Card/CardContainer] styles updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 
 - Remove `pt60` class from `ExamplesPage` component. ([#70](https://github.com/mapbox/dr-ui/pull/70))
+- Update styles for `Card` and `CardContainer` components for consistent padding and spacing. ([#71](https://github.com/mapbox/dr-ui/pull/71))
 
 ## 0.0.9
 

--- a/src/components/card-container/card-container.js
+++ b/src/components/card-container/card-container.js
@@ -6,7 +6,7 @@ class CardContainer extends React.PureComponent {
   render() {
     const { props } = this;
     const categoryID = props.path.split('#')[1];
-    const cardClasses = classnames('pb12 col col--12', {
+    const cardClasses = classnames('col col--12 mb36', {
       'col--6-mm': !props.fullWidthCards
     });
     const renderedCards = props.cards.map((card, index) => {
@@ -18,12 +18,12 @@ class CardContainer extends React.PureComponent {
     });
     return (
       <div>
-        <a href={props.path} className="unprose mb12 block color-blue-on-hover">
-          <h2 className="txt-l" id={categoryID}>
+        <a href={props.path} className="unprose mb18 block color-blue-on-hover">
+          <h2 className="txt-bold" id={categoryID}>
             {props.title} ({props.cards.length})
           </h2>
         </a>
-        <div className="grid grid--gut12">{renderedCards}</div>
+        <div className="grid grid--gut36">{renderedCards}</div>
       </div>
     );
   }

--- a/src/components/card-container/card-container.js
+++ b/src/components/card-container/card-container.js
@@ -7,7 +7,7 @@ class CardContainer extends React.PureComponent {
     const { props } = this;
     const categoryID = props.path.split('#')[1];
     const cardClasses = classnames('col col--12 mb36', {
-      'col--6-mm': !props.fullWidthCards
+      'col--6-ml': !props.fullWidthCards
     });
     const renderedCards = props.cards.map((card, index) => {
       return (

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -11,7 +11,7 @@ class Card extends React.Component {
     let renderedLanguage = '';
     if (props.thumbnail) {
       renderedThumbnail = (
-        <div className="relative h120 mb12">{props.thumbnail}</div>
+        <div className="relative h120 mb6">{props.thumbnail}</div>
       );
     }
     if (props.level) {
@@ -23,22 +23,26 @@ class Card extends React.Component {
     }
     if (props.language) {
       renderedLanguage = (
-        <div className="inline-block color-gray-light txt-s txt-bold">
+        <div className="inline-block color-gray txt-s txt-bold">
           <Icon name="code" inline={true} /> {props.language}
         </div>
       );
     }
     return (
       <a
-        className="color-gray-dark transition shadow-darken10-on-hover round clip inline-block w-full px12 py12 unprose"
+        className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose"
         href={this.props.path}
       >
         {renderedThumbnail}
-        <div className="px6 pb6">
-          {renderedLevel}
-          {renderedLanguage}
+        <div>
+          <div className="mb6">
+            {renderedLevel}
+            {renderedLanguage}
+          </div>
           <div className="mb6 txt-m">{this.props.title}</div>
-          <div className="txt-s opacity75">{this.props.description}</div>
+          <div className="txt-s color-gray color-gray-on-hover">
+            {this.props.description}
+          </div>
         </div>
       </a>
     );


### PR DESCRIPTION
This PR makes a few subtle padding and style adjustments to `Card` and `CardContainer`. 

Right now each card has padding that is revealed when hovered by the addition of a shadow. Unfortunately, this adds unused padding to the design and knocks the cards out of alignment with each heading:

![image](https://user-images.githubusercontent.com/2180540/49672248-7bfb9d00-fa38-11e8-8835-bfea02f25a6b.png)

The changes in this PR, removes the padding around each card and changes the hover interactive to a changing the card's hover text color blue:

![image](https://user-images.githubusercontent.com/2180540/49672091-04c60900-fa38-11e8-918f-28e89642fd3d.png)

~~I'd also like to make the images have rounded corners, but I suspect I'll need to PR the ability to pass props in https://github.com/mapbox/appropriate-images~~ Nevermind! We can pass `style` to the element! 