### PR TITLE
Add CSS to set max-height and style scrollbars for prose code examples

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,4 @@
 {
-  "*.js": ["eslint", "prettier --write", "git add"]
+  "*.js": ["eslint", "prettier --write", "git add"],
+  "*.css": ["prettier --write", "git add"]
 }

--- a/src/css/docs-prose.css
+++ b/src/css/docs-prose.css
@@ -55,7 +55,7 @@
   background: transparent;
 }
 
-@media screen and (min-width:640px) {
+@media screen and (min-width: 640px) {
   .scroll-auto-mm {
     overflow: auto !important;
     -webkit-overflow-scrolling: touch;

--- a/src/css/docs-prose.css
+++ b/src/css/docs-prose.css
@@ -24,6 +24,37 @@
   padding-top: 40px;
 }
 
+/* set max-height for code examples */
+.prose pre {
+  max-height: 300px;
+  overflow: auto;
+}
+
+/* styled scrollbars for long (x or y) code examples */
+.prose pre::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+  background: transparent;
+}
+.prose pre::-webkit-scrollbar:hover {
+  background: transparent;
+}
+.prose pre::-webkit-scrollbar-track {
+  background: none;
+}
+.prose pre::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.25);
+  border-color: transparent;
+  width: 6px;
+  border-radius: 3px;
+}
+.prose pre::-webkit-scrollbar-thumb:hover {
+  background: rgba(0, 0, 0, 0.35);
+}
+.prose pre::-webkit-scrollbar-track:hover {
+  background: transparent;
+}
+
 @media screen and (min-width:640px) {
   .scroll-auto-mm {
     overflow: auto !important;


### PR DESCRIPTION
I have added these styles to at least two other repos, I think they are great candidates for application docs-wide.

This PR also makes Prettier format *.css files.

fixes #99

