### PR TITLE
add swiftype attribute to ignore content blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Master
+
+- Add Swiftype attribute to ignore content blocks in `CardContainer`, `SectionedNavigation`, and `TopbarSticker`. (#119)(https://github.com/mapbox/dr-ui/pull/119)
+
 ## 0.9.0
 
 - Add `BetaFlag` component, `beta` prop to OverviewHeader, `beta` prop to ProductMenu; update mr-ui to v0.7.0. (#123)(https://github.com/mapbox/dr-ui/pull/123)

--- a/src/components/card-container/card-container.js
+++ b/src/components/card-container/card-container.js
@@ -24,7 +24,8 @@ class CardContainer extends React.PureComponent {
       <div>
         <a href={props.path} className="unprose mb18 block color-blue-on-hover">
           <h2 className="txt-bold" id={categoryID}>
-            {props.title} ({props.cards.length})
+            {props.title}{' '}
+            <span data-swiftype-index="false">({props.cards.length})</span>
           </h2>
         </a>
         <div className={containerClasses}>{renderedCards}</div>

--- a/src/components/sectioned-navigation/sectioned-navigation.js
+++ b/src/components/sectioned-navigation/sectioned-navigation.js
@@ -76,7 +76,7 @@ class SectionedNavigation extends React.Component {
   render() {
     const { props } = this;
     return (
-      <div>
+      <div data-swiftype-index="false">
         {this.renderTitle()}
         {this.renderFilterBar()}
         {this.state.visibleSections.map((section, i) => (

--- a/src/components/topbar-sticker/topbar-sticker.js
+++ b/src/components/topbar-sticker/topbar-sticker.js
@@ -39,7 +39,10 @@ class TopbarSticker extends React.PureComponent {
         bottomBoundary={this.state.bottomBoundaryValue}
         innerZ={3}
       >
-        <div className="border-t border-b border--gray-light bg-white">
+        <div
+          className="border-t border-b border--gray-light bg-white"
+          data-swiftype-index="false"
+        >
           {this.props.children}
         </div>
       </Sticky>


### PR DESCRIPTION
Adds `data-swiftype-index="false"` to content that we don't necessarily want to get index.

The counter number in the card container title adds some cruft, so we should not index that number. Otherwise it could show up in results and looks out of place:

![image](https://user-images.githubusercontent.com/2180540/55587203-d4962a80-56f8-11e9-8393-6cfdb951c0e9.png)

Turning off indexing for the sectioned navigation as a whole since all the content is duplicated in the body of the page.

refs https://github.com/mapbox/documentation/issues/76#issuecomment-480016159
