### PR TITLE
update search-ui, add loader, increase debounce length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Master
+
+* Update search-ui, add loader, increase debounce length, and reset search when modal is closed for `Search` component. [#145](https://github.com/mapbox/dr-ui/pull/145)
+
 ## 0.15.2
 
 * Fix build to remove `optionalDependencies` and `jest` from package.json. [#143](https://github.com/mapbox/dr-ui/pull/143)

--- a/package-lock.json
+++ b/package-lock.json
@@ -966,23 +966,25 @@
       }
     },
     "@elastic/react-search-ui": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@elastic/react-search-ui/-/react-search-ui-0.8.0.tgz",
-      "integrity": "sha512-FeQcLHk+qff5poVLNyNM+VXBj5QGuijqOjIn2xseMR6CUwNhiJ8RKNOsd97bR/3xFHK02dIoo0Fdl5S3TZ86ig==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@elastic/react-search-ui/-/react-search-ui-0.10.0.tgz",
+      "integrity": "sha512-YfSqLND2OqQw37OiEk3ugKptvQ0TRpTVTO2mKpwctRWs9HQMMfdTZf21PkLe8mowylWqz1VH7wCqsV87Xg5Rnw==",
       "requires": {
         "@babel/polyfill": "^7.2.5",
-        "@elastic/react-search-ui-views": "0.8.0",
-        "@elastic/search-ui": "0.8.0",
+        "@elastic/react-search-ui-views": "0.10.0",
+        "@elastic/search-ui": "0.10.0",
+        "core-js": "^2.6.9",
         "debounce-fn": "^1.0.0"
       }
     },
     "@elastic/react-search-ui-views": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@elastic/react-search-ui-views/-/react-search-ui-views-0.8.0.tgz",
-      "integrity": "sha512-sB4bl3H9BpMOluKqQ+K0b8RastqCyE5dsO3oFcNbnLrqTYtVBT7txQoIZo3uZCnlDChEGJPrMX00JPRjudfFAg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@elastic/react-search-ui-views/-/react-search-ui-views-0.10.0.tgz",
+      "integrity": "sha512-g2BZDa1XLVSZJf6bqeMXsrufaxUQyTfzxFvVhvMUn7IumkXXsZISqu0CvGT5esDoV9m8ipaB6hgZjA28+t1D5A==",
       "requires": {
         "@babel/polyfill": "^7.2.5",
         "autoprefixer": "^9.4.7",
+        "core-js": "^2.6.9",
         "deep-equal": "^1.0.1",
         "downshift": "^3.2.7",
         "rc-pagination": "^1.17.3",
@@ -990,11 +992,12 @@
       }
     },
     "@elastic/search-ui": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@elastic/search-ui/-/search-ui-0.8.0.tgz",
-      "integrity": "sha512-Eh+kmwPRDL5Fe5iyl7fScC1pjIDZNBFFgC3WCvopaQ8bemtkAmqoR0labG79mcGhpXo79+E/W5qgUkOMsVm8mQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@elastic/search-ui/-/search-ui-0.10.0.tgz",
+      "integrity": "sha512-5pMbeY/sodixMXh8aaJjUcey8FM7iV5I7gtRbXHjz9VY2mb3MdO88gHxKVYYb4PWzNQn+s2tzsaYiw2Cvgkkaw==",
       "requires": {
         "@babel/polyfill": "^7.2.5",
+        "core-js": "^2.6.9",
         "date-fns": "^1.29.0",
         "debounce-fn": "^1.0.0",
         "deep-equal": "^1.0.1",
@@ -1003,11 +1006,12 @@
       }
     },
     "@elastic/search-ui-site-search-connector": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@elastic/search-ui-site-search-connector/-/search-ui-site-search-connector-0.8.0.tgz",
-      "integrity": "sha512-trdBegOLiREX7RMdQ8dNXYA5AKxgYThvacWXV//9E/o56h5x2e+Y33PBNuMomGkkgcivdWhlFfQySftZkewBYw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@elastic/search-ui-site-search-connector/-/search-ui-site-search-connector-0.10.0.tgz",
+      "integrity": "sha512-ZTxV57vhrGRdIQc3B/fjJJu9kh9JFLW3GVgNT5pn/CAg9q1TGO/+6/AMqBNWBrGWQNEY8x5qHobqbDTrea09HQ==",
       "requires": {
-        "@babel/polyfill": "^7.2.5"
+        "@babel/polyfill": "^7.2.5",
+        "core-js": "^2.6.9"
       }
     },
     "@emotion/babel-utils": {
@@ -2003,16 +2007,47 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.5.1.tgz",
-      "integrity": "sha512-KJSzkStUl3wP0D5sdMlP82Q52JLy5+atf2MHAre48+ckWkXgixmfHyWmA77wFDy6jTHU6mIgXv6hAQ2mf1PjJQ==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.0.tgz",
+      "integrity": "sha512-kuip9YilBqhirhHEGHaBTZKXL//xxGnzvsD0FtBQa6z+A69qZD6s/BAX9VzDF1i9VKDquTJDQaPLSEhOnL6FvQ==",
       "requires": {
-        "browserslist": "^4.5.4",
-        "caniuse-lite": "^1.0.30000957",
+        "browserslist": "^4.6.1",
+        "caniuse-lite": "^1.0.30000971",
+        "chalk": "^2.4.2",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
-        "postcss": "^7.0.14",
+        "postcss": "^7.0.16",
         "postcss-value-parser": "^3.3.1"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.6.2",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.2.tgz",
+          "integrity": "sha512-2neU/V0giQy9h3XMPwLhEY3+Ao0uHSwHvU8Q1Ea6AgLVL1sXbX3dzPrJ8NWe5Hi4PoTkCYXOtVR9rfRLI0J/8Q==",
+          "requires": {
+            "caniuse-lite": "^1.0.30000974",
+            "electron-to-chromium": "^1.3.150",
+            "node-releases": "^1.1.23"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000974",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz",
+          "integrity": "sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww=="
+        },
+        "electron-to-chromium": {
+          "version": "1.3.164",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.164.tgz",
+          "integrity": "sha512-VLlalqUeduN4+fayVtRZvGP2Hl1WrRxlwzh2XVVMJym3IFrQUS29BFQ1GP/BxOJXJI1OFCrJ5BnFEsAe8NHtOg=="
+        },
+        "node-releases": {
+          "version": "1.1.23",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.23.tgz",
+          "integrity": "sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==",
+          "requires": {
+            "semver": "^5.3.0"
+          }
+        }
       }
     },
     "aws-sign2": {
@@ -2294,9 +2329,9 @@
       }
     },
     "babel-plugin-macros": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.6.0.tgz",
-      "integrity": "sha512-6hrXm6NIoSp+JiqhHZ6tUemhClnu//vjx9fAU5tkRCztTKxgiUpFpMDBX4yZiJIco7qkf0CPX2u4Ax3x6GCiUg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.6.1.tgz",
+      "integrity": "sha512-6W2nwiXme6j1n2erPOnmRiWfObUhWH7Qw1LMi9XZy8cj+KtESu3T6asZvtk5bMQQjX8te35o7CFueiSdL/2NmQ==",
       "requires": {
         "@babel/runtime": "^7.4.2",
         "cosmiconfig": "^5.2.0",
@@ -2726,6 +2761,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.0.tgz",
       "integrity": "sha512-Jk0YFwXBuMOOol8n6FhgkDzn3mY9PYLYGk29zybF05SbRTsMgPqmTNeQQhOghCxq5oFqAXE3u4sYddr4C0uRhg==",
+      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30000967",
         "electron-to-chromium": "^1.3.133",
@@ -2895,7 +2931,8 @@
     "caniuse-lite": {
       "version": "1.0.30000967",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000967.tgz",
-      "integrity": "sha512-rUBIbap+VJfxTzrM4akJ00lkvVb5/n5v3EGXfWzSH5zT8aJmGzjA8HWhJ4U6kCpzxozUSnB+yvAYDRPY6mRpgQ=="
+      "integrity": "sha512-rUBIbap+VJfxTzrM4akJ00lkvVb5/n5v3EGXfWzSH5zT8aJmGzjA8HWhJ4U6kCpzxozUSnB+yvAYDRPY6mRpgQ==",
+      "dev": true
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -3314,9 +3351,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
     },
     "core-js-compat": {
       "version": "3.0.1",
@@ -4192,7 +4229,8 @@
     "electron-to-chromium": {
       "version": "1.3.133",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.133.tgz",
-      "integrity": "sha512-lyoC8aoqbbDqsprb6aPdt9n3DpOZZzdz/T4IZKsR0/dkZIxnJVUjjcpOSwA66jPRIOyDAamCTAUqweU05kKNSg=="
+      "integrity": "sha512-lyoC8aoqbbDqsprb6aPdt9n3DpOZZzdz/T4IZKsR0/dkZIxnJVUjjcpOSwA66jPRIOyDAamCTAUqweU05kKNSg==",
+      "dev": true
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -9038,6 +9076,7 @@
       "version": "1.1.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.19.tgz",
       "integrity": "sha512-SH/B4WwovHbulIALsQllAVwqZZD1kPmKCqrhGfR29dXjLAVZMHvBjD3S6nL9D/J9QkmZ1R92/0wCMDKXUUvyyA==",
+      "dev": true,
       "requires": {
         "semver": "^5.3.0"
       }
@@ -9727,9 +9766,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
-      "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+      "version": "7.0.17",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
+      "integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -65,9 +65,9 @@
     "unist-util-visit": "^1.4.0"
   },
   "dependencies": {
-    "@elastic/react-search-ui": "^0.8.0",
-    "@elastic/react-search-ui-views": "^0.8.0",
-    "@elastic/search-ui-site-search-connector": "^0.8.0",
+    "@elastic/react-search-ui": "^0.10.0",
+    "@elastic/react-search-ui-views": "^0.10.0",
+    "@elastic/search-ui-site-search-connector": "^0.10.0",
     "@mapbox/mr-ui": "^0.7.0",
     "classnames": "^2.2.6",
     "debounce": "^1.2.0",

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -118,7 +118,7 @@ class SearchBox extends React.Component {
         }}
         onInputValueChange={newValue => {
           if (props.searchTerm === newValue) return;
-          props.setSearchTerm(newValue, { debounce: 300 });
+          props.setSearchTerm(newValue, { debounce: 1500 });
           // track query
           if (window && window.analytics) {
             analytics.track('Searched docs', {
@@ -153,8 +153,17 @@ class SearchBox extends React.Component {
                     <use xlinkHref="#icon-search" />
                   </svg>
                 </div>
+                {this.props.isLoading && (
+                  <div
+                    className="loading loading--s absolute bg-white"
+                    style={{
+                      top: this.state.useModal ? '21px' : '10px',
+                      right: '26px',
+                      zIndex: 5
+                    }}
+                  />
+                )}
               </label>
-
               <input
                 ref={input => {
                   this.docsSeachInput = input;
@@ -262,6 +271,7 @@ class SearchBox extends React.Component {
 SearchBox.propTypes = {
   searchTerm: PropTypes.string,
   trackClickThrough: PropTypes.func,
+  isLoading: PropTypes.bool,
   setSearchTerm: PropTypes.func,
   results: PropTypes.array,
   placeholder: PropTypes.string,

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -41,6 +41,7 @@ class SearchBox extends React.Component {
   }
 
   closeModal() {
+    this.props.reset();
     this.setState({ modalOpen: false });
   }
 
@@ -273,6 +274,7 @@ SearchBox.propTypes = {
   trackClickThrough: PropTypes.func,
   isLoading: PropTypes.bool,
   setSearchTerm: PropTypes.func,
+  reset: PropTypes.func,
   results: PropTypes.array,
   placeholder: PropTypes.string,
   background: PropTypes.oneOf(['light', 'dark']).isRequired,

--- a/src/components/search/search-result.js
+++ b/src/components/search/search-result.js
@@ -14,9 +14,6 @@ class SearchResult extends React.Component {
 
   render() {
     const { props } = this;
-
-    console.log(props.result);
-
     const getItemProps = props.downshiftProps.getItemProps;
     const highlighted = props.downshiftProps.highlightedIndex === props.index;
     const site = this.returnRaw(props.result.site);

--- a/src/components/search/search-result.js
+++ b/src/components/search/search-result.js
@@ -24,9 +24,7 @@ class SearchResult extends React.Component {
     const title = this.returnRaw(props.result.title);
     const url = this.returnRaw(props.result.url);
     const excerpt = props.result.excerpt
-      ? props.result.body.snippet ||
-        props.result.excerpt.snippet ||
-        props.result.excerpt.raw
+      ? props.result.excerpt.snippet || props.result.excerpt.raw
       : '';
     const resultTitle = titleGenerator(title, subsite, site).reverse();
     return (

--- a/src/components/search/search-result.js
+++ b/src/components/search/search-result.js
@@ -15,6 +15,8 @@ class SearchResult extends React.Component {
   render() {
     const { props } = this;
 
+    console.log(props.result);
+
     const getItemProps = props.downshiftProps.getItemProps;
     const highlighted = props.downshiftProps.highlightedIndex === props.index;
     const site = this.returnRaw(props.result.site);
@@ -25,7 +27,9 @@ class SearchResult extends React.Component {
     const title = this.returnRaw(props.result.title);
     const url = this.returnRaw(props.result.url);
     const excerpt = props.result.excerpt
-      ? props.result.excerpt.snippet || props.result.excerpt.raw
+      ? props.result.body.snippet ||
+        props.result.excerpt.snippet ||
+        props.result.excerpt.raw
       : '';
     const resultTitle = titleGenerator(title, subsite, site).reverse();
     return (

--- a/src/components/search/search.js
+++ b/src/components/search/search.js
@@ -34,14 +34,16 @@ class Search extends React.Component {
             setSearchTerm,
             results,
             trackClickThrough,
-            wasSearched
+            wasSearched,
+            reset
           }) => ({
             isLoading,
             searchTerm,
             setSearchTerm,
             results,
             trackClickThrough,
-            wasSearched
+            wasSearched,
+            reset
           })}
         >
           {({
@@ -50,7 +52,8 @@ class Search extends React.Component {
             setSearchTerm,
             results,
             trackClickThrough,
-            wasSearched
+            wasSearched,
+            reset
           }) => {
             return (
               <div className="h36 relative">
@@ -67,6 +70,7 @@ class Search extends React.Component {
                   narrow={props.narrow}
                   disableModal={props.disableModal}
                   site={props.site}
+                  reset={reset}
                 />
               </div>
             );

--- a/src/components/search/search.js
+++ b/src/components/search/search.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SiteSearchAPIConnector from '@elastic/search-ui-site-search-connector';
-import { SearchProvider } from '@elastic/react-search-ui';
+import { SearchProvider, WithSearch } from '@elastic/react-search-ui';
 import SearchBox from './search-box';
 
 const connector = new SiteSearchAPIConnector({
@@ -27,33 +27,51 @@ class Search extends React.Component {
           }
         }}
       >
-        {({
-          isLoading,
-          searchTerm,
-          setSearchTerm,
-          results,
-          trackClickThrough,
-          wasSearched
-        }) => {
-          return (
-            <div className="h36 relative">
-              <SearchBox
-                searchTerm={searchTerm}
-                trackClickThrough={trackClickThrough}
-                setSearchTerm={setSearchTerm}
-                results={results}
-                wasSearched={wasSearched}
-                placeholder={props.placeholder}
-                isLoading={isLoading}
-                inputId={props.inputId}
-                background={props.background}
-                narrow={props.narrow}
-                disableModal={props.disableModal}
-                site={props.site}
-              />
-            </div>
-          );
-        }}
+        <WithSearch
+          mapContextToProps={({
+            isLoading,
+            searchTerm,
+            setSearchTerm,
+            results,
+            trackClickThrough,
+            wasSearched
+          }) => ({
+            isLoading,
+            searchTerm,
+            setSearchTerm,
+            results,
+            trackClickThrough,
+            wasSearched
+          })}
+        >
+          {({
+            isLoading,
+            searchTerm,
+            setSearchTerm,
+            results,
+            trackClickThrough,
+            wasSearched
+          }) => {
+            return (
+              <div className="h36 relative">
+                <SearchBox
+                  searchTerm={searchTerm}
+                  trackClickThrough={trackClickThrough}
+                  setSearchTerm={setSearchTerm}
+                  results={results}
+                  wasSearched={wasSearched}
+                  placeholder={props.placeholder}
+                  isLoading={isLoading}
+                  inputId={props.inputId}
+                  background={props.background}
+                  narrow={props.narrow}
+                  disableModal={props.disableModal}
+                  site={props.site}
+                />
+              </div>
+            );
+          }}
+        </WithSearch>
       </SearchProvider>
     );
   }


### PR DESCRIPTION
This PR:

* updates the search-ui component to 0.10.0
* adds a spinning loader while the search engine is loading results
* increase to the debounce length to help prevent fragmented queries
* reset search when modal is closed