### PR TITLE
Add EnterpriseFlag, add option to ProductMenu and OveriewHeader

### DIFF
--- a/src/components/enterprise-flag/__tests__/enterprise-flag-test-cases.js
+++ b/src/components/enterprise-flag/__tests__/enterprise-flag-test-cases.js
@@ -1,0 +1,20 @@
+import EnterpriseFlag from '../enterprise-flag';
+
+const testCases = {};
+const noRenderCases = {};
+
+testCases.basic = {
+  component: EnterpriseFlag,
+  description: 'Basic',
+  props: {}
+};
+
+noRenderCases.custom = {
+  component: EnterpriseFlag,
+  description: 'Custom note',
+  props: {
+    tooltipText: 'Hello. This is custom text.'
+  }
+};
+
+export default { testCases, noRenderCases };

--- a/src/components/enterprise-flag/enterprise-flag.js
+++ b/src/components/enterprise-flag/enterprise-flag.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Badge from '@mapbox/mr-ui/badge';
+
+export default class EnterpriseFlag extends React.Component {
+  render() {
+    const { props } = this;
+    return (
+      <Badge
+        badgeText="Enterprise"
+        coloring="blue"
+        tooltipText={props.tooltipText}
+      />
+    );
+  }
+}
+
+EnterpriseFlag.propTypes = {
+  tooltipText: PropTypes.string
+};
+
+EnterpriseFlag.defaultProps = {
+  tooltipText: 'This product is only available for Enterprise accounts.'
+};

--- a/src/components/overview-header/__tests__/overview-header-test-cases.js
+++ b/src/components/overview-header/__tests__/overview-header-test-cases.js
@@ -78,6 +78,24 @@ testCases.beta = {
   }
 };
 
+testCases.enterprise = {
+  description: 'Enterprise and beta product',
+  component: OverviewHeader,
+  props: {
+    features: ['Chips', 'Tots', 'Fries'],
+    title: 'Mapbox Potato SDK',
+    beta: true,
+    enterprise: true,
+    image: (
+      <img
+        width={800}
+        height={499}
+        src="https://farm2.staticflickr.com/1790/29050447978_41e671dcd5_o.jpg"
+      />
+    )
+  }
+};
+
 testCases.allContactUs = {
   description: 'All, plus Contact Us button',
   component: OverviewHeader,

--- a/src/components/overview-header/overview-header.js
+++ b/src/components/overview-header/overview-header.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Icon from '@mapbox/mr-ui/icon';
 import BetaFlag from '../beta-flag/beta-flag';
+import EnterpriseFlag from '../enterprise-flag/enterprise-flag';
 
 class OverviewHeader extends React.PureComponent {
   renderVersion() {
@@ -92,6 +93,16 @@ class OverviewHeader extends React.PureComponent {
       <div className="scroll-hidden border-b border--gray-light prose mb24">
         <h1 className="mb6 txt-fancy">
           {props.title}
+          {props.enterprise ? (
+            <span
+              className="ml12 inline-block relative"
+              style={{ top: '-7px' }}
+            >
+              <EnterpriseFlag />
+            </span>
+          ) : (
+            ''
+          )}
           {props.beta ? (
             <span
               className="ml12 inline-block relative"
@@ -123,6 +134,7 @@ class OverviewHeader extends React.PureComponent {
 OverviewHeader.propTypes = {
   features: PropTypes.arrayOf(PropTypes.string).isRequired,
   title: PropTypes.string.isRequired,
+  enterprise: PropTypes.bool,
   beta: PropTypes.bool,
   image: PropTypes.node.isRequired,
   version: PropTypes.string,
@@ -133,6 +145,7 @@ OverviewHeader.propTypes = {
 };
 
 OverviewHeader.defaultProps = {
+  enterprise: false,
   beta: false
 };
 

--- a/src/components/product-menu/__tests__/product-menu-test-cases.js
+++ b/src/components/product-menu/__tests__/product-menu-test-cases.js
@@ -47,9 +47,20 @@ testCases.beta = {
   component: ProductMenu,
   description: 'Beta product',
   props: {
-    productName: 'Vision SDK for Android',
+    productName: 'Vision SDK for iOS',
     beta: true,
     homePage: '/vision/'
+  }
+};
+
+testCases.enterprise = {
+  component: ProductMenu,
+  description: 'Enterprise product',
+  props: {
+    productName: 'Future Fancy API',
+    beta: true,
+    enterprise: true,
+    homePage: '#'
   }
 };
 

--- a/src/components/product-menu/product-menu.js
+++ b/src/components/product-menu/product-menu.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import BetaFlag from '../beta-flag/beta-flag';
+import EnterpriseFlag from '../enterprise-flag/enterprise-flag';
 
 class ProductMenu extends React.PureComponent {
   render() {
@@ -8,13 +9,20 @@ class ProductMenu extends React.PureComponent {
     return (
       <a
         href={props.homePage}
-        className={`wmax240-ml wmax180-mm txt-fancy txt-l block txt-truncate${
+        className={`wmax240-ml wmax180-mm txt-fancy txt-l block${
           props.lightText
             ? ' color-white color-gray-light-on-hover'
             : ' color-blue-on-hover'
         }`}
       >
         {props.productName}
+        {props.enterprise ? (
+          <span className="inline-block ml6 relative" style={{ top: '-2px' }}>
+            <EnterpriseFlag />
+          </span>
+        ) : (
+          ''
+        )}
         {props.beta ? (
           <span className="inline-block ml6 relative" style={{ top: '-2px' }}>
             <BetaFlag />
@@ -30,12 +38,14 @@ class ProductMenu extends React.PureComponent {
 ProductMenu.propTypes = {
   productName: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
     .isRequired,
+  enterprise: PropTypes.bool,
   beta: PropTypes.bool,
   lightText: PropTypes.bool,
   homePage: PropTypes.string.isRequired
 };
 
 ProductMenu.defaultProps = {
+  enterprise: false,
   beta: false,
   lightText: false
 };


### PR DESCRIPTION
Adds an Enterprise flag for products and features that are only available for users with Enterprise accounts. Then adds the option to add the flag to the ProductMenu and OverviewHeader components similar to the BetaFlag component. 

This works well for the OverviewHeader component, but the length of the word `Enterprise` doesn't work so well with the ProductMenu (especially for a product that might be both in Beta and for Enterprise accounts only). @katydecorah do you have any ideas here? 

<img width="631" alt="Screen Shot 2019-05-16 at 5 38 40 PM" src="https://user-images.githubusercontent.com/10479155/57895911-dcbaad00-7802-11e9-89c1-00cbbdf9e8fa.png">

<img width="505" alt="Screen Shot 2019-05-16 at 5 40 16 PM" src="https://user-images.githubusercontent.com/10479155/57895912-e0e6ca80-7802-11e9-86fa-4f3a2337f676.png">
