### PR TITLE
🐛do not package optionalDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Master
+
+* Fix build to remove `optionalDependencies` and `jest` from package.json. [#143](https://github.com/mapbox/dr-ui/pull/143)
+
 ## 0.15.1
 
 * Fix toggle in `Search` to be a button and track toggle event.

--- a/scripts/build-package.js
+++ b/scripts/build-package.js
@@ -57,6 +57,7 @@ function createPackageJson() {
   delete publishable.private;
   delete publishable.scripts;
   delete publishable.devDependencies;
+  delete publishable.optionalDependencies;
   delete publishable['lint-staged'];
   fs.writeFileSync(
     path.resolve(outputDir, 'package.json'),

--- a/scripts/build-package.js
+++ b/scripts/build-package.js
@@ -59,6 +59,7 @@ function createPackageJson() {
   delete publishable.devDependencies;
   delete publishable.optionalDependencies;
   delete publishable['lint-staged'];
+  delete publishable.jest;
   fs.writeFileSync(
     path.resolve(outputDir, 'package.json'),
     JSON.stringify(publishable, null, 2)


### PR DESCRIPTION
When we run `npm run build` a script does a lot of things to get dr-ui ready for npm. This PR removes our optionalDependencies from being included in the npm version of our package.json.

While updating dr-ui on /mapbox-gl-js, I ran into an issue where yarn said:

```
error Couldn't find package "@mapbox/web-analytics@^0.5.1" required by "@mapbox/dr-ui@0.15.1" on the "npm" registry.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```

Since we're already removing devDependencies from package.json for the npm version, I think it's safe to also remove optionalDependencies.

We can also remove `jest` from package.json since that's only needed for development.

---

How to test:

1. pull down branch
2. run `npm run build`
3. open `pkg/package.json`
4. you should _not_ see `optionalDependencies` or `jest` in the file