### PR TITLE
[search] add "collapse" option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10213,6 +10213,18 @@
       "resolved": "https://registry.npmjs.org/react-submittable/-/react-submittable-2.0.0.tgz",
       "integrity": "sha512-xenO5Z0Ibrvv0CxQwFOj+nyxim/Nznwbv5cG+tp6e9+ZvS5Ku518HM+BxfTtySc0RbKnmSSJjuydoY/8odDbIA=="
     },
+    "react-test-renderer": {
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.6.tgz",
+      "integrity": "sha512-H2srzU5IWYT6cZXof6AhUcx/wEyJddQ8l7cLM/F7gDXYyPr4oq+vCIxJYXVGhId1J706sqziAjuOEjyNkfgoEw==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.8.6",
+        "scheduler": "^0.13.6"
+      }
+    },
     "react-transition-group": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "cp-assembly": "del ./src/test-cases-app/dist && cpy node_modules/@mapbox/mbx-assembly/dist/*.* ./src/test-cases-app/dist && cpy src/css/docs-prose.css ./src/test-cases-app/dist && cpy src/css/prism.css ./src/test-cases-app/dist",
     "budo": "budo test/app.js -l -d -P -- -t babelify",
     "prestart": "npm run build-component-index && npm run cp-assembly",
-    "test": "jest tests/*.test.js",
+    "test": "jest",
     "build-component-index": "rtk-index ./src/components ./src/test-cases-app/component-index.js",
     "lint": "eslint .",
     "pretest": "npm run lint",
@@ -59,6 +59,7 @@
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
+    "react-test-renderer": "^16.8.6",
     "unist-util-visit": "^1.4.0"
   },
   "dependencies": {
@@ -72,5 +73,8 @@
     "react-html-parser": "^2.0.2",
     "react-stickynode": "^2.1.1",
     "rehype-sectionize-headings": "^1.0.0-rc.1"
+  },
+  "jest": {
+    "testRegex": ".*\\.test\\.js$"
   }
 }

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -2,7 +2,8 @@
   "root": true,
   "parser": "babel-eslint",
   "env": {
-    "browser": true
+    "browser": true,
+    "jest": true
   },
   "extends": [
     "@mapbox/eslint-config-mapbox/react",

--- a/src/components/search/__tests__/__snapshots__/search.test.js.snap
+++ b/src/components/search/__tests__/__snapshots__/search.test.js.snap
@@ -6,12 +6,6 @@ exports[`Search component, collapse 1`] = `
 >
   <div
     className="w36-mm"
-    style={
-      Object {
-        "right": 0,
-        "top": 0,
-      }
-    }
   >
     <div
       aria-expanded={false}

--- a/src/components/search/__tests__/__snapshots__/search.test.js.snap
+++ b/src/components/search/__tests__/__snapshots__/search.test.js.snap
@@ -1,0 +1,165 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Search component, collapse 1`] = `
+<div
+  className="h36 relative"
+>
+  <div
+    className="w36-mm"
+    style={
+      Object {
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <div
+      aria-expanded={false}
+      aria-haspopup="listbox"
+      aria-labelledby="docs-search-label"
+      aria-owns={null}
+      role="combobox"
+    >
+      <label
+        className="cursor-pointer"
+        htmlFor="docs-search-input"
+        id="docs-search-label"
+      >
+        <div
+          className="absolute flex-parent flex-parent--center-cross flex-parent--center-main w36 h36"
+        >
+          <svg
+            className="icon color-gray"
+          >
+            <title>
+              Search
+            </title>
+            <use
+              xlinkHref="#icon-search"
+            />
+          </svg>
+        </div>
+      </label>
+      <input
+        aria-activedescendant={null}
+        aria-autocomplete="list"
+        aria-controls={null}
+        aria-labelledby="docs-search-label"
+        autoComplete="off"
+        className="input bg-white px30 px0-mm color-transparent-mm"
+        id="docs-search-input"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        placeholder=""
+        value=""
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Search component, no options 1`] = `
+<div
+  className="h36 relative"
+>
+  <div>
+    <div
+      aria-expanded={false}
+      aria-haspopup="listbox"
+      aria-labelledby="docs-search-label"
+      aria-owns={null}
+      role="combobox"
+    >
+      <label
+        className="cursor-pointer"
+        htmlFor="docs-search-input"
+        id="docs-search-label"
+      >
+        <div
+          className="absolute flex-parent flex-parent--center-cross flex-parent--center-main w36 h36"
+        >
+          <svg
+            className="icon color-gray"
+          >
+            <title>
+              Search
+            </title>
+            <use
+              xlinkHref="#icon-search"
+            />
+          </svg>
+        </div>
+      </label>
+      <input
+        aria-activedescendant={null}
+        aria-autocomplete="list"
+        aria-controls={null}
+        aria-labelledby="docs-search-label"
+        autoComplete="off"
+        className="input bg-white px30"
+        id="docs-search-input"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        placeholder="Search docs.mapbox.com"
+        value=""
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Search component, placeholder 1`] = `
+<div
+  className="h36 relative"
+>
+  <div>
+    <div
+      aria-expanded={false}
+      aria-haspopup="listbox"
+      aria-labelledby="docs-search-label"
+      aria-owns={null}
+      role="combobox"
+    >
+      <label
+        className="cursor-pointer"
+        htmlFor="docs-search-input"
+        id="docs-search-label"
+      >
+        <div
+          className="absolute flex-parent flex-parent--center-cross flex-parent--center-main w36 h36"
+        >
+          <svg
+            className="icon color-gray"
+          >
+            <title>
+              Search
+            </title>
+            <use
+              xlinkHref="#icon-search"
+            />
+          </svg>
+        </div>
+      </label>
+      <input
+        aria-activedescendant={null}
+        aria-autocomplete="list"
+        aria-controls={null}
+        aria-labelledby="docs-search-label"
+        autoComplete="off"
+        className="input bg-white px30"
+        id="docs-search-input"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        placeholder="Search me, ok?"
+        value=""
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/search/__tests__/search-test-cases.js
+++ b/src/components/search/__tests__/search-test-cases.js
@@ -25,7 +25,7 @@ testCases.darkNote = {
 };
 
 testCases.commonUseCase = {
-  description: 'Search placement',
+  description: 'Search placement with `collapse` option set',
   element: (
     <div>
       <TopbarSticker>

--- a/src/components/search/__tests__/search-test-cases.js
+++ b/src/components/search/__tests__/search-test-cases.js
@@ -45,7 +45,7 @@ testCases.commonUseCase = {
             </div>
 
             <div className="col col--1-mm col--12 flex-parent flex-parent--end-main-mm flex-parent--center-cross">
-              <div className="wmax360 w-full mb12 mb0-mm">
+              <div className="wmax360 mb12 mb0-mm">
                 <Search collapse={true} />
               </div>
             </div>

--- a/src/components/search/__tests__/search-test-cases.js
+++ b/src/components/search/__tests__/search-test-cases.js
@@ -39,13 +39,13 @@ testCases.commonUseCase = {
                 <ProductMenu productName="API Documentation" homePage="/api/" />
               </div>
             </div>
-            <div className="col col--7-mm col--12 flex-parent flex-parent--end-main-mm flex-parent--center-cross align-r">
-              <div className="ml12 inline-block">Navigation Link 1</div>
+            <div className="col col--7-mm col--12 flex-parent flex-parent--end-main-mm flex-parent--center-cross align-r mb12 mb0-mm">
+              <div className="inline-block">Navigation Link 1</div>
               <div className="ml12 inline-block">Navigation Link 2</div>
             </div>
 
             <div className="col col--1-mm col--12 flex-parent flex-parent--end-main-mm flex-parent--center-cross">
-              <div className="wmax360 mb12 mb0-mm">
+              <div className="wmax360 w-full mb12 mb0-mm">
                 <Search collapse={true} />
               </div>
             </div>

--- a/src/components/search/__tests__/search-test-cases.js
+++ b/src/components/search/__tests__/search-test-cases.js
@@ -39,9 +39,14 @@ testCases.commonUseCase = {
                 <ProductMenu productName="API Documentation" homePage="/api/" />
               </div>
             </div>
-            <div className="col col--8-mm col--12 flex-parent flex-parent--end-main-mm flex-parent--center-cross">
+            <div className="col col--7-mm col--12 flex-parent flex-parent--end-main-mm flex-parent--center-cross align-r">
+              <div className="ml12 inline-block">Navigation Link 1</div>
+              <div className="ml12 inline-block">Navigation Link 2</div>
+            </div>
+
+            <div className="col col--1-mm col--12 flex-parent flex-parent--end-main-mm flex-parent--center-cross">
               <div className="wmax360 mb12 mb0-mm">
-                <Search />
+                <Search collapse={true} />
               </div>
             </div>
           </div>

--- a/src/components/search/__tests__/search-test-cases.js
+++ b/src/components/search/__tests__/search-test-cases.js
@@ -18,7 +18,7 @@ testCases.darkNote = {
   element: (
     <div className="py24 px24 bg-blue">
       <div className="wmax360">
-        <Search placeholder="SEARCH!" />
+        <Search inputId="search2" placeholder="SEARCH!" />
       </div>
     </div>
   )
@@ -46,7 +46,7 @@ testCases.commonUseCase = {
 
             <div className="col col--1-mm col--12 flex-parent flex-parent--end-main-mm flex-parent--center-cross">
               <div className="wmax360 mb12 mb0-mm">
-                <Search collapse={true} />
+                <Search inputId="search3" collapse={true} />
               </div>
             </div>
           </div>
@@ -94,30 +94,6 @@ testCases.commonUseCase = {
               natoque penatibus et magnis dis parturient montes, nascetur
               ridiculus mus. Lorem ipsum dolor sit amet, consectetur adipiscing
               elit. Vestibulum id ligula porta felis euismod semper.
-            </p>
-            <p>
-              Aenean lacinia bibendum nulla sed consectetur. Maecenas sed diam
-              eget risus varius blandit sit amet non magna. Vestibulum id ligula
-              porta felis euismod semper. Lorem ipsum dolor sit amet,
-              consectetur adipiscing elit. Cras justo odio, dapibus ac facilisis
-              in, egestas eget quam. Donec id elit non mi porta gravida at eget
-              metus. Duis mollis, est non commodo luctus, nisi erat porttitor
-              ligula, eget lacinia odio sem nec elit.
-            </p>
-            <p>
-              Donec sed odio dui. Cras justo odio, dapibus ac facilisis in,
-              egestas eget quam. Curabitur blandit tempus porttitor. Duis
-              mollis, est non commodo luctus, nisi erat porttitor ligula, eget
-              lacinia odio sem nec elit. Nullam quis risus eget urna mollis
-              ornare vel eu leo. Praesent commodo cursus magna, vel scelerisque
-              nisl consectetur et. Duis mollis, est non commodo luctus, nisi
-              erat porttitor ligula, eget lacinia odio sem nec elit.
-            </p>
-            <p>
-              Morbi leo risus, porta ac consectetur ac, vestibulum at eros.
-              Donec sed odio dui. Aenean eu leo quam. Pellentesque ornare sem
-              lacinia quam venenatis vestibulum. Integer posuere erat a ante
-              venenatis dapibus posuere velit aliquet.
             </p>
           </div>
         </PageLayout>

--- a/src/components/search/__tests__/search.test.js
+++ b/src/components/search/__tests__/search.test.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import Search from '../search';
+import renderer from 'react-test-renderer';
+import visit from 'unist-util-visit';
+
+test('Search component, no options', () => {
+  const component = renderer.create(<Search />);
+  let tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+  visit(tree, 'input', node => {
+    expect(node.props.placeholder).toBe('Search docs.mapbox.com');
+  });
+});
+
+test('Search component, placeholder', () => {
+  const component = renderer.create(<Search placeholder="Search me, ok?" />);
+  let tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+
+  visit(tree, 'input', node => {
+    expect(node.props.placeholder).toBe('Search me, ok?');
+  });
+});
+
+test('Search component, collapse', () => {
+  const component = renderer.create(<Search collapse={true} />);
+  let tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+  visit(tree, 'input', node => {
+    expect(node.props.placeholder).toBe('');
+  });
+});

--- a/src/components/search/__tests__/search.test.js
+++ b/src/components/search/__tests__/search.test.js
@@ -28,5 +28,9 @@ test('Search component, collapse', () => {
   expect(tree).toMatchSnapshot();
   visit(tree, 'input', node => {
     expect(node.props.placeholder).toBe('');
+    expect(node.props.className).toBe(
+      'input bg-white px30 px0-mm color-transparent-mm'
+    );
   });
+  expect(tree.children[0].props.className).toBe('w36-mm'); // collapse option adds width to container
 });

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -22,9 +22,7 @@ class SearchBox extends React.Component {
     const { props } = this;
 
     const inputClasses = classnames('input bg-white px30', {
-      // 'px30': (props.collapse && this.state.isUncollapse) || (!props.collapse),
-      'px0-mm': props.collapse && !this.state.isUncollapse,
-      'color-white-mm': props.collapse && !this.state.isUncollapse
+      'px0-mm color-transparent-mm': props.collapse && !this.state.isUncollapse // turn off padding and hide input color on larger screens (allows us to disable collapse on mobile)
     });
 
     const searchContainerClasses = classnames('', {

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -27,7 +27,7 @@ class SearchBox extends React.Component {
 
     const searchContainerClasses = classnames('', {
       'w36-mm': props.collapse,
-      'absolute-mm wmax360 wmin300-mm':
+      'absolute-mm wmax360 wmin300-mm top right':
         props.collapse && this.state.isUncollapse
     });
 
@@ -36,10 +36,7 @@ class SearchBox extends React.Component {
     });
 
     return (
-      <div
-        className={searchContainerClasses || undefined}
-        style={props.collapse ? { top: 0, right: 0 } : undefined}
-      >
+      <div className={searchContainerClasses || undefined}>
         {props.isLoading && (
           <div className="absolute top right flex-parent flex-parent--center-cross flex-parent--center-main w36 h36">
             <span className={loaderClasses} />

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -46,7 +46,7 @@ class SearchBox extends React.Component {
           </div>
         )}
         <Downshift
-          id="docs-search"
+          id={props.inputId}
           inputValue={props.searchTerm}
           onChange={selection => {
             props.trackClickThrough(selection.id.raw); // track selection click through
@@ -81,7 +81,6 @@ class SearchBox extends React.Component {
                   ref={input => {
                     this.docsSeachInput = input;
                   }}
-                  id="docs-search"
                   placeholder={props.placeholder}
                   className={inputClasses}
                   {...getInputProps({

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -108,9 +108,11 @@ class SearchBox extends React.Component {
                   {...getInputProps({
                     onFocus: () => {
                       openMenu();
-                      this.handleCollapse();
+                      if (props.collapse) this.handleCollapse();
                     },
-                    onBlur: this.handleCollapse
+                    onBlur: () => {
+                      if (props.collapse) this.handleCollapse();
+                    }
                   })}
                 />
                 {isOpen && props.searchTerm && props.wasSearched && (

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -37,20 +37,9 @@ class SearchBox extends React.Component {
 
     return (
       <div
-        className={searchContainerClasses}
-        onClick={() => {
-          this.docsSeachInput.focus();
-        }}
-        style={{ top: 0, right: 0 }}
+        className={searchContainerClasses || undefined}
+        style={props.collapse ? { top: 0, right: 0 } : undefined}
       >
-        <div className="cursor-pointer absolute flex-parent flex-parent--center-cross flex-parent--center-main w36 h36">
-          <label htmlFor="docs-search">
-            <svg className="icon color-gray cursor-pointer ">
-              <use xlinkHref="#icon-search" />
-            </svg>
-          </label>
-        </div>
-
         {props.isLoading && (
           <div className="absolute top right flex-parent flex-parent--center-cross flex-parent--center-main w36 h36">
             <span className={loaderClasses} />
@@ -79,25 +68,15 @@ class SearchBox extends React.Component {
 
             return (
               <div>
-                <label
-                  style={{
-                    // allow screenreaders to read the label
-                    // but hides it for everyone else
-                    position: 'absolute',
-                    width: '0.1px',
-                    height: '0.1px',
-                    margin: '-0.1px',
-                    padding: '0',
-                    overflow: 'hidden',
-                    whiteSpace: 'nowrap',
-                    border: '0',
-                    clip: 'rect(0 0 0 0)',
-                    clipPath: 'inset(100%)'
-                  }}
-                  {...getLabelProps()}
-                >
-                  Search
+                <label {...getLabelProps()}>
+                  <div className="cursor-pointer absolute flex-parent flex-parent--center-cross flex-parent--center-main w36 h36">
+                    <svg className="icon color-gray cursor-pointer ">
+                      <title>Search</title>
+                      <use xlinkHref="#icon-search" />
+                    </svg>
+                  </div>
                 </label>
+
                 <input
                   ref={input => {
                     this.docsSeachInput = input;

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -2,92 +2,149 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Downshift from 'downshift';
 import SearchResult from './search-result';
+import classnames from 'classnames';
 
 class SearchBox extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      isUncollapse: false
+    };
+    this.handleCollapse = this.handleCollapse.bind(this);
+  }
+  handleCollapse() {
+    this.setState(prevState => ({
+      isUncollapse: !prevState.isUncollapse
+    }));
+  }
+
   render() {
     const { props } = this;
 
-    return (
-      <Downshift
-        id="docs-search"
-        inputValue={props.searchTerm}
-        onChange={selection => {
-          props.trackClickThrough(selection.id.raw); // track selection click through
-          window.open(selection.url.raw, '_self'); // open selection in current window
-        }}
-        onInputValueChange={newValue => {
-          if (props.searchTerm === newValue) return;
-          props.setSearchTerm(newValue);
-        }}
-        itemToString={() => props.searchTerm}
-      >
-        {downshiftProps => {
-          const {
-            getInputProps,
-            isOpen,
-            getLabelProps,
-            openMenu
-          } = downshiftProps;
+    const inputClasses = classnames('input bg-white px30', {
+      // 'px30': (props.collapse && this.state.isUncollapse) || (!props.collapse),
+      'px0-mm': props.collapse && !this.state.isUncollapse,
+      'color-white-mm': props.collapse && !this.state.isUncollapse
+    });
 
-          return (
-            <div>
-              <label
-                style={{
-                  // allow screenreaders to read the label
-                  // but hides it for everyone else
-                  position: 'absolute',
-                  width: '0.1px',
-                  height: '0.1px',
-                  margin: '-0.1px',
-                  padding: '0',
-                  overflow: 'hidden',
-                  whiteSpace: 'nowrap',
-                  border: '0',
-                  clip: 'rect(0 0 0 0)',
-                  clipPath: 'inset(100%)'
-                }}
-                {...getLabelProps()}
-              >
-                Search
-              </label>
-              <input
-                id="docs-search"
-                placeholder={props.placeholder}
-                className="input px30 bg-white"
-                {...getInputProps({ onFocus: openMenu })}
-              />
-              {isOpen && props.searchTerm && props.wasSearched && (
-                <div className="color-text shadow-darken25 round mt3 absolute bg-white scroll-auto scroll-styled hmax360 absolute z4 w-full align-l">
-                  <div style={{ fontSize: '13px', lineHeight: '19px' }}>
-                    {props.results.length ? (
-                      <ul>
-                        {props.results.map((result, index) => (
-                          <SearchResult
-                            key={index}
-                            result={result}
-                            index={index}
-                            downshiftProps={downshiftProps}
-                          />
-                        ))}
-                      </ul>
-                    ) : (
-                      <div className="py12 px12 prose">
-                        <p>
-                          Hmmm, we didn't find anything. Reword your search, or{' '}
-                          <a href="https://support.mapbox.com/hc/en-us">
-                            contact Support
-                          </a>
-                          .
-                        </p>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              )}
-            </div>
-          );
+    const searchContainerClasses = classnames('', {
+      'w36-mm cursor-pointer': props.collapse,
+      'absolute-mm wmax360 wmin300-mm':
+        props.collapse && this.state.isUncollapse
+    });
+
+    return (
+      <div
+        className={searchContainerClasses}
+        onClick={() => {
+          this.docsSeachInput.focus();
         }}
-      </Downshift>
+        style={{ top: 0, right: 0 }}
+      >
+        <div className="cursor-pointer absolute flex-parent flex-parent--center-cross flex-parent--center-main w36 h36">
+          <label htmlFor="docs-search">
+            <svg className="icon color-gray cursor-pointer ">
+              <use xlinkHref="#icon-search" />
+            </svg>
+          </label>
+        </div>
+
+        {props.isLoading && (
+          <div className="absolute top right flex-parent flex-parent--center-cross flex-parent--center-main w36 h36">
+            <span className="loading loading--s" />
+          </div>
+        )}
+        <Downshift
+          id="docs-search"
+          inputValue={props.searchTerm}
+          onChange={selection => {
+            props.trackClickThrough(selection.id.raw); // track selection click through
+            window.open(selection.url.raw, '_self'); // open selection in current window
+          }}
+          onInputValueChange={newValue => {
+            if (props.searchTerm === newValue) return;
+            props.setSearchTerm(newValue);
+          }}
+          itemToString={() => props.searchTerm}
+        >
+          {downshiftProps => {
+            const {
+              getInputProps,
+              isOpen,
+              getLabelProps,
+              openMenu
+            } = downshiftProps;
+
+            return (
+              <div>
+                <label
+                  style={{
+                    // allow screenreaders to read the label
+                    // but hides it for everyone else
+                    position: 'absolute',
+                    width: '0.1px',
+                    height: '0.1px',
+                    margin: '-0.1px',
+                    padding: '0',
+                    overflow: 'hidden',
+                    whiteSpace: 'nowrap',
+                    border: '0',
+                    clip: 'rect(0 0 0 0)',
+                    clipPath: 'inset(100%)'
+                  }}
+                  {...getLabelProps()}
+                >
+                  Search
+                </label>
+                <input
+                  ref={input => {
+                    this.docsSeachInput = input;
+                  }}
+                  id="docs-search"
+                  placeholder={props.placeholder}
+                  className={inputClasses}
+                  {...getInputProps({
+                    onFocus: () => {
+                      openMenu();
+                      this.handleCollapse();
+                    },
+                    onBlur: this.handleCollapse
+                  })}
+                />
+                {isOpen && props.searchTerm && props.wasSearched && (
+                  <div className="color-text shadow-darken25 round mt3 bg-white scroll-auto scroll-styled hmax360 absolute z4 w-full align-l">
+                    <div style={{ fontSize: '13px', lineHeight: '19px' }}>
+                      {props.results.length ? (
+                        <ul>
+                          {props.results.map((result, index) => (
+                            <SearchResult
+                              key={index}
+                              result={result}
+                              index={index}
+                              downshiftProps={downshiftProps}
+                            />
+                          ))}
+                        </ul>
+                      ) : (
+                        <div className="py12 px12 prose">
+                          <p>
+                            Hmmm, we didn't find anything. Reword your search,
+                            or{' '}
+                            <a href="https://support.mapbox.com/hc/en-us">
+                              contact Support
+                            </a>
+                            .
+                          </p>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          }}
+        </Downshift>
+      </div>
     );
   }
 }

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -31,6 +31,10 @@ class SearchBox extends React.Component {
         props.collapse && this.state.isUncollapse
     });
 
+    const loaderClasses = classnames('loading loading--s', {
+      'none-mm': props.collapse && !this.state.isUncollapse
+    });
+
     return (
       <div
         className={searchContainerClasses}
@@ -49,7 +53,7 @@ class SearchBox extends React.Component {
 
         {props.isLoading && (
           <div className="absolute top right flex-parent flex-parent--center-cross flex-parent--center-main w36 h36">
-            <span className="loading loading--s" />
+            <span className={loaderClasses} />
           </div>
         )}
         <Downshift

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -26,7 +26,7 @@ class SearchBox extends React.Component {
     });
 
     const searchContainerClasses = classnames('', {
-      'w36-mm cursor-pointer': props.collapse,
+      'w36-mm': props.collapse,
       'absolute-mm wmax360 wmin300-mm':
         props.collapse && this.state.isUncollapse
     });
@@ -68,9 +68,9 @@ class SearchBox extends React.Component {
 
             return (
               <div>
-                <label {...getLabelProps()}>
-                  <div className="cursor-pointer absolute flex-parent flex-parent--center-cross flex-parent--center-main w36 h36">
-                    <svg className="icon color-gray cursor-pointer ">
+                <label className="cursor-pointer" {...getLabelProps()}>
+                  <div className="absolute flex-parent flex-parent--center-cross flex-parent--center-main w36 h36">
+                    <svg className="icon color-gray">
                       <title>Search</title>
                       <use xlinkHref="#icon-search" />
                     </svg>

--- a/src/components/search/search.js
+++ b/src/components/search/search.js
@@ -13,44 +13,42 @@ const connector = new SiteSearchAPIConnector({
 class Search extends React.Component {
   render() {
     return (
-      <div>
-        <SearchProvider
-          config={{
-            apiConnector: connector,
-            initialState: {
-              resultsPerPage: 10
-            }
-          }}
-        >
-          {({
-            isLoading,
-            searchTerm,
-            setSearchTerm,
-            results,
-            trackClickThrough,
-            wasSearched
-          }) => {
-            return (
-              <div className="h36 relative" style={{ minWidth: '36px' }}>
-                <SearchBox
-                  searchTerm={searchTerm}
-                  trackClickThrough={trackClickThrough}
-                  setSearchTerm={setSearchTerm}
-                  results={results}
-                  wasSearched={wasSearched}
-                  placeholder={
-                    this.props.collapse
-                      ? ''
-                      : this.props.placeholder || 'Search docs.mapbox.com'
-                  }
-                  collapse={this.props.collapse || false}
-                  isLoading={isLoading}
-                />
-              </div>
-            );
-          }}
-        </SearchProvider>
-      </div>
+      <SearchProvider
+        config={{
+          apiConnector: connector,
+          initialState: {
+            resultsPerPage: 10
+          }
+        }}
+      >
+        {({
+          isLoading,
+          searchTerm,
+          setSearchTerm,
+          results,
+          trackClickThrough,
+          wasSearched
+        }) => {
+          return (
+            <div className="h36 relative" style={{ minWidth: '36px' }}>
+              <SearchBox
+                searchTerm={searchTerm}
+                trackClickThrough={trackClickThrough}
+                setSearchTerm={setSearchTerm}
+                results={results}
+                wasSearched={wasSearched}
+                placeholder={
+                  this.props.collapse
+                    ? ''
+                    : this.props.placeholder || 'Search docs.mapbox.com'
+                }
+                collapse={this.props.collapse || false}
+                isLoading={isLoading}
+              />
+            </div>
+          );
+        }}
+      </SearchProvider>
     );
   }
 }

--- a/src/components/search/search.js
+++ b/src/components/search/search.js
@@ -48,6 +48,7 @@ class Search extends React.Component {
                 }
                 collapse={props.collapse || false}
                 isLoading={isLoading}
+                inputId={props.inputId || 'docs-search'}
               />
             </div>
           );
@@ -59,7 +60,8 @@ class Search extends React.Component {
 
 Search.propTypes = {
   placeholder: PropTypes.string, // option to replace the input placehoder with a different string,
-  collapse: PropTypes.bool // option collapse input
+  collapse: PropTypes.bool, // option to collapse input to fit in a crowded space
+  inputId: PropTypes.string // option to override default id for input/label, used for testing
 };
 
 export default Search;

--- a/src/components/search/search.js
+++ b/src/components/search/search.js
@@ -12,6 +12,7 @@ const connector = new SiteSearchAPIConnector({
 
 class Search extends React.Component {
   render() {
+    const { props } = this;
     return (
       <SearchProvider
         config={{
@@ -30,7 +31,10 @@ class Search extends React.Component {
           wasSearched
         }) => {
           return (
-            <div className="h36 relative" style={{ minWidth: '36px' }}>
+            <div
+              className="h36 relative"
+              style={props.collapsed ? { minWidth: '36px' } : undefined}
+            >
               <SearchBox
                 searchTerm={searchTerm}
                 trackClickThrough={trackClickThrough}
@@ -38,11 +42,11 @@ class Search extends React.Component {
                 results={results}
                 wasSearched={wasSearched}
                 placeholder={
-                  this.props.collapse
+                  props.collapse
                     ? ''
-                    : this.props.placeholder || 'Search docs.mapbox.com'
+                    : props.placeholder || 'Search docs.mapbox.com'
                 }
-                collapse={this.props.collapse || false}
+                collapse={props.collapse || false}
                 isLoading={isLoading}
               />
             </div>

--- a/src/components/search/search.js
+++ b/src/components/search/search.js
@@ -31,21 +31,7 @@ class Search extends React.Component {
             wasSearched
           }) => {
             return (
-              <div className="relative h36">
-                <div className="absolute flex-parent flex-parent--center-cross flex-parent--center-main w36 h36">
-                  <label htmlFor="docs-search">
-                    <svg className="icon color-gray">
-                      <use xlinkHref="#icon-search" />
-                    </svg>
-                  </label>
-                </div>
-                {isLoading ? (
-                  <div className="absolute top right flex-parent flex-parent--center-cross flex-parent--center-main w36 h36">
-                    <span className="loading loading--s" />
-                  </div>
-                ) : (
-                  ''
-                )}
+              <div className="h36 relative" style={{ minWidth: '36px' }}>
                 <SearchBox
                   searchTerm={searchTerm}
                   trackClickThrough={trackClickThrough}
@@ -53,8 +39,12 @@ class Search extends React.Component {
                   results={results}
                   wasSearched={wasSearched}
                   placeholder={
-                    this.props.placeholder || 'Search docs.mapbox.com'
+                    this.props.collapse
+                      ? ''
+                      : this.props.placeholder || 'Search docs.mapbox.com'
                   }
+                  collapse={this.props.collapse || false}
+                  isLoading={isLoading}
                 />
               </div>
             );
@@ -66,7 +56,8 @@ class Search extends React.Component {
 }
 
 Search.propTypes = {
-  placeholder: PropTypes.string // option to replace the input placehoder with a different string
+  placeholder: PropTypes.string, // option to replace the input placehoder with a different string,
+  collapse: PropTypes.bool // option collapse input
 };
 
 export default Search;

--- a/src/css/docs-prose.css
+++ b/src/css/docs-prose.css
@@ -60,4 +60,7 @@
     overflow: auto !important;
     -webkit-overflow-scrolling: touch;
   }
+  .color-transparent-mm {
+    color: transparent !important;
+  }
 }


### PR DESCRIPTION
If `collapse={true}` then the search component will collapse into a button:

> ![image](https://user-images.githubusercontent.com/2180540/57801231-4793b780-7721-11e9-9894-002e4f7c9e16.png)

When the button is clicked/focused, the input will expand. The input will overlap anything to its left so that it will fit in the space without breaking the layout:

> ![image](https://user-images.githubusercontent.com/2180540/57801311-714cde80-7721-11e9-9db0-513d06ea1dc0.png)

Once the user clicks way from the opened input, it will collapse again.

On smaller screens/mobile, the collapse option disables to reveal the full input:

> ![image](https://user-images.githubusercontent.com/2180540/57801369-8aee2600-7721-11e9-9ccb-0a9009bb1639.png)


# QA

## Responsive

- [x] Check on mobile-size viewport.
- [x] Check on tablet-size viewport.
- [x] Check on laptop-size viewport.
- [x] Check on big-monitor-size viewport.

## Cross-browser

- [x] Check in Chrome.
- [x] Check in Firefox.
- [x] Check in Safari.
- [x] Check in Edge.
- [ ] Check in IE11.
- [x] Check in mobile Safari.
- [x] Check in Android's Chrome.


# Review

⏲ No rush

