### PR TITLE
[helper function] title generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add ability to revisit a search query when the input has focus for the `Search` component. [#127](https://github.com/mapbox/dr-ui/pull/127)
 - Add style JSON for minimal styles used to illustrate the contents of Mapbox-maintained tilesets. [#125](https://github.com/mapbox/dr-ui/pull/125)
+- Add `titleGenerator` helper function to format title meta tags and search result titles. [#128](https://github.com/mapbox/dr-ui/pull/128)
 
 ## 0.11.1
 

--- a/src/components/search/search-result.js
+++ b/src/components/search/search-result.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import LevelIndicator from '../level-indicator/level-indicator';
 import ReactHtmlParser from 'react-html-parser';
 import Icon from '@mapbox/mr-ui/icon';
+import { titleGenerator } from '../../helpers/title-generator';
 
 class SearchResult extends React.Component {
   returnRaw = item => {
@@ -26,6 +27,7 @@ class SearchResult extends React.Component {
     const excerpt = props.result.excerpt
       ? props.result.excerpt.snippet || props.result.excerpt.raw
       : '';
+    const resultTitle = titleGenerator(title, subsite, site).reverse();
     return (
       <div
         className="py12 px18"
@@ -40,23 +42,16 @@ class SearchResult extends React.Component {
           <div className="block link--gray">
             <div className="mb3">
               <span className="txt-bold">
-                {site && site !== title ? (
-                  <span>
-                    {site}
-                    <Icon name="chevron-right" inline={true} />
-                  </span>
-                ) : (
-                  ''
-                )}
-                {subsite && subsite !== title && subsite !== site ? (
-                  <span>
-                    {subsite.replace(/\sfor\s(iOS|Android|Vision|Unity)/, '')}
-                    <Icon name="chevron-right" inline={true} />
-                  </span>
-                ) : (
-                  ''
-                )}
-                {title}
+                {resultTitle.map((t, index) => {
+                  return (
+                    <span key={`${props.result.id.raw}-${t}`}>
+                      {t}
+                      {resultTitle.length !== index + 1 && (
+                        <Icon name="chevron-right" inline={true} />
+                      )}
+                    </span>
+                  );
+                })}
               </span>
             </div>
 

--- a/src/helpers/title-generator.js
+++ b/src/helpers/title-generator.js
@@ -1,0 +1,13 @@
+export function titleGenerator(title, subsite, site) {
+  // create array for formatted title: {title} | {subsite} | {site}
+  const titleArr = [];
+  // do not push a title that is "Introduction"
+  if (title && title !== 'Introduction' && (subsite || site))
+    titleArr.push(title);
+  // push subsite, if same value doesn't exist yet, strip "for (Product)" from name
+  if (subsite && titleArr.indexOf(subsite) === -1)
+    titleArr.push(subsite.replace(/\sfor\s(iOS|Android|Vision|Unity)/, ''));
+  // push site, if same value doesn't exist yet
+  if (site && titleArr.indexOf(site) === -1) titleArr.push(site);
+  return titleArr;
+}

--- a/tests/title-generator.test.js
+++ b/tests/title-generator.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const tagger = require('../src/helpers/title-generator.js');
+
+describe('titleGenerator', () => {
+  it('no duplicated values', () => {
+    expect(tagger.titleGenerator('iOS', 'iOS', 'iOS')).toEqual(['iOS']);
+  });
+
+  it('no duplicated values', () => {
+    expect(tagger.titleGenerator('Rerouting', 'iOS', 'iOS')).toEqual([
+      'Rerouting',
+      'iOS'
+    ]);
+  });
+
+  it('do not display subsite if it does not exist', () => {
+    expect(tagger.titleGenerator('Rerouting', 'iOS')).toEqual([
+      'Rerouting',
+      'iOS'
+    ]);
+  });
+
+  it('remove redundancy from subsite', () => {
+    expect(
+      tagger.titleGenerator('Rerouting', 'Maps SDK for iOS', 'iOS')
+    ).toEqual(['Rerouting', 'Maps SDK', 'iOS']);
+  });
+
+  it('no "Introduction" as title', () => {
+    expect(
+      tagger.titleGenerator('Introduction', 'Maps SDK for iOS', 'iOS')
+    ).toEqual(['Maps SDK', 'iOS']);
+  });
+
+  it('no "Introduction" as title', () => {
+    expect(tagger.titleGenerator('Introduction', 'iOS')).toEqual(['iOS']);
+  });
+});


### PR DESCRIPTION
This PR adds a new function `titleGenerator` that takes a page's title, subsite (if available), and site and outputs an array for the meta `<title/>` tag (in docs-page-shell) and the title for each search result.

We make a few transformations to:
* Remove duplicates in the title tag.
* Remove "Introduction" from title and skip right to subsite or site name.
* Remove redundancy in subsite names by removing the "...for (product)". 


For pages titled "Introduction" we skip right to the subsite or site name. This simplifies the result:

Current | Proposed
--------|----------
![image](https://user-images.githubusercontent.com/2180540/57698640-15506000-7624-11e9-86a5-ee62c3c4f177.png) | ![image](https://user-images.githubusercontent.com/2180540/57698624-0d90bb80-7624-11e9-90be-9dca5eaf9c9e.png)


This PR also asserts the new function through tests.
