### PR TITLE
Add optional prop for tags for first level items in NavigationAccordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Master
+
+- Add an optional prop in `NavigationAccordion` to add tags to first level items. (#115)(https://github.com/mapbox/dr-ui/pull/115)
+
 ## 0.6.0
 
 - Add ability to filter the description if it's available in `SectionedNavigation`. (#111)(https://github.com/mapbox/dr-ui/pull/111)

--- a/src/components/navigation-accordion/__tests__/navigation-accordion-test-cases.js
+++ b/src/components/navigation-accordion/__tests__/navigation-accordion-test-cases.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import NavigationAccordion from '../navigation-accordion';
 
 const testCases = {};
@@ -63,10 +64,20 @@ testCases.withThirdLevelItems = {
       firstLevelItems: [
         {
           title: 'Title one',
+          tag: (
+            <div className="inline-block ml12 txt-xs txt-bold txt-uppercase px6 round color-pink bg-pink-faint">
+              Fundamentals
+            </div>
+          ),
           path: 'page-one'
         },
         {
           title: 'Title two',
+          tag: (
+            <div className="inline-block ml12 txt-xs txt-bold txt-uppercase px6 round color-blue bg-blue-faint">
+              Advanced
+            </div>
+          ),
           path: 'page-two'
         }
       ],

--- a/src/components/navigation-accordion/navigation-accordion.js
+++ b/src/components/navigation-accordion/navigation-accordion.js
@@ -134,7 +134,10 @@ class NavigationAccordion extends React.PureComponent {
                 href={page.path}
                 className="color-blue-on-hover color-gray text-decoration-none unprose flex-parent flex-parent--space-between-main flex-parent--center-cross"
               >
-                <div className={textClasses}>{title}</div>
+                <div className={textClasses}>
+                  {title}
+                  {page.tag ? page.tag : ''}
+                </div>
                 {icon}
               </a>
               {renderedSecondLevelContent}
@@ -164,6 +167,7 @@ NavigationAccordion.propTypes = {
     firstLevelItems: PropTypes.arrayOf(
       PropTypes.shape({
         title: PropTypes.string.isRequired,
+        tag: PropTypes.node,
         path: PropTypes.string.isRequired
       })
     ).isRequired,


### PR DESCRIPTION
Related: https://github.com/mapbox/android-docs/pull/842

Adds an additional prop to `NavigationAccordion` for adding a tag to a first level item.

<img width="897" alt="screen shot 2019-02-25 at 9 01 00 pm" src="https://user-images.githubusercontent.com/10479155/53388573-7bd8b280-3940-11e9-83fd-13f9aa179d0f.png">
