### PR TITLE
[search] open the menu onFocus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
+## Master
+
+- Add ability to revisit a search query when the input has focus for the `Search` component. [#127](https://github.com/mapbox/dr-ui/pull/127)
+
 ## 0.11.1
 
-- Wrap `LevelIndicator` in `txt-s txt-bold` classes in `Card`.
+- Wrap `LevelIndicator` in `txt-s txt-bold` classes in `Card`. [#/](https://github.com/mapbox/dr-ui/pull/126)
 
 ## 0.11.0
 
-- Add `Search` component
-- 🚨 [Breaking change] Remove `txt-bold` and `txt-s` from `LevelIndicator` component to make it more flexible.
+- Add `Search` component. [#121](https://github.com/mapbox/dr-ui/pull/121)
+- 🚨 Remove `txt-bold` and `txt-s` from `LevelIndicator` component to make it more flexible. [#121](https://github.com/mapbox/dr-ui/pull/121)
 
 ## 0.10.0
 

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -22,7 +22,12 @@ class SearchBox extends React.Component {
         itemToString={() => props.searchTerm}
       >
         {downshiftProps => {
-          const { getInputProps, isOpen, getLabelProps } = downshiftProps;
+          const {
+            getInputProps,
+            isOpen,
+            getLabelProps,
+            openMenu
+          } = downshiftProps;
 
           return (
             <div>
@@ -49,7 +54,7 @@ class SearchBox extends React.Component {
                 id="docs-search"
                 placeholder={props.placeholder}
                 className="input px30 bg-white"
-                {...getInputProps()}
+                {...getInputProps({ onFocus: openMenu })}
               />
               {isOpen && props.searchTerm && props.wasSearched && (
                 <div className="color-text shadow-darken25 round mt3 absolute bg-white scroll-auto scroll-styled hmax360 absolute z4 w-full align-l">


### PR DESCRIPTION
This PR will open the search results when the input is focused if a search query was exists in a URL parameter.

How to test:
1. run `npm start`
2. visit http://192.168.7.223:9966/Search?q=styles&size=n_10_n
3. Click or tab to the search box, the result box should open with results for the query found in the URL.