### PR TITLE
Add warning and error themes to `Note`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Add prism.css to create shared syntax styles [#108](https://github.com/mapbox/dr-ui/pull/108)
 - Add new styles for fullwidth `Card` and `CardContainer`. [#104](https://github.com/mapbox/dr-ui/pull/104)
 - Add CSS to set max-height and style scrollbars for prose code examples. [#103](https://github.com/mapbox/dr-ui/pull/103)
+- Add warning, error, and default themes to `Note` and removes ability to pass `padding`, `background`, `fontSize`, `lineHeight`, and `color` to `Note`. [#102](https://github.com/mapbox/dr-ui/pull/102)
+- Add `WarningImage` for primary use with `Note`. [#102](https://github.com/mapbox/dr-ui/pull/102)
+- 🚨 Replace `width` and `height` props with `size` on `BookImage`, `BookletImage`, `ContactImage`, `TroubleshootImage`. [#102](https://github.com/mapbox/dr-ui/pull/102)
 
 ## 0.4.0
 

--- a/src/components/book-image/book-image.js
+++ b/src/components/book-image/book-image.js
@@ -9,8 +9,8 @@ export default class BookImage extends React.Component {
         id="Layer_1"
         data-name="Layer 1"
         xmlns="http://www.w3.org/2000/svg"
-        width={props.width}
-        height={props.height}
+        width={props.size}
+        height={props.size}
         viewBox="0 0 108 108"
       >
         <title>help</title>
@@ -39,6 +39,5 @@ export default class BookImage extends React.Component {
 }
 
 BookImage.propTypes = {
-  width: PropTypes.string.isRequired,
-  height: PropTypes.string.isRequired
+  size: PropTypes.string.isRequired
 };

--- a/src/components/booklet-image/booklet-image.js
+++ b/src/components/booklet-image/booklet-image.js
@@ -9,8 +9,8 @@ export default class BookletImage extends React.Component {
         id="Layer_1"
         data-name="Layer 1"
         xmlns="http://www.w3.org/2000/svg"
-        width={props.width}
-        height={props.height}
+        width={props.size}
+        height={props.size}
         viewBox="0 0 108 108"
       >
         <title>help</title>
@@ -47,6 +47,5 @@ export default class BookletImage extends React.Component {
 }
 
 BookletImage.propTypes = {
-  width: PropTypes.string.isRequired,
-  height: PropTypes.string.isRequired
+  size: PropTypes.string.isRequired
 };

--- a/src/components/contact-image/contact-image.js
+++ b/src/components/contact-image/contact-image.js
@@ -9,8 +9,8 @@ export default class ContactImage extends React.Component {
         id="Layer_1"
         data-name="Layer 1"
         xmlns="http://www.w3.org/2000/svg"
-        width={props.width}
-        height={props.height}
+        width={props.size}
+        height={props.size}
         viewBox="0 0 108 108"
       >
         <title>help</title>
@@ -70,6 +70,5 @@ export default class ContactImage extends React.Component {
 }
 
 ContactImage.propTypes = {
-  width: PropTypes.string.isRequired,
-  height: PropTypes.string.isRequired
+  size: PropTypes.string.isRequired
 };

--- a/src/components/note/__tests__/note-test-cases.js
+++ b/src/components/note/__tests__/note-test-cases.js
@@ -3,6 +3,7 @@ import Note from '../note';
 import BookImage from '../../book-image/book-image';
 import BookletImage from '../../booklet-image/booklet-image';
 import ContactImage from '../../contact-image/contact-image';
+import WarningImage from '../../warning-image/warning-image';
 import TroubleshootImage from '../../troubleshoot-image/troubleshoot-image';
 
 const testCases = {};
@@ -83,7 +84,7 @@ testCases.warning = {
   props: {
     theme: 'warning',
     children: <div>Here is a little thing to note.</div>,
-    imageComponent: <BookImage width="60" height="60" />
+    imageComponent: <WarningImage color="orange" width="60" height="60" />
   }
 };
 
@@ -94,7 +95,7 @@ testCases.error = {
     theme: 'error',
     title: 'Oh, fudge!',
     children: <div>Here is a little thing to note.</div>,
-    imageComponent: <div />
+    imageComponent: <WarningImage color="red" width="60" height="60" />
   }
 };
 

--- a/src/components/note/__tests__/note-test-cases.js
+++ b/src/components/note/__tests__/note-test-cases.js
@@ -44,22 +44,6 @@ testCases.basicTroubleshoot = {
   }
 };
 
-testCases.basicThemed = {
-  component: Note,
-  description: 'A basic themed note',
-  props: {
-    children: <div>Here is a little note with pretty colors.</div>,
-    imageComponent: <BookImage width="60" height="60" />,
-    theme: {
-      padding: '10px 10px 10px',
-      background: 'pink',
-      fontSize: '16px',
-      lineHeight: '25px',
-      color: 'blue'
-    }
-  }
-};
-
 testCases.customTitle = {
   component: Note,
   description: 'Note with custom title',
@@ -90,6 +74,27 @@ testCases.customTitle = {
       </div>
     ),
     imageComponent: <BookImage width="60" height="60" />
+  }
+};
+
+testCases.warning = {
+  component: Note,
+  description: 'A warning note',
+  props: {
+    theme: 'warning',
+    children: <div>Here is a little thing to note.</div>,
+    imageComponent: <BookImage width="60" height="60" />
+  }
+};
+
+testCases.error = {
+  component: Note,
+  description: 'An error note',
+  props: {
+    theme: 'error',
+    title: 'Oh, fudge!',
+    children: <div>Here is a little thing to note.</div>,
+    imageComponent: <div />
   }
 };
 

--- a/src/components/note/__tests__/note-test-cases.js
+++ b/src/components/note/__tests__/note-test-cases.js
@@ -11,7 +11,7 @@ testCases.basicNote = {
   description: 'A basic note',
   props: {
     children: <div>Here is a little thing to note.</div>,
-    imageComponent: <BookImage width="60" height="60" />
+    imageComponent: <BookImage size="60" />
   }
 };
 
@@ -44,7 +44,7 @@ testCases.customTitle = {
         </p>
       </div>
     ),
-    imageComponent: <BookImage width="60" height="60" />
+    imageComponent: <BookImage size="60" />
   }
 };
 
@@ -62,7 +62,7 @@ testCases.warning = {
         </p>
       </div>
     ),
-    imageComponent: <WarningImage color="orange" width="60" height="60" />
+    imageComponent: <WarningImage color="orange" size="60" />
   }
 };
 
@@ -73,7 +73,7 @@ testCases.error = {
     theme: 'error',
     title: 'Error',
     children: <div>Did something not go as planned?</div>,
-    imageComponent: <WarningImage color="red" width="60" height="60" />
+    imageComponent: <WarningImage color="red" size="60" />
   }
 };
 

--- a/src/components/note/__tests__/note-test-cases.js
+++ b/src/components/note/__tests__/note-test-cases.js
@@ -8,21 +8,21 @@ const noRenderCases = {};
 
 testCases.basicNote = {
   component: Note,
-  description: 'A basic note',
+  description: 'A basic note to call out information on a page.',
   props: {
-    children: <div>Here is a little thing to note.</div>,
+    children: <p>Here is a little thing to note.</p>,
     imageComponent: <BookImage size="60" />
   }
 };
 
 testCases.customTitle = {
   component: Note,
-  description: 'Note with custom title',
+  description: 'Note with custom title.',
   props: {
     title: 'A very important note',
     children: (
       <div>
-        <p className="mb12">
+        <p>
           Nullam id dolor id nibh ultricies vehicula ut id elit. Cras justo
           odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus
           eget urna mollis ornare vel eu leo. Duis mollis, est non commodo
@@ -30,14 +30,14 @@ testCases.customTitle = {
           Cras mattis consectetur purus sit amet fermentum. Maecenas sed diam
           eget risus varius blandit sit amet non magna.
         </p>
-        <p className="mb12">
+        <p>
           Cras mattis consectetur purus sit amet fermentum. Aenean eu leo quam.
           Pellentesque ornare sem lacinia quam venenatis vestibulum. Vestibulum
           id ligula porta felis euismod semper. Nullam id dolor id nibh
           ultricies vehicula ut id elit. Curabitur blandit tempus porttitor.
           Maecenas sed diam eget risus varius blandit sit amet non magna.
         </p>
-        <p className="mb12">
+        <p>
           Maecenas faucibus mollis interdum. Nulla vitae elit libero, a pharetra
           augue. Etiam porta sem malesuada magna mollis euismod. Etiam porta sem
           malesuada magna mollis euismod.
@@ -50,17 +50,16 @@ testCases.customTitle = {
 
 testCases.warning = {
   component: Note,
-  description: 'A warning note',
+  description:
+    'A warning note to let the user know something has changed or will change.',
   props: {
     theme: 'warning',
     title: 'This API is in beta',
     children: (
-      <div>
-        <p>
-          Have you already installed the SDK? If so,{' '}
-          <a href="#">click here to read our migration guide</a>.
-        </p>
-      </div>
+      <p>
+        The API may change without advance notice during the preview period.
+        Preview features are not supported for production use.
+      </p>
     ),
     imageComponent: <WarningImage color="orange" size="60" />
   }
@@ -68,11 +67,17 @@ testCases.warning = {
 
 testCases.error = {
   component: Note,
-  description: 'An error or troubleshooting note',
+  description:
+    'A note to display an error with steps or links on how to troubleshoot.',
   props: {
     theme: 'error',
     title: 'Error',
-    children: <div>Did something not go as planned?</div>,
+    children: (
+      <p>
+        Did something not go as planned? Check out the{' '}
+        <a href="#">troubleshooting guide</a>.
+      </p>
+    ),
     imageComponent: <WarningImage color="red" size="60" />
   }
 };

--- a/src/components/note/__tests__/note-test-cases.js
+++ b/src/components/note/__tests__/note-test-cases.js
@@ -4,12 +4,11 @@ import BookImage from '../../book-image/book-image';
 import BookletImage from '../../booklet-image/booklet-image';
 import ContactImage from '../../contact-image/contact-image';
 import WarningImage from '../../warning-image/warning-image';
-import TroubleshootImage from '../../troubleshoot-image/troubleshoot-image';
 
 const testCases = {};
 const noRenderCases = {};
 
-testCases.basicBook = {
+testCases.basicNote = {
   component: Note,
   description: 'A basic note',
   props: {
@@ -18,30 +17,29 @@ testCases.basicBook = {
   }
 };
 
-testCases.basicBooklet = {
+testCases.relatedContentNote = {
   component: Note,
-  description: 'A basic note with a booklet image',
+  description: 'A note for related content',
   props: {
-    children: <div>Here is a little thing to note.</div>,
+    title: 'Related content',
+    children: (
+      <div className="prose">
+        <p>
+          To learn more, check out this <a href="#">cool guide</a>.
+        </p>
+      </div>
+    ),
     imageComponent: <BookletImage width="60" height="60" />
   }
 };
 
-testCases.basicContact = {
+testCases.contactNote = {
   component: Note,
-  description: 'A basic note with a contact image',
+  description: 'A note for contact information',
   props: {
-    children: <div>Here is a little thing to note.</div>,
+    title: 'Contact us',
+    children: <div>Call me. Day or night. Preferably day.</div>,
     imageComponent: <ContactImage width="60" height="60" />
-  }
-};
-
-testCases.basicTroubleshoot = {
-  component: Note,
-  description: 'A basic note with a troubleshoot image',
-  props: {
-    children: <div>Here is a little thing to note.</div>,
-    imageComponent: <TroubleshootImage width="60" height="60" />
   }
 };
 
@@ -83,6 +81,7 @@ testCases.warning = {
   description: 'A warning note',
   props: {
     theme: 'warning',
+    title: 'This API is in public beta',
     children: <div>Here is a little thing to note.</div>,
     imageComponent: <WarningImage color="orange" width="60" height="60" />
   }
@@ -90,11 +89,11 @@ testCases.warning = {
 
 testCases.error = {
   component: Note,
-  description: 'An error note',
+  description: 'An error or troubleshooting note',
   props: {
     theme: 'error',
-    title: 'Oh, fudge!',
-    children: <div>Here is a little thing to note.</div>,
+    title: 'Error',
+    children: <div>Did something not go as planned?</div>,
     imageComponent: <WarningImage color="red" width="60" height="60" />
   }
 };

--- a/src/components/note/__tests__/note-test-cases.js
+++ b/src/components/note/__tests__/note-test-cases.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import Note from '../note';
 import BookImage from '../../book-image/book-image';
-import BookletImage from '../../booklet-image/booklet-image';
-import ContactImage from '../../contact-image/contact-image';
 import WarningImage from '../../warning-image/warning-image';
 
 const testCases = {};
@@ -14,32 +12,6 @@ testCases.basicNote = {
   props: {
     children: <div>Here is a little thing to note.</div>,
     imageComponent: <BookImage width="60" height="60" />
-  }
-};
-
-testCases.relatedContentNote = {
-  component: Note,
-  description: 'A note for related content',
-  props: {
-    title: 'Related content',
-    children: (
-      <div className="prose">
-        <p>
-          To learn more, check out this <a href="#">cool guide</a>.
-        </p>
-      </div>
-    ),
-    imageComponent: <BookletImage width="60" height="60" />
-  }
-};
-
-testCases.contactNote = {
-  component: Note,
-  description: 'A note for contact information',
-  props: {
-    title: 'Contact us',
-    children: <div>Call me. Day or night. Preferably day.</div>,
-    imageComponent: <ContactImage width="60" height="60" />
   }
 };
 
@@ -81,8 +53,15 @@ testCases.warning = {
   description: 'A warning note',
   props: {
     theme: 'warning',
-    title: 'This API is in public beta',
-    children: <div>Here is a little thing to note.</div>,
+    title: 'This API is in beta',
+    children: (
+      <div>
+        <p>
+          Have you already installed the SDK? If so,{' '}
+          <a href="#">click here to read our migration guide</a>.
+        </p>
+      </div>
+    ),
     imageComponent: <WarningImage color="orange" width="60" height="60" />
   }
 };

--- a/src/components/note/note.js
+++ b/src/components/note/note.js
@@ -29,8 +29,10 @@ class Note extends React.Component {
     if (props.title) {
       titleText = props.title;
     }
-    const themeNote =
-      Object.assign(themes['base'], themes[props.theme]) || themes['default'];
+    const themeNote = Object.assign(
+      themes['base'],
+      themes[props.theme] || themes['default']
+    );
 
     return (
       <div className="flex-parent flex-parent--row mb18" style={themeNote}>

--- a/src/components/note/note.js
+++ b/src/components/note/note.js
@@ -5,26 +5,38 @@ class Note extends React.Component {
   render() {
     const { props } = this;
     let titleText = 'Note';
-    let themeNote = {
-      padding: '18px',
-      background: '#f1faff',
-      fontSize: '13px',
-      lineHeight: '20px',
-      color: '#587594',
-      borderRadius: '4px'
+    const themes = {
+      base: {
+        // applied to every note
+        padding: '18px',
+        fontSize: '13px',
+        lineHeight: '20px',
+        borderRadius: '4px'
+      },
+      default: {
+        background: '#f1faff',
+        color: '#587594'
+      },
+      warning: {
+        background: '#feefe2',
+        color: '#945823'
+      },
+      error: {
+        background: '#fbe5e5',
+        color: '#ba3b3f'
+      }
     };
     if (props.title) {
       titleText = props.title;
     }
-    if (props.theme) {
-      themeNote = props.theme;
-    }
+    const themeNote =
+      Object.assign(themes['base'], themes[props.theme]) || themes['default'];
 
     return (
       <div className="flex-parent flex-parent--row" style={themeNote}>
         <div className="flex-child mr12">{props.imageComponent}</div>
         <div className="flex-child">
-          <div className="txt-bold txt-m color-gray-dark">{titleText}</div>
+          <div className="txt-bold txt-m mb6">{titleText}</div>
           {props.children}
         </div>
       </div>
@@ -36,13 +48,7 @@ Note.propTypes = {
   title: PropTypes.string,
   children: PropTypes.node.isRequired,
   imageComponent: PropTypes.node.isRequired,
-  theme: PropTypes.shape({
-    padding: PropTypes.string,
-    background: PropTypes.string,
-    fontSize: PropTypes.string,
-    lineHeight: PropTypes.string,
-    color: PropTypes.string
-  })
+  theme: PropTypes.string
 };
 
 export default Note;

--- a/src/components/note/note.js
+++ b/src/components/note/note.js
@@ -33,7 +33,7 @@ class Note extends React.Component {
       Object.assign(themes['base'], themes[props.theme]) || themes['default'];
 
     return (
-      <div className="flex-parent flex-parent--row" style={themeNote}>
+      <div className="flex-parent flex-parent--row mb18" style={themeNote}>
         <div className="flex-child mr12">{props.imageComponent}</div>
         <div className="flex-child">
           <div className="txt-bold txt-m mb6">{titleText}</div>

--- a/src/components/troubleshoot-image/troubleshoot-image.js
+++ b/src/components/troubleshoot-image/troubleshoot-image.js
@@ -9,8 +9,8 @@ export default class TroubleshootImage extends React.Component {
         id="Layer_1"
         data-name="Layer 1"
         xmlns="http://www.w3.org/2000/svg"
-        width={props.width}
-        height={props.height}
+        width={props.size}
+        height={props.size}
         viewBox="0 0 108 108"
       >
         <title>help</title>
@@ -58,6 +58,5 @@ export default class TroubleshootImage extends React.Component {
 }
 
 TroubleshootImage.propTypes = {
-  width: PropTypes.string.isRequired,
-  height: PropTypes.string.isRequired
+  size: PropTypes.string.isRequired
 };

--- a/src/components/warning-image/index.js
+++ b/src/components/warning-image/index.js
@@ -1,0 +1,3 @@
+import main from './warning-image';
+
+export default main;

--- a/src/components/warning-image/warning-image.js
+++ b/src/components/warning-image/warning-image.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class WarningImage extends React.Component {
+  render() {
+    const { props } = this;
+    return (
+      <div
+        style={{
+          padding: '5px',
+          width: `${props.width}px`,
+          height: `${props.height}px`
+        }}
+      >
+        <div className={`bg-${props.color || 'blue'}-light px3 round-full`}>
+          <svg viewBox="0 0 18 18" className={`color-${props.color || 'blue'}`}>
+            <title>warning</title>
+            <path
+              style={{ fill: 'currentColor' }}
+              d="M9,3C8.4,3,7.8,3.3,7.5,3.8L3.2,13c-0.5,0.8,0,2,1.1,2H9h4.7c1.1,0,1.6-1.2,1.1-2l-4.3-9.2C10.2,3.3,9.6,3,9,3z M9,6
+c0.6,0,1,0.4,1,1v2c0,0.6-0.4,1-1,1S8,9.6,8,9V7C8,6.4,8.4,6,9,6z M9,11c0.6,0,1,0.4,1,1s-0.4,1-1,1s-1-0.4-1-1S8.4,11,9,11z"
+            />
+          </svg>
+        </div>
+      </div>
+    );
+  }
+}
+
+WarningImage.propTypes = {
+  width: PropTypes.string.isRequired,
+  height: PropTypes.string.isRequired,
+  color: PropTypes.string
+};

--- a/src/components/warning-image/warning-image.js
+++ b/src/components/warning-image/warning-image.js
@@ -8,8 +8,8 @@ export default class WarningImage extends React.Component {
       <div
         style={{
           padding: '5px',
-          width: `${props.width}px`,
-          height: `${props.height}px`
+          width: `${props.size}px`,
+          height: `${props.size}px`
         }}
       >
         <div className={`bg-${props.color || 'blue'}-light px3 round-full`}>
@@ -28,7 +28,6 @@ c0.6,0,1,0.4,1,1v2c0,0.6-0.4,1-1,1S8,9.6,8,9V7C8,6.4,8.4,6,9,6z M9,11c0.6,0,1,0.
 }
 
 WarningImage.propTypes = {
-  width: PropTypes.string.isRequired,
-  height: PropTypes.string.isRequired,
+  size: PropTypes.string.isRequired,
   color: PropTypes.string
 };


### PR DESCRIPTION
@colleenmcginnis do you know offhand if we have any sites using the Note component and passing a custom theme to it? This PR proposes to remove passing style-based themes and replace it with keyword themes (default/no theme specified, warning, error). If it's important to be able to customize the note, I can adjust!

fixes #94

