### PR TITLE
[SectionedNavigation] filter the description if it's available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Master
+
+- Add ability to filter the description if it's available in `SectionedNavigation`. (#111)(https://github.com/mapbox/dr-ui/pull/111)
+
 ## 0.5.0
 
 - Add prism.css to create shared syntax styles [#108](https://github.com/mapbox/dr-ui/pull/108)

--- a/src/components/sectioned-navigation/__tests__/sectioned-navigation-test-cases.js
+++ b/src/components/sectioned-navigation/__tests__/sectioned-navigation-test-cases.js
@@ -170,7 +170,8 @@ testCases.filter = {
         items: [
           {
             text: 'Camera animation',
-            url: '#foo'
+            url: '#foo',
+            description: 'pizza'
           },
           {
             text: 'Mark a place',
@@ -179,7 +180,8 @@ testCases.filter = {
           },
           {
             text: 'Apply a style',
-            url: '#fooandyou'
+            url: '#fooandyou',
+            description: 'pretzels'
           }
         ]
       },
@@ -189,11 +191,13 @@ testCases.filter = {
         items: [
           {
             text: 'Annotation models',
-            url: '#fooboo'
+            url: '#fooboo',
+            description: 'pretzels'
           },
           {
             text: 'Callouts',
-            url: '#foocrew'
+            url: '#foocrew',
+            description: 'pretzels'
           }
         ]
       },
@@ -203,7 +207,8 @@ testCases.filter = {
         items: [
           {
             text: 'Apply a style',
-            url: '#fooblue'
+            url: '#fooblue',
+            description: 'ice cream'
           }
         ]
       }

--- a/src/components/sectioned-navigation/sectioned-navigation.js
+++ b/src/components/sectioned-navigation/sectioned-navigation.js
@@ -50,13 +50,19 @@ class SectionedNavigation extends React.Component {
     const visibleSections = this.props.sections
       .filter(section => {
         const matchedItems = section.items.filter(item => {
-          return item.text.toLowerCase().indexOf(filter) > -1;
+          return (
+            item.text.toLowerCase().indexOf(filter) > -1 ||
+            (item.description && item.description.indexOf(filter) > -1)
+          );
         });
         return matchedItems.length > 0;
       })
       .map(filteredSection => {
         const filteredItems = filteredSection.items.filter(item => {
-          return item.text.toLowerCase().indexOf(filter) > -1;
+          return (
+            item.text.toLowerCase().indexOf(filter) > -1 ||
+            (item.description && item.description.indexOf(filter) > -1)
+          );
         });
         return {
           title: filteredSection.title,


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gl-js/issues/7888

In the `SectionedNavigation` when `includeFilterBar` is true, if the dataset sent to the component includes a `description`, then we'll also filter on the description in addition to the title.

How to test: I updated the *With a title, linked section headings, counts, and filter*  test case on http://192.168.7.223:9966/SectionedNavigation with a few descriptions. You can try searching for `pizza` or `pretzels` (naturally).