### PR TITLE
[docs-prose.css] make `.prose pre` rules more specific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add ability to filter the description if it's available in `SectionedNavigation`. (#111)(https://github.com/mapbox/dr-ui/pull/111)
 - Add `mb24` to `OverviewHeader`. [#112](https://github.com/mapbox/dr-ui/pull/#112)
+- Fix `.prose pre` rules in docs-prose.css to make specific to code blocks with `.language-` prefixed classes. [#113](https://github.com/mapbox/dr-ui/pull/#113)
 
 ## 0.5.0
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "budo ./src/test-cases-app/test-cases-app.js --dir ./src/test-cases-app --live --debug --pushstate -- -t babelify",
-    "cp-assembly": "del ./src/test-cases-app/dist && cpy node_modules/@mapbox/mapbox-assembly/dist/*.* ./src/test-cases-app/dist",
+    "cp-assembly": "del ./src/test-cases-app/dist && cpy node_modules/@mapbox/mapbox-assembly/dist/*.* ./src/test-cases-app/dist && cpy src/css/docs-prose.css ./src/test-cases-app/dist && cpy src/css/prism.css ./src/test-cases-app/dist",
     "budo": "budo test/app.js -l -d -P -- -t babelify",
     "prestart": "npm run build-component-index && npm run cp-assembly",
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/components/page-layout/__tests__/page-layout-test-cases.js
+++ b/src/components/page-layout/__tests__/page-layout-test-cases.js
@@ -235,4 +235,99 @@ testCases.manyItems = {
   }
 };
 
+testCases.codeHighlighting = {
+  description: 'Code highlighting test',
+  component: PageLayout,
+  props: {
+    sidebarContent: <div>Some content</div>,
+    sidebarTitle: 'Some title',
+    sidebarContentStickyTop: 0,
+    sidebarContentStickyTopNarrow: 0,
+    children: (
+      <div className="prose">
+        <h2>Has scrollbar</h2>
+        <pre className=" language-curl">
+          <code className=" language-curl">
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+            culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum
+            dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+            veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+            ea commodo consequat. Duis aute irure dolor in reprehenderit in
+            voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
+            officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit
+            amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
+            ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+            nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+            consequat. Duis aute irure dolor in reprehenderit in voluptate velit
+            esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+            cupidatat non proident, sunt in culpa qui officia deserunt mollit
+            anim id est laborum. Lorem ipsum dolor sit amet, consectetur
+            adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+            dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+            exercitation ullamco laboris nisi ut aliquip ex ea commodo
+            consequat. Duis aute irure dolor in reprehenderit in voluptate velit
+            esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+            cupidatat non proident, sunt in culpa qui officia deserunt mollit
+            anim id est laborum. Lorem ipsum dolor sit amet, consectetur
+            adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+            dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+            exercitation ullamco laboris nisi ut aliquip ex ea commodo
+            consequat. Duis aute irure dolor in reprehenderit in voluptate velit
+            esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+            cupidatat non proident, sunt in culpa qui officia deserunt mollit
+            anim id est laborum.
+          </code>
+        </pre>
+        <h2>No scrollbar</h2>
+        <pre>
+          <code>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+            culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum
+            dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+            veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+            ea commodo consequat. Duis aute irure dolor in reprehenderit in
+            voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
+            officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit
+            amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
+            ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+            nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+            consequat. Duis aute irure dolor in reprehenderit in voluptate velit
+            esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+            cupidatat non proident, sunt in culpa qui officia deserunt mollit
+            anim id est laborum. Lorem ipsum dolor sit amet, consectetur
+            adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+            dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+            exercitation ullamco laboris nisi ut aliquip ex ea commodo
+            consequat. Duis aute irure dolor in reprehenderit in voluptate velit
+            esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+            cupidatat non proident, sunt in culpa qui officia deserunt mollit
+            anim id est laborum. Lorem ipsum dolor sit amet, consectetur
+            adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+            dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+            exercitation ullamco laboris nisi ut aliquip ex ea commodo
+            consequat. Duis aute irure dolor in reprehenderit in voluptate velit
+            esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+            cupidatat non proident, sunt in culpa qui officia deserunt mollit
+            anim id est laborum.
+          </code>
+        </pre>
+      </div>
+    )
+  }
+};
+
 export { testCases };

--- a/src/css/docs-prose.css
+++ b/src/css/docs-prose.css
@@ -25,33 +25,33 @@
 }
 
 /* set max-height for code examples */
-.prose pre {
+.prose pre[class*='language-'] {
   max-height: 300px;
   overflow: auto;
 }
 
 /* styled scrollbars for long (x or y) code examples */
-.prose pre::-webkit-scrollbar {
+.prose pre[class*='language-']::-webkit-scrollbar {
   width: 6px;
   height: 6px;
   background: transparent;
 }
-.prose pre::-webkit-scrollbar:hover {
+.prose pre[class*='language-']::-webkit-scrollbar:hover {
   background: transparent;
 }
-.prose pre::-webkit-scrollbar-track {
+.prose pre[class*='language-']::-webkit-scrollbar-track {
   background: none;
 }
-.prose pre::-webkit-scrollbar-thumb {
+.prose pre[class*='language-']::-webkit-scrollbar-thumb {
   background: rgba(0, 0, 0, 0.25);
   border-color: transparent;
   width: 6px;
   border-radius: 3px;
 }
-.prose pre::-webkit-scrollbar-thumb:hover {
+.prose pre[class*='language-']::-webkit-scrollbar-thumb:hover {
   background: rgba(0, 0, 0, 0.35);
 }
-.prose pre::-webkit-scrollbar-track:hover {
+.prose pre[class*='language-']::-webkit-scrollbar-track:hover {
   background: transparent;
 }
 

--- a/src/css/docs-prose.css
+++ b/src/css/docs-prose.css
@@ -31,27 +31,27 @@
 }
 
 /* styled scrollbars for long (x or y) code examples */
-.prose pre[class*='language-']::-webkit-scrollbar {
+.prose pre::-webkit-scrollbar {
   width: 6px;
   height: 6px;
   background: transparent;
 }
-.prose pre[class*='language-']::-webkit-scrollbar:hover {
+.prose pre::-webkit-scrollbar:hover {
   background: transparent;
 }
-.prose pre[class*='language-']::-webkit-scrollbar-track {
+.prose pre::-webkit-scrollbar-track {
   background: none;
 }
-.prose pre[class*='language-']::-webkit-scrollbar-thumb {
+.prose pre::-webkit-scrollbar-thumb {
   background: rgba(0, 0, 0, 0.25);
   border-color: transparent;
   width: 6px;
   border-radius: 3px;
 }
-.prose pre[class*='language-']::-webkit-scrollbar-thumb:hover {
+.prose pre::-webkit-scrollbar-thumb:hover {
   background: rgba(0, 0, 0, 0.35);
 }
-.prose pre[class*='language-']::-webkit-scrollbar-track:hover {
+.prose pre::-webkit-scrollbar-track:hover {
   background: transparent;
 }
 

--- a/src/test-cases-app/index.html
+++ b/src/test-cases-app/index.html
@@ -5,9 +5,11 @@
   <meta charset='utf-8'>
   <meta name='viewport' content='width=device-width, initial-scale=1'>
   <link id="assembly-css" href="dist/assembly.min.css" rel="stylesheet">
+  <link href="dist/docs-prose.css" rel="stylesheet">
+  <link href="dist/prism.css" rel="stylesheet">
   <script id="assembly-js" src="dist/assembly.js"></script>
 </head>
-<body>
+<body id="docs-content">
   <script src="test-cases-app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
When markdown parses code blocks, it adds classes with the language to the pre element, for example: `class="language-html"`.

This PR updates the `.prose pre` classes in docs-prose.css to only apply the classes if the pre element has a `language-` class.

This will keep example pages on our various docs sites from getting max-height on code blocks, where it's not preferred.

This PR also copies over docs-prose.css to the test-cases-app so we can see it in use!

How to test: to PageLayout I added a test case to simulate code output.