### PR TITLE
[OverviewHeader] Add `contactLink` to create Contact us button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 
 - Update to mr-ui 0.5.0. ([#95](https://github.com/mapbox/dr-ui/pull/95))
+- Add `contactLink` prop to `OverviewHeader` to create Contact us button. ([#105](https://github.com/mapbox/dr-ui/pull/105))
 
 ## 0.3.0
 

--- a/src/components/overview-header/__tests__/overview-header-test-cases.js
+++ b/src/components/overview-header/__tests__/overview-header-test-cases.js
@@ -61,4 +61,42 @@ testCases.some = {
   }
 };
 
+testCases.allContactUs = {
+  description: 'All, plus Contact Us button',
+  component: OverviewHeader,
+  props: {
+    features: ['Smooth scrambled eggs', 'Vegetarian sausage', 'Fruit syrups'],
+    title: 'Mapbox SDK for Breakfast',
+    version: '0.1.0',
+    changelogLink: 'https://keepachangelog.com/en/0.3.0/',
+    installLink: 'https://www.mapbox.com/install',
+    ghLink: 'https://github.com/mapbox',
+    contactLink: 'https://www.mapbox.com/contact/',
+    image: (
+      <img
+        height={300}
+        src="https://farm2.staticflickr.com/1790/29050447978_41e671dcd5_o.jpg"
+      />
+    )
+  }
+};
+
+testCases.contactUs = {
+  description: 'Adds Contact Us button',
+  component: OverviewHeader,
+  props: {
+    features: ['Smooth scrambled eggs', 'Vegetarian sausage', 'Fruit syrups'],
+    title: 'Mapbox SDK for Breakfast',
+    version: '0.1.0',
+    changelogLink: 'https://keepachangelog.com/en/0.3.0/',
+    contactLink: 'https://www.mapbox.com/contact/',
+    image: (
+      <img
+        height={300}
+        src="https://farm2.staticflickr.com/1790/29050447978_41e671dcd5_o.jpg"
+      />
+    )
+  }
+};
+
 export { testCases };

--- a/src/components/overview-header/overview-header.js
+++ b/src/components/overview-header/overview-header.js
@@ -7,7 +7,9 @@ class OverviewHeader extends React.PureComponent {
     const { props } = this;
 
     const versionEl = props.version !== undefined && (
-      <span>Current version: v{props.version} </span>
+      <span>
+        Current version: <code>v{props.version}</code>{' '}
+      </span>
     );
 
     const changelogLinkEl = props.changelogLink && (
@@ -49,13 +51,23 @@ class OverviewHeader extends React.PureComponent {
       </a>
     );
 
-    if (!installLinkEl && !ghLinkEl) {
+    const contactLinkEl = props.contactLink && (
+      <a
+        href={props.contactLink}
+        className="btn txt-l round inline-block color-white unprose mr24"
+      >
+        Contact us
+      </a>
+    );
+
+    if (!installLinkEl && !ghLinkEl && !contactLinkEl) {
       return null;
     }
 
     return (
       <div className="mb24">
         {installLinkEl}
+        {contactLinkEl}
         {ghLinkEl}
       </div>
     );
@@ -100,9 +112,10 @@ OverviewHeader.propTypes = {
   title: PropTypes.string.isRequired,
   image: PropTypes.node.isRequired,
   version: PropTypes.string,
-  changelogLink: PropTypes.string,
-  installLink: PropTypes.string,
-  ghLink: PropTypes.string
+  changelogLink: PropTypes.string, // creates a "View changelog" link
+  installLink: PropTypes.string, // creates a "Install" button
+  ghLink: PropTypes.string, // creates a "Contribute on GitHub" link
+  contactLink: PropTypes.string // creates a "Contact us" button
 };
 
 export default OverviewHeader;


### PR DESCRIPTION
This PR adds a new optional prop `contactLink` to `OverviewHeader` which will add a "Contact us" button to the header if populated:

![image](https://user-images.githubusercontent.com/2180540/52002476-266bcb80-2490-11e9-87a2-850d75286415.png)

This PR also wraps the version in a code element to increase discoverability of the version number in the header.