### PR TITLE
[PageLayout] rm px12 on content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add optional prop (`sideBarColSize`) to change the column size of the sidebar in `PageLayout`. ([#96](https://github.com/mapbox/dr-ui/pull/96))
 - Add additional selectors for `#docs-content .prose`. ([#91](https://github.com/mapbox/dr-ui/pull/91))
 - Add make-table-scroll plugin. ([#90](https://github.com/mapbox/dr-ui/pull/90))
+- Remove `px12` on content element in `PageLayout`. ([#98](https://github.com/mapbox/dr-ui/pull/98))
 
 ## 0.1.1
 

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -90,7 +90,7 @@ class PageLayout extends React.Component {
           id="docs-content"
           className={`col col--8-mm ${
             sideBarColSize ? `col--${12 - sideBarColSize}-ml` : ''
-          } col--12 mt24-mm mb60 pr0-mm px12 px36-mm`}
+          } col--12 mt24-mm mb60 pr0-mm px36-mm`}
         >
           {props.children}
         </div>


### PR DESCRIPTION
This content div adds padding:

![image](https://user-images.githubusercontent.com/2180540/51633645-23b52780-1f20-11e9-8f6a-3e704eeea064.png)

From my testing, we don't need it!

@colleenmcginnis for review 🙇‍♀️ 