### PR TITLE
[search] adds segment tracking for queries and clicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Master
 
-* Fixes z-index issue with `Search` modal and `TopbarSticker`. [#139](https://github.com/mapbox/dr-ui/pull/139)
+* Fix z-index issue with `Search` modal and `TopbarSticker`. [#139](https://github.com/mapbox/dr-ui/pull/139)
 * Add ability to filter `Search` results by current site or all docs. [#138](https://github.com/mapbox/dr-ui/pull/138)
+* Add Segment events for tracking queries and clicks in the `Search` component. [#140](https://github.com/mapbox/dr-ui/pull/14)
 
 ## 0.14.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1473,6 +1473,12 @@
         "pascal-case": "^2.0.1"
       }
     },
+    "@mapbox/web-analytics": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/web-analytics/-/web-analytics-0.5.1.tgz",
+      "integrity": "sha512-4/g6PqjArMqXYC275kFDmHEsSLOP5Mldubw3+Ie9xsYIv95KIVhkgniasHa2FyXgL6Q/5QPRTbr13Kk81Cn09g==",
+      "dev": true
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1477,7 +1477,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@mapbox/web-analytics/-/web-analytics-0.5.1.tgz",
       "integrity": "sha512-4/g6PqjArMqXYC275kFDmHEsSLOP5Mldubw3+Ie9xsYIv95KIVhkgniasHa2FyXgL6Q/5QPRTbr13Kk81Cn09g==",
-      "dev": true
+      "optional": true
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@mapbox/eslint-config-mapbox": "^1.2.1",
     "@mapbox/mbx-assembly": "^0.28.2",
     "@mapbox/react-test-kitchen": "^0.1.3",
+    "@mapbox/web-analytics": "^0.5.1",
     "babel-eslint": "^8.2.6",
     "babelify": "^10.0.0",
     "budo": "^11.6.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@mapbox/eslint-config-mapbox": "^1.2.1",
     "@mapbox/mbx-assembly": "^0.28.2",
     "@mapbox/react-test-kitchen": "^0.1.3",
-    "@mapbox/web-analytics": "^0.5.1",
     "babel-eslint": "^8.2.6",
     "babelify": "^10.0.0",
     "budo": "^11.6.0",
@@ -76,6 +75,9 @@
     "react-html-parser": "^2.0.2",
     "react-stickynode": "^2.1.1",
     "rehype-sectionize-headings": "^1.0.0-rc.1"
+  },
+  "optionalDependencies": {
+    "@mapbox/web-analytics": "^0.5.1"
   },
   "jest": {
     "testRegex": ".*\\.test\\.js$"

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -11,6 +11,9 @@
     "@mapbox/eslint-config-mapbox/promise",
     "prettier"
   ],
+  "globals": {
+    "analytics": true
+  },
   "rules": {
     "prefer-const": "off",
     "react/no-deprecated": "off",

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -48,12 +48,25 @@ class SearchBox extends React.Component {
         id={this.props.inputId}
         inputValue={this.props.searchTerm}
         onChange={selection => {
+          // track click
+          if (window && window.analytics) {
+            analytics.track('Searched docs', {
+              query: this.props.searchTerm,
+              clicked: selection.url.raw
+            });
+          }
           this.props.trackClickThrough(selection.id.raw); // track selection click through
           window.open(selection.url.raw, '_self'); // open selection in current window
         }}
         onInputValueChange={newValue => {
           if (props.searchTerm === newValue) return;
           props.setSearchTerm(newValue, { debounce: 300 });
+          // track query
+          if (window && window.analytics) {
+            analytics.track('Searched docs', {
+              query: newValue
+            });
+          }
         }}
         itemToString={() => props.searchTerm}
       >

--- a/src/test-cases-app/test-cases-app.js
+++ b/src/test-cases-app/test-cases-app.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestKitchen from '@mapbox/react-test-kitchen';
 import componentIndex from './component-index'; // eslint-disable-line
-import '@mapbox/web-analytics'; // exposes global `initializeMapboxAnalytics()` function
+import '@mapbox/web-analytics'; // eslint-disable-line
 
 class App extends React.Component {
   componentDidMount() {

--- a/src/test-cases-app/test-cases-app.js
+++ b/src/test-cases-app/test-cases-app.js
@@ -2,8 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestKitchen from '@mapbox/react-test-kitchen';
 import componentIndex from './component-index'; // eslint-disable-line
+import '@mapbox/web-analytics'; // exposes global `initializeMapboxAnalytics()` function
 
 class App extends React.Component {
+  componentDidMount() {
+    if (window && window.initializeMapboxAnalytics) {
+      window.initializeMapboxAnalytics();
+    }
+  }
+
   render() {
     return <ReactTestKitchen componentIndex={componentIndex} />;
   }


### PR DESCRIPTION
This PR adds tracking to our Search component for:
1. Queries typed
2. Result clicked

How to test:
1. npm install
2. npm start
3. open segment > sources > mapbox-staging (leave window open) 
4. in another window: navigate to http://192.168.7.223:9966/Search
5. type a query, click a result
6. switch back to segment and click "Pause" and search for "Searched docs" events. Click each one. You should see an event for the queries and an event for the clicked item:

![image](https://user-images.githubusercontent.com/2180540/58840989-f9921580-8635-11e9-99db-cb0a4e7f7564.png)
 
When you click "Raw" you'll see the metadata attached with the event, including page searched from 🎉 