### PR TITLE
increase zIndex for sticky sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Master
 
 - Refactors the `Search` component to use a modal on larger screens. [#133](https://github.com/mapbox/dr-ui/pull/133).
+- Increase z-index for sticky sidebar in `PageLayout` and `TopbarSticker`. [#134](https://github.com/mapbox/dr-ui/pull/134)
+
 
 ## 0.13.0
 

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -99,7 +99,7 @@ class PageLayout extends React.Component {
           <Sticky
             enabled={state.stickyEnabled}
             bottomBoundary={state.bottomBoundaryValue}
-            innerZ={1}
+            innerZ={3}
             top={state.topValue}
           >
             <div

--- a/src/components/search/__tests__/__snapshots__/search.test.js.snap
+++ b/src/components/search/__tests__/__snapshots__/search.test.js.snap
@@ -128,7 +128,7 @@ exports[`search Search with \`narrow\` option set renders as expected 2`] = `
         Object {
           "position": "relative",
           "top": "0px",
-          "zIndex": 3,
+          "zIndex": 4,
         }
       }
     >
@@ -244,7 +244,7 @@ exports[`search Search with \`narrow\` option set renders as expected 2`] = `
               Object {
                 "position": "relative",
                 "top": "0px",
-                "zIndex": 1,
+                "zIndex": 3,
               }
             }
           >

--- a/src/components/topbar-sticker/topbar-sticker.js
+++ b/src/components/topbar-sticker/topbar-sticker.js
@@ -37,7 +37,7 @@ class TopbarSticker extends React.PureComponent {
         enabled={this.state.isStuck}
         top={0}
         bottomBoundary={this.state.bottomBoundaryValue}
-        innerZ={3}
+        innerZ={4}
       >
         <div
           className="border-t border-b border--gray-light bg-white"


### PR DESCRIPTION
While reviewing https://github.com/mapbox/studio-manual/pull/73 I noticed that the sticky sidebar has a zIndex fight with the illustrations.

![image](https://user-images.githubusercontent.com/2180540/58632873-ec32ff00-82b4-11e9-95b1-8c65e944b17c.png)

We updated the zIndex for the TopBarSticker to 3 in https://github.com/mapbox/dr-ui/pull/67 and I think we should do the same for the sidebar sticky navigation.