### PR TITLE
adds `window.scroll()` to `BackToTopButton`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## Master
+## 0.0.12 - next release
 
 - Fix a bug where `NavigationDropdown` did not appear on mobile. ([#79](https://github.com/mapbox/dr-ui/pull/79))
+- Fix a bug where `BackToTopButton` did not, in fact, go back to top on mobile. ([#80](https://github.com/mapbox/dr-ui/pull/80))
 
 ## 0.0.10
 

--- a/src/components/back-to-top-button/back-to-top-button.js
+++ b/src/components/back-to-top-button/back-to-top-button.js
@@ -7,7 +7,11 @@ export default class BackToTopButton extends React.Component {
       <div className="block mx24 my24 z5">
         <IconButton
           onClick={() => {
-            document.documentElement.scrollTop = 0;
+            document.documentElement.scrollTop = 0; // fallback
+            window.scroll({
+              top: 0,
+              left: 0
+            });
           }}
           icon="arrow-up"
           tooltipProps={{
@@ -22,5 +26,3 @@ export default class BackToTopButton extends React.Component {
     );
   }
 }
-
-// {/* none-mm fixed bottom right */}


### PR DESCRIPTION
fixes #76, by adding `window.scroll()` and keeping `document.documentElement.scrollTop` as a fallback since the former doesn't have complete browser support