### PR TITLE
Add BetaFlag component and options to add it to other components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Master
+
+- Add `BetaFlag` component, `beta` prop to OverviewHeader, `beta` prop to ProductMenu; update mr-ui to v0.7.0. (#123)(https://github.com/mapbox/dr-ui/pull/123)
+
 ## 0.8.1
 
 - [Patch] Use babel.config.js and update build-package.js to output components to directories during `npm run build`.(#118)(https://github.com/mapbox/dr-ui/pull/118)

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,8 +86,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -108,14 +107,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -130,20 +127,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -260,8 +254,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -273,7 +266,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -288,7 +280,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -296,14 +287,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -322,7 +311,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -403,8 +391,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -416,7 +403,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -502,8 +488,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -539,7 +524,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -559,7 +543,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -603,14 +586,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -3320,9 +3301,9 @@
       }
     },
     "@mapbox/mr-ui": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mr-ui/-/mr-ui-0.5.0.tgz",
-      "integrity": "sha512-NcL6GSrukl1mxmXgQQmz7IpasbtxLLaWv8PCWiacw43iPly6bCjvH4o8dIjPBDkG5GrZFpMjZXX1IK7vM86rww==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mr-ui/-/mr-ui-0.7.0.tgz",
+      "integrity": "sha512-o61YbdMUrn8NpAHx+CY2OSho14VAmL0neyPWIxgCeraE4W5C5rA0pULDUd3pAHS3nqoZfgZ81b+Ak1YOzUaemQ==",
       "requires": {
         "@mapbox/query-selector-contains-node": "^1.0.0",
         "classnames": "^2.2.6",
@@ -7105,8 +7086,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7130,15 +7110,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7155,22 +7133,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7301,8 +7276,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7316,7 +7290,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7333,7 +7306,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7342,15 +7314,13 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -7371,7 +7341,6 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7460,8 +7429,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7475,7 +7443,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7571,8 +7538,7 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7614,7 +7580,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7636,7 +7601,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7685,15 +7649,13 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -11511,9 +11473,9 @@
       }
     },
     "moment": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
-      "integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA=="
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "ms": {
       "version": "2.0.0",
@@ -12340,9 +12302,9 @@
       "dev": true
     },
     "popper.js": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.6.tgz",
-      "integrity": "sha512-AGwHGQBKumlk/MDfrSOf0JHhJCImdDMcGNoqKmKkU+68GFazv3CQ6q9r7Ja1sKDZmYWTckY/uLyEznheTDycnA=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
+      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -12715,9 +12677,9 @@
       }
     },
     "react-aria-modal": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/react-aria-modal/-/react-aria-modal-3.0.1.tgz",
-      "integrity": "sha512-H0pV5ITXe6JCQAUGoSiSncfTeGunImT8KFzLLMisuzOzsG4X7GZQJGcjk6uSwZmvwZpHL+EjMwRD+vJZx3nG8g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-aria-modal/-/react-aria-modal-3.1.0.tgz",
+      "integrity": "sha512-wTnKxbCe2uGRrHuxd//5mqIkMRskwr4QHWjISeVjOuyY8KNVjqAQ/iXGHN9OrWYqouKwE5r1RMcvX52wODwimA==",
       "requires": {
         "focus-trap-react": "^4.0.0",
         "no-scroll": "^2.1.1",
@@ -12760,9 +12722,9 @@
       "dev": true
     },
     "react-onclickoutside": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz",
-      "integrity": "sha512-p84kBqGaMoa7VYT0vZ/aOYRfJB+gw34yjpda1Z5KeLflg70HipZOT+MXQenEhdkPAABuE2Astq4zEPdMqUQxcg=="
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.8.0.tgz",
+      "integrity": "sha512-5Q4Rn7QLEoh7WIe66KFvYIpWJ49GeHoygP1/EtJyZjXKgrWH19Tf0Ty3lWyQzrEEDyLOwUvvmBFSE3dcDdvagA=="
     },
     "react-popper": {
       "version": "0.7.4",
@@ -13420,9 +13382,9 @@
       }
     },
     "shallow-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.0.0.tgz",
-      "integrity": "sha1-UI0YOLPeWQq4dXsBGyXkMJAJRfc="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.1.0.tgz",
+      "integrity": "sha512-0SW1nWo1hnabO62SEeHsl8nmTVVEzguVWZCj5gaQrgWAxz/BaCja4OWdJBWLVPDxdtE/WU7c98uUCCXyPHSCvw=="
     },
     "shallowequal": {
       "version": "1.1.0",
@@ -14332,9 +14294,9 @@
       }
     },
     "tiny-emitter": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
-      "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "unist-util-visit": "^1.4.0"
   },
   "dependencies": {
-    "@mapbox/mr-ui": "^0.5.0",
+    "@mapbox/mr-ui": "^0.7.0",
     "classnames": "^2.2.6",
     "debounce": "^1.2.0",
     "extend": "^3.0.2",

--- a/src/components/beta-flag/__tests__/beta-flag-test-cases.js
+++ b/src/components/beta-flag/__tests__/beta-flag-test-cases.js
@@ -1,0 +1,20 @@
+import BetaFlag from '../beta-flag';
+
+const testCases = {};
+const noRenderCases = {};
+
+testCases.basic = {
+  component: BetaFlag,
+  description: 'Basic',
+  props: {}
+};
+
+noRenderCases.custom = {
+  component: BetaFlag,
+  description: 'Custom note',
+  props: {
+    tooltipText: 'Hello. This is custom text.'
+  }
+};
+
+export default { testCases, noRenderCases };

--- a/src/components/beta-flag/beta-flag.js
+++ b/src/components/beta-flag/beta-flag.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Badge from '@mapbox/mr-ui/badge';
+
+export default class BetaFlag extends React.Component {
+  render() {
+    const { props } = this;
+    return <Badge badgeText="Beta" tooltipText={props.tooltipText} />;
+  }
+}
+
+BetaFlag.propTypes = {
+  tooltipText: PropTypes.string
+};
+
+BetaFlag.defaultProps = {
+  tooltipText:
+    'This feature is in public beta and is subject to potential changes.'
+};

--- a/src/components/beta-flag/index.js
+++ b/src/components/beta-flag/index.js
@@ -1,0 +1,3 @@
+import main from './back-to-top-button';
+
+export default main;

--- a/src/components/overview-header/__tests__/overview-header-test-cases.js
+++ b/src/components/overview-header/__tests__/overview-header-test-cases.js
@@ -61,6 +61,23 @@ testCases.some = {
   }
 };
 
+testCases.beta = {
+  description: 'Beta product',
+  component: OverviewHeader,
+  props: {
+    features: ['Chips', 'Tots', 'Fries'],
+    title: 'Mapbox Potato SDK',
+    beta: true,
+    image: (
+      <img
+        width={800}
+        height={499}
+        src="https://farm2.staticflickr.com/1790/29050447978_41e671dcd5_o.jpg"
+      />
+    )
+  }
+};
+
 testCases.allContactUs = {
   description: 'All, plus Contact Us button',
   component: OverviewHeader,

--- a/src/components/overview-header/overview-header.js
+++ b/src/components/overview-header/overview-header.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Icon from '@mapbox/mr-ui/icon';
+import BetaFlag from '../beta-flag/beta-flag';
 
 class OverviewHeader extends React.PureComponent {
   renderVersion() {
@@ -89,7 +90,16 @@ class OverviewHeader extends React.PureComponent {
 
     return (
       <div className="scroll-hidden border-b border--gray-light prose mb24">
-        <h1 className="mb6 txt-fancy">{props.title}</h1>
+        <h1 className="mb6 txt-fancy">
+          {props.title}
+          {props.beta ? (
+            <span className="ml12">
+              <BetaFlag />
+            </span>
+          ) : (
+            ''
+          )}
+        </h1>
         <div className="relative">
           <div className="pr12-ml mr240-ml mr0">
             {this.renderVersion()}
@@ -110,12 +120,17 @@ class OverviewHeader extends React.PureComponent {
 OverviewHeader.propTypes = {
   features: PropTypes.arrayOf(PropTypes.string).isRequired,
   title: PropTypes.string.isRequired,
+  beta: PropTypes.bool,
   image: PropTypes.node.isRequired,
   version: PropTypes.string,
   changelogLink: PropTypes.string, // creates a "View changelog" link
   installLink: PropTypes.string, // creates a "Install" button
   ghLink: PropTypes.string, // creates a "Contribute on GitHub" link
   contactLink: PropTypes.string // creates a "Contact us" button
+};
+
+OverviewHeader.defaultProps = {
+  beta: false
 };
 
 export default OverviewHeader;

--- a/src/components/overview-header/overview-header.js
+++ b/src/components/overview-header/overview-header.js
@@ -93,7 +93,10 @@ class OverviewHeader extends React.PureComponent {
         <h1 className="mb6 txt-fancy">
           {props.title}
           {props.beta ? (
-            <span className="ml12">
+            <span
+              className="ml12 inline-block relative"
+              style={{ top: '-7px' }}
+            >
               <BetaFlag />
             </span>
           ) : (

--- a/src/components/product-menu/__tests__/product-menu-test-cases.js
+++ b/src/components/product-menu/__tests__/product-menu-test-cases.js
@@ -43,4 +43,14 @@ testCases.customStyle = {
   )
 };
 
+testCases.beta = {
+  component: ProductMenu,
+  description: 'Beta product',
+  props: {
+    productName: 'Vision SDK for Android',
+    beta: true,
+    homePage: '/vision/'
+  }
+};
+
 export default { testCases };

--- a/src/components/product-menu/product-menu.js
+++ b/src/components/product-menu/product-menu.js
@@ -16,7 +16,7 @@ class ProductMenu extends React.PureComponent {
       >
         {props.productName}
         {props.beta ? (
-          <span className="ml12">
+          <span className="inline-block ml6 relative" style={{ top: '-2px' }}>
             <BetaFlag />
           </span>
         ) : (

--- a/src/components/product-menu/product-menu.js
+++ b/src/components/product-menu/product-menu.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import BetaFlag from '../beta-flag/beta-flag';
 
 class ProductMenu extends React.PureComponent {
   render() {
@@ -14,18 +15,28 @@ class ProductMenu extends React.PureComponent {
         }`}
       >
         {props.productName}
+        {props.beta ? (
+          <span className="ml12">
+            <BetaFlag />
+          </span>
+        ) : (
+          ''
+        )}
       </a>
     );
   }
 }
 
 ProductMenu.propTypes = {
-  productName: PropTypes.string.isRequired,
+  productName: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
+    .isRequired,
+  beta: PropTypes.bool,
   lightText: PropTypes.bool,
   homePage: PropTypes.string.isRequired
 };
 
 ProductMenu.defaultProps = {
+  beta: false,
   lightText: false
 };
 


### PR DESCRIPTION
This PR:

- Bumps the version of mr-ui to v0.7.0
- Adds `BetaFlag` component extending the mr-ui `Badge` component
- Adds `beta` prop to `OverviewHeader`
- Adds `beta` prop to `ProductMenu`

In practice, use of these components should look like this:

![image](https://user-images.githubusercontent.com/10479155/56050088-ce5b0c00-5cff-11e9-8a14-9edb45d25de9.png)
