### PR TITLE
[PageLayout] adds optional prop to change the column size of the sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Master
+
+- Add optional prop (`sideBarColSize`) to change the column size of the sidebar in `PageLayout`. ([#96](https://github.com/mapbox/dr-ui/pull/96))
+
 ## 0.1.1
 
 - Fix `bottomBoundaryValue` on `PageLayout`'s sticky sidebar to account for slimmer docs-page-shell footer. ([#88](https://github.com/mapbox/dr-ui/pull/88))

--- a/src/components/page-layout/__tests__/page-layout-test-cases.js
+++ b/src/components/page-layout/__tests__/page-layout-test-cases.js
@@ -17,7 +17,7 @@ testCases.basic = {
 };
 
 testCases.smallSidebarCol = {
-  description: 'Basic, small sideBarCol',
+  description: 'Custom sidebar column size',
   component: PageLayout,
   props: {
     sidebarContent: <div>Some content</div>,
@@ -25,6 +25,34 @@ testCases.smallSidebarCol = {
     sidebarContentStickyTop: 0,
     sidebarContentStickyTopNarrow: 0,
     sideBarColSize: 3,
+    children: <div>Doc content</div>
+  }
+};
+
+testCases.tooSmallSidebarCol = {
+  description:
+    'Custom sidebar column size, too small - default to original size',
+  component: PageLayout,
+  props: {
+    sidebarContent: <div>Some content</div>,
+    sidebarTitle: 'Some title',
+    sidebarContentStickyTop: 0,
+    sidebarContentStickyTopNarrow: 0,
+    sideBarColSize: 2,
+    children: <div>Doc content</div>
+  }
+};
+
+testCases.tooLargeSidebarCol = {
+  description:
+    'Custom sidebar column size, too large - default to original size',
+  component: PageLayout,
+  props: {
+    sidebarContent: <div>Some content</div>,
+    sidebarTitle: 'Some title',
+    sidebarContentStickyTop: 0,
+    sidebarContentStickyTopNarrow: 0,
+    sideBarColSize: 7,
     children: <div>Doc content</div>
   }
 };

--- a/src/components/page-layout/__tests__/page-layout-test-cases.js
+++ b/src/components/page-layout/__tests__/page-layout-test-cases.js
@@ -16,6 +16,19 @@ testCases.basic = {
   }
 };
 
+testCases.smallSidebarCol = {
+  description: 'Basic, small sideBarCol',
+  component: PageLayout,
+  props: {
+    sidebarContent: <div>Some content</div>,
+    sidebarTitle: 'Some title',
+    sidebarContentStickyTop: 0,
+    sidebarContentStickyTopNarrow: 0,
+    sideBarColSize: 3,
+    children: <div>Doc content</div>
+  }
+};
+
 testCases.commonUseCase = {
   description: 'Common use case',
   component: PageLayout,

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -57,11 +57,19 @@ class PageLayout extends React.Component {
       'none block-mm': !props.sidebarStackedOnNarrowScreens
     });
 
+    let sideBarColSize = null;
+    if (
+      props.sideBarColSize &&
+      props.sideBarColSize > 2 &&
+      props.sideBarColSize < 7
+    )
+      sideBarColSize = props.sideBarColSize;
+
     return (
       <div className="grid">
         <div
           className={`col col--4-mm ${
-            props.sideBarColSize ? `col--${props.sideBarColSize}-ml` : ''
+            sideBarColSize ? `col--${sideBarColSize}-ml` : ''
           } col--12 ${props.sidebarTheme}`}
         >
           <Sticky
@@ -81,7 +89,7 @@ class PageLayout extends React.Component {
         <div
           id="docs-content"
           className={`col col--8-mm ${
-            props.sideBarColSize ? `col--${12 - props.sideBarColSize}-ml` : ''
+            sideBarColSize ? `col--${12 - sideBarColSize}-ml` : ''
           } col--12 mt24-mm mb60 pr0-mm px12 px36-mm`}
         >
           {props.children}

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -59,7 +59,11 @@ class PageLayout extends React.Component {
 
     return (
       <div className="grid">
-        <div className={`col col--4-mm col--12 ${props.sidebarTheme}`}>
+        <div
+          className={`col col--4-mm ${
+            props.sideBarColSize ? `col--${props.sideBarColSize}-ml` : ''
+          } col--12 ${props.sidebarTheme}`}
+        >
           <Sticky
             enabled={state.stickyEnabled}
             bottomBoundary={state.bottomBoundaryValue}
@@ -76,7 +80,9 @@ class PageLayout extends React.Component {
         </div>
         <div
           id="docs-content"
-          className="col col--8-mm col--12 mt24-mm mb60 pr0-mm px12 px36-mm"
+          className={`col col--8-mm ${
+            props.sideBarColSize ? `col--${12 - props.sideBarColSize}-ml` : ''
+          } col--12 mt24-mm mb60 pr0-mm px12 px36-mm`}
         >
           {props.children}
         </div>
@@ -92,6 +98,7 @@ PageLayout.propTypes = {
   sidebarContentStickyTop: PropTypes.number.isRequired,
   sidebarContentStickyTopNarrow: PropTypes.number.isRequired,
   sidebarStackedOnNarrowScreens: PropTypes.bool,
+  sideBarColSize: PropTypes.number,
   children: PropTypes.node.isRequired
 };
 


### PR DESCRIPTION
The width of the sidebar and content is fixed in dr-ui's `PageLayout`. Sometimes our content asks for more flexibility. This PR adds an optional prop `sideBarColSize`, a number. If available, dr-ui will use that number for the sidebar column: `col--[sideBarColSize]-ml` and then compute the content column size: `col--[12 - sideBarColSize]-ml` size.

We'll keep the `-mm` col sizes as they are to make sure that content doesn't get too squished at that breakpoint.

For quality control, sideBarColSize must be > 2 and < 7. Otherwise it will ignore the value and use the default column sizing.