### PR TITLE
[search] debounce search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.2
+
+- Debounce `Search` results. [#129](https://github.com/mapbox/dr-ui/pull/129)
+
 ## 0.12.1
 
 - Move `titleGenerator` to `Search` component directory.

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -17,7 +17,7 @@ class SearchBox extends React.Component {
         }}
         onInputValueChange={newValue => {
           if (props.searchTerm === newValue) return;
-          props.setSearchTerm(newValue);
+          props.setSearchTerm(newValue, { debounce: 300 });
         }}
         itemToString={() => props.searchTerm}
       >


### PR DESCRIPTION
This PR sets `debounce` to 300 to help prevent
e
ev
eve
ever
every 
every l
every le
every let
every lett
every lette
every letter 
every letter f
every letter fr
every letter fro
every letter from 
every letter from b
every letter from be
every letter from bei
every letter from bein
every letter from being
every letter from being s
every letter from being se
every letter from being sear
every letter from being searc
every letter from being search
every letter from being searche
every letter from being searched

> "debounce" search requests to avoid creating an excessive number of requests. This controls the length to debounce / wait.

As a result it will take an extra second for results to display, but I think the pay off of preventing unnecessary requests is worth it.