### PR TITLE
fixes bug in firefox where arrow was not vertically centered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 
 - Add Swiftype attribute to ignore content blocks in `CardContainer`, `SectionedNavigation`, and `TopbarSticker`. (#119)(https://github.com/mapbox/dr-ui/pull/119)
+- Fix bug in Firefox where arrow was not vertically centered in `BackToTopButton`. (#122)(https://github.com/mapbox/dr-ui/pull/122)
 
 ## 0.9.0
 

--- a/src/components/back-to-top-button/back-to-top-button.js
+++ b/src/components/back-to-top-button/back-to-top-button.js
@@ -30,7 +30,7 @@ export default class BackToTopButton extends React.Component {
             }}
             passthroughProps={{
               className:
-                'btn--blue w60 h60 px0 round-full shadow-darken25 color-white flex-parent flex-parent--center-main'
+                'btn--blue w60 h60 px0 round-full shadow-darken25 color-white flex-parent flex-parent--center-main flex-parent--center-cross'
             }}
           >
             <Icon name="arrow-up" size={30} />


### PR DESCRIPTION
fixes #120 

Firefox: 
![image](https://user-images.githubusercontent.com/2180540/55982290-a4a1d680-5c66-11e9-9b48-55efdd8fe9de.png)

Chrome:
![image](https://user-images.githubusercontent.com/2180540/55982306-abc8e480-5c66-11e9-929e-7596d0b6e8eb.png)

Safari:
![image](https://user-images.githubusercontent.com/2180540/55982337-ba170080-5c66-11e9-8e42-19aa51448683.png)

