### PR TITLE
cleans up styles to allow `NavigationDropdown` to appear on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Master
+
+- Fix a bug where `NavigationDropdown` did not appear on mobile. ([#79](https://github.com/mapbox/dr-ui/pull/79))
+
 ## 0.0.10
 
 - Remove `pt60` class from `ExamplesPage` component. ([#70](https://github.com/mapbox/dr-ui/pull/70))

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -67,7 +67,7 @@ class PageLayout extends React.Component {
             top={state.topValue}
           >
             <div
-              className={`pt24-mm pt0 viewport-almost-mm scroll-auto scroll-styled ${sidebarNarrowClasses}`}
+              className={`pt24-mm pt0 viewport-almost-mm scroll-auto-mm scroll-styled ${sidebarNarrowClasses}`}
             >
               {title}
               {props.sidebarContent}
@@ -76,7 +76,7 @@ class PageLayout extends React.Component {
         </div>
         <div
           id="docs-content"
-          className="col col--8-mm col--12 mt24 mb60 pr0-mm pr36 pl36"
+          className="col col--8-mm col--12 mt24-mm mb60 pr0-mm px12 px36-mm"
         >
           {props.children}
         </div>

--- a/src/css/docs-prose.css
+++ b/src/css/docs-prose.css
@@ -20,3 +20,10 @@
   font-size: 24px;
   padding-top: 40px;
 }
+
+@media screen and (min-width:640px) {
+  .scroll-auto-mm {
+    overflow: auto !important;
+    -webkit-overflow-scrolling: touch;
+  }
+}


### PR DESCRIPTION
I believe `NavigationDropdown` was being obfuscated by a parent with `.scroll-auto` and an absolutely positioned container. I created a new class `.scroll-auto-mm` as that class is only needed for larger screens. We will also need to make style adjustments in each repo's page-shell to remove the absolutely position classes (PR forthcoming in /help).

I also adjusted the padding around the content for mobile sizes as it was a bit too wide:

> ![img_f8cc152effdc-1](https://user-images.githubusercontent.com/2180540/50160648-dce06c00-02a7-11e9-954f-38f6dc3b61ad.jpeg)
