### PR TITLE
[PageLayout] adds optional interactiveClass prop to watch for changes on click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add additional selectors for `#docs-content .prose`. ([#91](https://github.com/mapbox/dr-ui/pull/91))
 - Add make-table-scroll plugin. ([#90](https://github.com/mapbox/dr-ui/pull/90))
 - Remove `px12` on content element in `PageLayout`. ([#98](https://github.com/mapbox/dr-ui/pull/98))
+- Add optional `interactiveClass` prop to watch for changes on click in `PageLayout` to adjust the sidebar height. ([#97](https://github.com/mapbox/dr-ui/pull/97))
 
 ## 0.1.1
 

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -35,7 +35,7 @@ class PageLayout extends React.Component {
       this.setState({ stickyEnabled: true });
     }, 500);
     window.addEventListener('resize', this.debounceHandleWindowResize);
-    // when available, the page will recalcute the height of the page when a user clicks and an element with the given class name
+    // when available, the page will recalculate the height of the page when a user clicks an element with the given class name
     if (this.props.interactiveClass) {
       const interactiveClass = document.getElementsByClassName(
         this.props.interactiveClass
@@ -80,7 +80,7 @@ class PageLayout extends React.Component {
       'none block-mm': !props.sidebarStackedOnNarrowScreens
     });
 
-    // if available, sets the col--#-ml size. If the value is outside of the range, it doesn't not set the col--#-ml value and sticks with the default
+    // if available, sets col--#-ml size for the sidebar and content elements. If the value is outside of the range, it will not set the col--#-ml values and defer to the default col sizes
     let sideBarColSize = null;
     if (
       props.sideBarColSize &&

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -35,6 +35,7 @@ class PageLayout extends React.Component {
       this.setState({ stickyEnabled: true });
     }, 500);
     window.addEventListener('resize', this.debounceHandleWindowResize);
+    // when available, the page will recalcute the height of the page when a user clicks and an element with the given class name
     if (this.props.interactiveClass) {
       const interactiveClass = document.getElementsByClassName(
         this.props.interactiveClass
@@ -79,6 +80,7 @@ class PageLayout extends React.Component {
       'none block-mm': !props.sidebarStackedOnNarrowScreens
     });
 
+    // if available, sets the col--#-ml size. If the value is outside of the range, it doesn't not set the col--#-ml value and sticks with the default
     let sideBarColSize = null;
     if (
       props.sideBarColSize &&
@@ -128,9 +130,9 @@ PageLayout.propTypes = {
   sidebarContentStickyTop: PropTypes.number.isRequired,
   sidebarContentStickyTopNarrow: PropTypes.number.isRequired,
   sidebarStackedOnNarrowScreens: PropTypes.bool,
-  sideBarColSize: PropTypes.number,
-  children: PropTypes.node.isRequired,
-  interactiveClass: PropTypes.string
+  sideBarColSize: PropTypes.number, // accepts numbers 3 - 6 to change the column width of the sidebar at the -ml breakpoint
+  interactiveClass: PropTypes.string, // the class name of an interactive element, when clicked PageLayout will recalculate the height of the page and sizing for the the sidebar
+  children: PropTypes.node.isRequired
 };
 
 PageLayout.defaultProps = {

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -35,10 +35,32 @@ class PageLayout extends React.Component {
       this.setState({ stickyEnabled: true });
     }, 500);
     window.addEventListener('resize', this.debounceHandleWindowResize);
+    if (this.props.interactiveClass) {
+      const interactiveClass = document.getElementsByClassName(
+        this.props.interactiveClass
+      );
+      for (let i = 0; i < interactiveClass.length; i++) {
+        interactiveClass[i].addEventListener(
+          'click',
+          this.debounceHandleWindowResize
+        );
+      }
+    }
   }
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.debounceHandleWindowResize);
+    if (this.props.interactiveClass) {
+      const interactiveClass = document.getElementsByClassName(
+        this.props.interactiveClass
+      );
+      for (let i = 0; i < interactiveClass.length; i++) {
+        interactiveClass[i].removeEventListener(
+          'click',
+          this.debounceHandleWindowResize
+        );
+      }
+    }
   }
 
   render() {
@@ -107,7 +129,8 @@ PageLayout.propTypes = {
   sidebarContentStickyTopNarrow: PropTypes.number.isRequired,
   sidebarStackedOnNarrowScreens: PropTypes.bool,
   sideBarColSize: PropTypes.number,
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  interactiveClass: PropTypes.string
 };
 
 PageLayout.defaultProps = {


### PR DESCRIPTION
On the new mapbox-gl-js page, when you start expanding the api items, the length of the page changes. However, since we aren't listening for changes to the page height the sticky sidebar gets unmounted from its position too early: 

![image](https://user-images.githubusercontent.com/2180540/51632000-39c0e900-1f1c-11e9-893d-3e98c730e21c.png)

This PR adds an optional prop that you can pass a class that you want to watch for clicks. If that element is clicked then the height of the page will be recalculated and the sticky sidebar will adjust and stay mounted until the bottom of the page.

@colleenmcginnis for review 🙇‍♀️ this is a little tricky to test in our current testing suite