### PR TITLE
increase modal zindex to prevent collision with topbar sticker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Master
+
+* Fixes z-index issue with `Search` modal and `TopbarSticker`. [#139](https://github.com/mapbox/dr-ui/pull/139)
+
 ## 0.14.0
 
 - Refactors the `Search` component to use a modal on larger screens. [#133](https://github.com/mapbox/dr-ui/pull/133).

--- a/src/components/search/search-modal.js
+++ b/src/components/search/search-modal.js
@@ -65,7 +65,7 @@ export default class Modal extends React.Component {
       underlayProps: { 'data-popover-ignore-clicks': true },
       underlayClass: 'bg-darken50 px12 py12 px60-mm py60-mm ',
       underlayStyle: {
-        zIndex: 3
+        zIndex: 4
       }
     };
 


### PR DESCRIPTION

Before:
![image](https://user-images.githubusercontent.com/2180540/58806272-d3dc2080-85e3-11e9-9465-a945fcc4ec2a.png)

After:
![image](https://user-images.githubusercontent.com/2180540/58806306-e2c2d300-85e3-11e9-8181-906d0d70e435.png)
