### PR TITLE
Add optional `unStickWidth` prop to `TopbarSticker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Master
+
+- Add optional `unStickWidth` prop to `TopbarSticker`. ([#100](https://github.com/mapbox/dr-ui/pull/100))
+
 ## 0.2.0
 
 - Add optional prop (`sideBarColSize`) to change the column size of the sidebar in `PageLayout`. ([#96](https://github.com/mapbox/dr-ui/pull/96))

--- a/src/components/topbar-sticker/__tests__/topbar-sticker-test-cases.js
+++ b/src/components/topbar-sticker/__tests__/topbar-sticker-test-cases.js
@@ -20,4 +20,21 @@ testCases.display = {
   )
 };
 
+testCases.unStickSooner = {
+  description: 'Unsticks at 900px',
+  element: (
+    <div style={{ background: 'blue', height: 3000 }}>
+      <div className="px24 py12">Above the bar.</div>
+      <TopbarSticker unStickWidth={900}>
+        <div className="px24 py12">
+          I'm going to unstick at 900px wide or less!
+        </div>
+      </TopbarSticker>
+      <div className="px24 py12">
+        Below the bar, with lots of space to scroll.
+      </div>
+    </div>
+  )
+};
+
 export { testCases };

--- a/src/components/topbar-sticker/topbar-sticker.js
+++ b/src/components/topbar-sticker/topbar-sticker.js
@@ -16,7 +16,7 @@ class TopbarSticker extends React.PureComponent {
       const width = document.body.clientWidth;
       const height = document.body.clientHeight;
       this.setState({
-        isStuck: width > 640,
+        isStuck: width > (this.props.unStickWidth || 640),
         bottomBoundaryValue: height - 400
       });
     }, 200);
@@ -48,6 +48,7 @@ class TopbarSticker extends React.PureComponent {
 }
 
 TopbarSticker.propTypes = {
+  unStickWidth: PropTypes.number, // optional prop to change the breakpoint when the topbar will unstick
   children: PropTypes.node.isRequired
 };
 


### PR DESCRIPTION
This optional prop for `TopbarSticker` will afford us a little wiggle room in customizing when the component should unstick itself. When the prop is not supplied, it will default to `640`.