### PR TITLE
additional selectors for `#docs-content`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 
 - Add optional prop (`sideBarColSize`) to change the column size of the sidebar in `PageLayout`. ([#96](https://github.com/mapbox/dr-ui/pull/96))
+- Add additional selectors for `#docs-content .prose`. ([#91](https://github.com/mapbox/dr-ui/pull/91))
 
 ## 0.1.1
 

--- a/src/css/docs-prose.css
+++ b/src/css/docs-prose.css
@@ -1,9 +1,11 @@
+#docs-content .prose h1,
 #docs-content.prose h1 {
   margin-top: 6px;
   margin-bottom: 30px;
   font-size: 36px;
 }
 
+#docs-content .prose h2,
 #docs-content.prose h2 {
   font-weight: normal !important;
   cursor: pointer;
@@ -14,6 +16,7 @@
   margin: 36px 0px 18px;
 }
 
+#docs-content .prose h3,
 #docs-content.prose h3 {
   font-weight: normal;
   cursor: pointer;


### PR DESCRIPTION
For each `#docs-content` rules, I added a child selector to give us more flexibility and avoid adding more than one `#doc-content` to a single page

fixes #85 