### PR TITLE
[search] add ability to filter results to current site versus all docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 
 * Fixes z-index issue with `Search` modal and `TopbarSticker`. [#139](https://github.com/mapbox/dr-ui/pull/139)
+* Add ability to filter `Search` results by current site or all docs. [#138](https://github.com/mapbox/dr-ui/pull/138)
 
 ## 0.14.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2288,9 +2288,9 @@
       }
     },
     "babel-plugin-macros": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.5.1.tgz",
-      "integrity": "sha512-xN3KhAxPzsJ6OQTktCanNpIFnnMsCV+t8OloKxIL72D6+SUZYFn9qfklPgef5HyyDtzYZqqb+fs1S12+gQY82Q==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.6.0.tgz",
+      "integrity": "sha512-6hrXm6NIoSp+JiqhHZ6tUemhClnu//vjx9fAU5tkRCztTKxgiUpFpMDBX4yZiJIco7qkf0CPX2u4Ax3x6GCiUg==",
       "requires": {
         "@babel/runtime": "^7.4.2",
         "cosmiconfig": "^5.2.0",
@@ -3638,9 +3638,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.4.tgz",
-      "integrity": "sha512-lAJUJP3M6HxFXbqtGRc0iZrdyeN+WzOWeY0q/VnFzI+kqVrYIzC7bWlKqCW7oCIdzoPkvfp82EVvrTlQ8zsWQg=="
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.5.tgz",
+      "integrity": "sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -10088,9 +10088,9 @@
       }
     },
     "rc-pagination": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-1.18.0.tgz",
-      "integrity": "sha512-5kO8w9OxRlYkY1urXeYPcFTf7D8Tb6AdKtpE0RLh9kh1+UWxrXur1gQ6XMM1OecTzU/Vyu/hQi3laTCg3h4z2g==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-1.20.1.tgz",
+      "integrity": "sha512-EC2sxfKo1+R34fDN8EQgFiJn0Z6SKef4O0FizoqV3IomPczSikoarxL1RrHzqeGNsfg7JbUYaux5fQdmUAlPnA==",
       "requires": {
         "babel-runtime": "6.x",
         "classnames": "^2.2.6",
@@ -10190,9 +10190,9 @@
       }
     },
     "react-select": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-2.4.3.tgz",
-      "integrity": "sha512-cmxNaiHpviRYkojeW9rGEUJ4jpX7QTmPe2wcscwA4d1lStzw/cJtr4ft5H2O/YhfpkrcwaLghu3XmEYdXhBo8Q==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-2.4.4.tgz",
+      "integrity": "sha512-C4QPLgy9h42J/KkdrpVxNmkY6p4lb49fsrbDk/hRcZpX7JvZPNb6mGj+c5SzyEtBv1DmQ9oPH4NmhAFvCrg8Jw==",
       "requires": {
         "classnames": "^2.2.5",
         "emotion": "^9.1.2",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "dependencies": {
     "@elastic/react-search-ui": "^0.8.0",
+    "@elastic/react-search-ui-views": "^0.8.0",
     "@elastic/search-ui-site-search-connector": "^0.8.0",
     "@mapbox/mr-ui": "^0.7.0",
     "classnames": "^2.2.6",

--- a/src/components/search/__tests__/__snapshots__/search.test.js.snap
+++ b/src/components/search/__tests__/__snapshots__/search.test.js.snap
@@ -29,6 +29,35 @@ exports[`search Basic search renders as expected 1`] = `
 </div>
 `;
 
+exports[`search Basic search with \`site\` set to show filter toggle renders as expected 1`] = `
+<div
+  className="h36 relative"
+>
+  <div>
+    <div>
+      <button
+        className="flex-parent flex-parent--center-cross flex-parent--center-main h36  px12 round color-gray color-gray-dark-on-hover bg-gray-faint"
+        onClick={[Function]}
+      >
+        <span
+          className="mr6"
+        >
+          <svg
+            className="icon"
+          >
+            <use
+              xlinkHref="#icon-search"
+            />
+          </svg>
+        </span>
+         
+        Search
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`search Search with \`disableModal\` option set renders as expected 1`] = `
 <div
   className="h36 relative"

--- a/src/components/search/__tests__/search-test-cases.js
+++ b/src/components/search/__tests__/search-test-cases.js
@@ -17,7 +17,7 @@ testCases.site = {
   component: Search,
   description: 'Basic search with `site` set to show filter toggle',
   props: {
-    site: 'Help'
+    site: 'API'
   }
 };
 

--- a/src/components/search/__tests__/search-test-cases.js
+++ b/src/components/search/__tests__/search-test-cases.js
@@ -13,6 +13,14 @@ testCases.basic = {
   props: {}
 };
 
+testCases.site = {
+  component: Search,
+  description: 'Basic search with `site` set to show filter toggle',
+  props: {
+    site: 'Help'
+  }
+};
+
 testCases.dark = {
   description: 'Search with dark background, custom placeholder',
   element: (

--- a/src/components/search/__tests__/search.test.js
+++ b/src/components/search/__tests__/search.test.js
@@ -22,6 +22,24 @@ describe('search', () => {
     });
   });
 
+  describe(testCases.site.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.site;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
   describe(testCases.dark.description, () => {
     let testCase;
     let wrapper;

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -4,6 +4,8 @@ import Downshift from 'downshift';
 import SearchModal from './search-modal';
 import SearchResult from './search-result';
 import debounce from 'debounce';
+import { getFilterValueDisplay } from '@elastic/react-search-ui-views/lib/view-helpers';
+import { Facet } from '@elastic/react-search-ui';
 
 class SearchBox extends React.Component {
   constructor(props) {
@@ -16,6 +18,7 @@ class SearchBox extends React.Component {
     this.closeModal = this.closeModal.bind(this);
     this.renderModal = this.renderModal.bind(this);
     this.renderSearchBar = this.renderSearchBar.bind(this);
+    this.singleLinksFacet = this.singleLinksFacet.bind(this);
     this.checkWidth = debounce(() => {
       const width = document.body.clientWidth;
       this.setState({
@@ -40,6 +43,55 @@ class SearchBox extends React.Component {
   closeModal() {
     this.setState({ modalOpen: false });
   }
+
+  singleLinksFacet = ({
+    className, // eslint-disable-line
+    label, // eslint-disable-line
+    onRemove,
+    onSelect,
+    options,
+    values = []
+  }) => {
+    const value = values[0];
+    const siteFilter = options.filter(opt => opt.value === this.props.site)[0];
+
+    return siteFilter ? (
+      <div className="py12 border-b border--gray-faint mx6">
+        <div className="toggle-group">
+          <div className="toggle-container">
+            <a
+              key={getFilterValueDisplay(siteFilter.value)}
+              className={`toggle py3 ${
+                value === siteFilter.value ? 'bg-gray color-white' : ''
+              }`}
+              href="/"
+              onClick={e => {
+                e.preventDefault();
+                onSelect(siteFilter.value);
+              }}
+            >
+              {getFilterValueDisplay(siteFilter.value)}
+            </a>
+          </div>
+
+          <div className="toggle-container">
+            <a
+              onClick={e => {
+                e.preventDefault();
+                onRemove(value);
+              }}
+              className={`toggle py3 ${!value ? 'bg-gray color-white' : ''}`}
+              href="/"
+            >
+              All docs
+            </a>
+          </div>
+        </div>
+      </div>
+    ) : (
+      ''
+    );
+  };
 
   renderSearchBar() {
     const { props } = this;
@@ -101,6 +153,11 @@ class SearchBox extends React.Component {
               {isOpen && props.searchTerm && props.wasSearched && (
                 <div className="color-text shadow-darken25 round mt3 bg-white scroll-auto scroll-styled hmax360 absolute z4 w-full align-l">
                   <div>
+                    <Facet
+                      field="site"
+                      label="Site"
+                      view={this.singleLinksFacet}
+                    />
                     {this.props.results.length ? (
                       <ul>
                         {this.props.results.map((result, index) => (
@@ -189,7 +246,8 @@ SearchBox.propTypes = {
   background: PropTypes.oneOf(['light', 'dark']).isRequired,
   inputId: PropTypes.string,
   narrow: PropTypes.bool,
-  disableModal: PropTypes.bool
+  disableModal: PropTypes.bool,
+  site: PropTypes.string
 };
 
 export default SearchBox;

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -153,11 +153,14 @@ class SearchBox extends React.Component {
               {isOpen && props.searchTerm && props.wasSearched && (
                 <div className="color-text shadow-darken25 round mt3 bg-white scroll-auto scroll-styled hmax360 absolute z4 w-full align-l">
                   <div>
-                    <Facet
-                      field="site"
-                      label="Site"
-                      view={this.singleLinksFacet}
-                    />
+                    {this.props.site && (
+                      <Facet
+                        show={20}
+                        field="site"
+                        label="Site"
+                        view={this.singleLinksFacet}
+                      />
+                    )}
                     {this.props.results.length ? (
                       <ul>
                         {this.props.results.map((result, index) => (

--- a/src/components/search/search.js
+++ b/src/components/search/search.js
@@ -19,6 +19,11 @@ class Search extends React.Component {
           apiConnector: connector,
           initialState: {
             resultsPerPage: 10
+          },
+          searchQuery: {
+            facets: {
+              site: { type: 'value' }
+            }
           }
         }}
       >
@@ -44,6 +49,7 @@ class Search extends React.Component {
                 background={props.background}
                 narrow={props.narrow}
                 disableModal={props.disableModal}
+                site={props.site}
               />
             </div>
           );
@@ -58,7 +64,8 @@ Search.propTypes = {
   narrow: PropTypes.bool, // option to collapse input to fit in a crowded space
   background: PropTypes.oneOf(['light', 'dark']),
   inputId: PropTypes.string, // option to override default id for input/label, used for testing
-  disableModal: PropTypes.bool // option to completely disable modal if you always want an input
+  disableModal: PropTypes.bool, // option to completely disable modal if you always want an input
+  site: PropTypes.string
 };
 
 Search.defaultProps = {

--- a/src/components/search/search.js
+++ b/src/components/search/search.js
@@ -65,7 +65,7 @@ Search.propTypes = {
   background: PropTypes.oneOf(['light', 'dark']),
   inputId: PropTypes.string, // option to override default id for input/label, used for testing
   disableModal: PropTypes.bool, // option to completely disable modal if you always want an input
-  site: PropTypes.string
+  site: PropTypes.string // option to add current site or all docs filter toggle
 };
 
 Search.defaultProps = {


### PR DESCRIPTION
If you set the `site` prop, it will add a toggle at the top of the results so that the user can filter results for the current site or across all docs.

Unfortunately, we cannot default the toggle to the current site (waiting for sticky filters upstream in search-ui). Without sticky filters, any filter we set manually gets reset when the user searches. Hopefully we'll be able to add this in the near future.

> ![image](https://user-images.githubusercontent.com/2180540/58805893-fb7eb900-85e2-11e9-85ba-e2a901d088e4.png)

> ![image](https://user-images.githubusercontent.com/2180540/58805909-076a7b00-85e3-11e9-8b9d-de0757c16aa6.png)



How to test:

1. npm run start
2. Navigate to http://192.168.7.223:9966/Search
3. Try the second test case: "Basic search with `site` set to show filter toggle"

