### PR TITLE
[PageLayout] add data attribute to prevent Swiftype from indexing sidebar content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Master
+
+* Add data attribute to prevent Swiftype from indexing sidebar content on `PageLayout`. [#146](https://github.com/mapbox/dr-ui/pull/146)
+
 ## 0.16.2
 
 * Fix bug where `Search` filter was not displaying with the first query.

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -6,6 +6,7 @@ exports[`page-layout Basic renders as expected 1`] = `
 >
   <div
     className="col col--4-mm  col--12 bg-gray-faint"
+    data-swiftype-index="false"
   >
     <div
       className="sticky-outer-wrapper"
@@ -53,6 +54,7 @@ exports[`page-layout Code highlighting test renders as expected 1`] = `
 >
   <div
     className="col col--4-mm  col--12 bg-gray-faint"
+    data-swiftype-index="false"
   >
     <div
       className="sticky-outer-wrapper"
@@ -121,6 +123,7 @@ exports[`page-layout Common use case renders as expected 1`] = `
 >
   <div
     className="col col--4-mm  col--12 bg-gray-faint"
+    data-swiftype-index="false"
   >
     <div
       className="sticky-outer-wrapper"
@@ -325,6 +328,7 @@ exports[`page-layout Custom sidebar column size renders as expected 1`] = `
 >
   <div
     className="col col--4-mm col--3-ml col--12 bg-gray-faint"
+    data-swiftype-index="false"
   >
     <div
       className="sticky-outer-wrapper"
@@ -372,6 +376,7 @@ exports[`page-layout Custom sidebar column size, too large - default to original
 >
   <div
     className="col col--4-mm  col--12 bg-gray-faint"
+    data-swiftype-index="false"
   >
     <div
       className="sticky-outer-wrapper"
@@ -419,6 +424,7 @@ exports[`page-layout Custom sidebar column size, too small - default to original
 >
   <div
     className="col col--4-mm  col--12 bg-gray-faint"
+    data-swiftype-index="false"
   >
     <div
       className="sticky-outer-wrapper"
@@ -466,6 +472,7 @@ exports[`page-layout Many first level items renders as expected 1`] = `
 >
   <div
     className="col col--4-mm  col--12 bg-gray-faint"
+    data-swiftype-index="false"
   >
     <div
       className="sticky-outer-wrapper"

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -95,6 +95,7 @@ class PageLayout extends React.Component {
           className={`col col--4-mm ${
             sideBarColSize ? `col--${sideBarColSize}-ml` : ''
           } col--12 ${props.sidebarTheme}`}
+          data-swiftype-index="false"
         >
           <Sticky
             enabled={state.stickyEnabled}

--- a/src/components/search/__tests__/__snapshots__/search.test.js.snap
+++ b/src/components/search/__tests__/__snapshots__/search.test.js.snap
@@ -262,6 +262,7 @@ exports[`search Search with \`narrow\` option set renders as expected 2`] = `
     >
       <div
         className="col col--4-mm  col--12 bg-gray-faint"
+        data-swiftype-index="false"
       >
         <div
           className="sticky-outer-wrapper"


### PR DESCRIPTION
Similar to #119 adding the data attribute to the `PageLayout` sidebar to help improve search results.

🐌 