### PR TITLE
[search] adds missing proptype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.18.2
+
+* Fix missing proptype for `Search`. [#151](https://github.com/mapbox/dr-ui/pull/151)
+
 ## 0.18.1
 
 * Update security vulnerabilities in dependencies. [#152](https://github.com/mapbox/dr-ui/pull/152)

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -282,7 +282,8 @@ SearchBox.propTypes = {
   inputId: PropTypes.string,
   narrow: PropTypes.bool,
   disableModal: PropTypes.bool,
-  site: PropTypes.string
+  site: PropTypes.string,
+  wasSearched: PropTypes.bool
 };
 
 export default SearchBox;


### PR DESCRIPTION
Adds missing proptype to search-box.js which is causing #144 to fail. 🐌 