### PR TITLE
[version-sort] do not push pre-releases of the latest stable version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add data attribute to prevent Swiftype from indexing sidebar content on `PageLayout`. [#146](https://github.com/mapbox/dr-ui/pull/146)
 * Add compare-versions as a dependency to support `helpers/version-sort.js`. [#142](https://github.com/mapbox/dr-ui/pull/142)
+* Fix `version-sort` helper function so it does not push pre-releases of the latest stable version. [#148](https://github.com/mapbox/dr-ui/pull/148)
 
 ## 0.16.2
 

--- a/src/helpers/version-sort.js
+++ b/src/helpers/version-sort.js
@@ -42,7 +42,13 @@ export function sortVersions(versions) {
     sortPreReleases
       .sort(sortBy('version'))
       .reverse()
-      .map(v => v.version);
+      .reduce((arr, v) => {
+        // do not push pre releases of lastest stable
+        if (!allLatestVersion.test(v.version)) {
+          arr.push(v.version);
+        }
+        return arr;
+      }, []);
 
   const versionsToDisplay = allVersionsOrdered.filter(version => {
     return !/^(\d|\.)+-(alpha|beta|rc|pre).+/.test(version);

--- a/tests/version-sort.test.js
+++ b/tests/version-sort.test.js
@@ -217,9 +217,7 @@ describe('ios', () => {
   });
 
   test(`newestPreRelease`, () => {
-    expect(sortVersions(allIosVersions).newestPreRelease).toEqual([
-      '5.0.0-beta.1'
-    ]);
+    expect(sortVersions(allIosVersions).newestPreRelease).toEqual([]);
   });
   test(`versionsToDisplay`, () => {
     expect(sortVersions(allIosVersions).versionsToDisplay).toEqual([
@@ -313,5 +311,33 @@ describe('ios', () => {
 
   test(`newestPreRelease, no pre releases`, () => {
     expect(sortVersions(['4.9.0', '4.8.0']).newestPreRelease).toEqual([]);
+  });
+
+  test('dont show pre releases of latest stable', () => {
+    expect(
+      sortVersions([
+        '5.1.0',
+        '5.1.0-beta.1',
+        '5.1.0-alpha.2',
+        '5.1.0-alpha.1',
+        '5.0.0',
+        '4.12.0-beta.1',
+        '4.11.0'
+      ])
+    ).toEqual({
+      allLatestVersion: /^5.1.0-.+/,
+      allVersionsOrdered: [
+        '5.1.0',
+        '5.1.0-beta.1',
+        '5.1.0-alpha.2',
+        '5.1.0-alpha.1',
+        '5.0.0',
+        '4.12.0-beta.1',
+        '4.11.0'
+      ],
+      latestStable: '5.1.0',
+      newestPreRelease: [],
+      versionsToDisplay: ['5.1.0', '5.0.0', '4.11.0']
+    });
   });
 });


### PR DESCRIPTION
Tested locally in /ios-sdk:

![image](https://user-images.githubusercontent.com/2180540/60125809-9722c580-975a-11e9-9b3c-8c1978981b75.png)

Removed the latest stable and pre-releases appear:

![image](https://user-images.githubusercontent.com/2180540/60125854-b02b7680-975a-11e9-8772-d9ee0b796618.png)


Refs https://github.com/mapbox/ios-sdk/issues/729