### PR TITLE
[card] wrap LevelIndicator in txt-s txt-bold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.1
+
+- Wrap `LevelIndicator` in `txt-s txt-bold` classes in `Card`.
+
 ## 0.11.0
 
 - Add `Search` component

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -16,7 +16,7 @@ class Card extends React.Component {
     }
     if (props.level) {
       renderedLevel = (
-        <div className="inline-block mr18">
+        <div className="inline-block mr18 txt-s txt-bold">
           <LevelIndicator level={props.level} />
         </div>
       );


### PR DESCRIPTION
I forgot to wrap LevelIndicator in txt-s txt-bold as it appears in the Card component:

![image](https://user-images.githubusercontent.com/2180540/57626075-2a18ef00-7563-11e9-8df8-cf44541c62d9.png)
