### PR TITLE
Create second-level-items.js helper function

### DIFF
--- a/src/helpers/second-level-items.js
+++ b/src/helpers/second-level-items.js
@@ -1,0 +1,33 @@
+// builds secondLevelItems for NavigationAccordion
+// `headings` = this.props.frontMatter.headings || this.props.headings
+export function buildSecondLevelItems(headings) {
+  const orderedHeadings = headings.map((heading, index) => {
+    return {
+      level: heading.level,
+      text: heading.text,
+      slug: heading.slug,
+      order: index
+    };
+  });
+  const topLevelHeadings = orderedHeadings.filter(h => h.level === 2);
+  return topLevelHeadings.map((h2, index) => {
+    const nextH2 = topLevelHeadings[index + 1];
+    return {
+      title: h2.text,
+      path: h2.slug,
+      thirdLevelItems: orderedHeadings
+        .filter(
+          f =>
+            f.level === 3 &&
+            f.order > h2.order &&
+            (nextH2 ? f.order < nextH2.order : true)
+        )
+        .map(h3 => {
+          return {
+            title: h3.text.replace(/i2157|i2860/, ''),
+            path: h3.slug
+          };
+        })
+    };
+  });
+}

--- a/tests/second-level-items.test.js
+++ b/tests/second-level-items.test.js
@@ -1266,4 +1266,555 @@ describe('buildSecondLevelItems', () => {
       }
     ]);
   });
+
+  it('Example: Vector tiles > Mapbox Streets v8', () => {
+    expect(
+      build.buildSecondLevelItems([
+        {
+          text: 'Overview',
+          slug: 'overview',
+          level: 2
+        },
+        {
+          text: 'Data sources & updates',
+          slug: 'data-sources--updates',
+          level: 3
+        },
+        {
+          text: 'Multiple geometry types',
+          slug: 'multiple-geometry-types',
+          level: 3
+        },
+        {
+          text: 'OpenStreetMap IDs',
+          slug: 'openstreetmap-ids',
+          level: 3
+        },
+        {
+          text: 'Data stability',
+          slug: 'data-stability',
+          level: 2
+        },
+        {
+          text: 'Common fields',
+          slug: 'common-fields',
+          level: 2
+        },
+        {
+          text: 'name text & name_<lang-code> text',
+          slug: 'name-text--name_lang-code-text',
+          level: 3
+        },
+        {
+          text: 'name_script text',
+          slug: 'name_script-text',
+          level: 3
+        },
+        {
+          text: 'sizerank number',
+          slug: 'sizerank-number',
+          level: 3
+        },
+        {
+          text: 'filterrank number',
+          slug: 'filterrank-number',
+          level: 3
+        },
+        {
+          text: 'maki text',
+          slug: 'maki-text',
+          level: 3
+        },
+        {
+          text: 'Layer Reference',
+          slug: 'layer-reference',
+          level: 2
+        },
+        {
+          text: 'admin',
+          slug: 'admin',
+          level: 3
+        },
+        {
+          text: '<!--admin--> admin_level number',
+          slug: '--admin---admin_level-number',
+          level: 4
+        },
+        {
+          text: '<!--admin--> worldview text',
+          slug: '--admin---worldview-text',
+          level: 4
+        },
+        {
+          text: '<!--admin--> disputed text',
+          slug: '--admin---disputed-text',
+          level: 4
+        },
+        {
+          text: '<!--admin--> maritime text',
+          slug: '--admin---maritime-text',
+          level: 4
+        },
+        {
+          text: '<!--admin--> iso_3166_1 text',
+          slug: '--admin---iso_3166_1-text',
+          level: 4
+        },
+        {
+          text: 'aeroway',
+          slug: 'aeroway',
+          level: 3
+        },
+        {
+          text: '<!--aeroway--> type text',
+          slug: '--aeroway---type-text',
+          level: 4
+        },
+        {
+          text: '<!--aeroway--> ref text',
+          slug: '--aeroway---ref-text',
+          level: 4
+        },
+        {
+          text: 'airport_label',
+          slug: 'airport_label',
+          level: 3
+        },
+        {
+          text: '<!--airport_label--> ref text',
+          slug: '--airport_label---ref-text',
+          level: 4
+        },
+        {
+          text: '<!--airport_label--> maki text',
+          slug: '--airport_label---maki-text',
+          level: 4
+        },
+        {
+          text: 'building',
+          slug: 'building',
+          level: 3
+        },
+        {
+          text: '<!--building--> underground text',
+          slug: '--building---underground-text',
+          level: 4
+        },
+        {
+          text: '<!--building--> type text',
+          slug: '--building---type-text',
+          level: 4
+        },
+        {
+          text: '<!--building--> height number',
+          slug: '--building---height-number',
+          level: 4
+        },
+        {
+          text: '<!--building--> min_height number',
+          slug: '--building---min_height-number',
+          level: 4
+        },
+        {
+          text: '<!--building--> extrude text',
+          slug: '--building---extrude-text',
+          level: 4
+        },
+        {
+          text: 'housenum_label',
+          slug: 'housenum_label',
+          level: 3
+        },
+        {
+          text: '<!--housenum_label--> house_num text',
+          slug: '--housenum_label---house_num-text',
+          level: 4
+        },
+        {
+          text: 'landuse_overlay',
+          slug: 'landuse_overlay',
+          level: 3
+        },
+        {
+          text: '<!--landuse_overlay--> class text',
+          slug: '--landuse_overlay---class-text',
+          level: 4
+        },
+        {
+          text: '<!--landuse_overlay--> type text',
+          slug: '--landuse_overlay---type-text',
+          level: 4
+        },
+        {
+          text: 'landuse',
+          slug: 'landuse',
+          level: 3
+        },
+        {
+          text: '<!--landuse--> class text',
+          slug: '--landuse---class-text',
+          level: 4
+        },
+        {
+          text: '<!--landuse--> type text',
+          slug: '--landuse---type-text',
+          level: 4
+        },
+        {
+          text: 'motorway_junction',
+          slug: 'motorway_junction',
+          level: 3
+        },
+        {
+          text: '<!--motorway_junction--> ref text, reflen number, & name text',
+          slug: '--motorway_junction---ref-text-reflen-number--name-text',
+          level: 4
+        },
+        {
+          text: '<!--motorway_junction--> class text & type text',
+          slug: '--motorway_junction---class-text--type-text',
+          level: 4
+        },
+        {
+          text: 'natural_label',
+          slug: 'natural_label',
+          level: 3
+        },
+        {
+          text: '<!--natural_label--> class text & maki text',
+          slug: '--natural_label---class-text--maki-text',
+          level: 4
+        },
+        {
+          text: '<!--natural_label--> elevation_m number & elevation_ft number',
+          slug: '--natural_label---elevation_m-number--elevation_ft-number',
+          level: 4
+        },
+        {
+          text: 'place_label',
+          slug: 'place_label',
+          level: 3
+        },
+        {
+          text: '<!--place_label--> type text',
+          slug: '--place_label---type-text',
+          level: 4
+        },
+        {
+          text: '<!--place_label--> class text',
+          slug: '--place_label---class-text',
+          level: 4
+        },
+        {
+          text: '<!--place_label--> symbolrank number',
+          slug: '--place_label---symbolrank-number',
+          level: 4
+        },
+        {
+          text: '<!--place_label--> iso_3166_1 text',
+          slug: '--place_label---iso_3166_1-text',
+          level: 4
+        },
+        {
+          text: '<!--place_label--> capital number',
+          slug: '--place_label---capital-number',
+          level: 4
+        },
+        {
+          text: '<!--place_label--> abbr text',
+          slug: '--place_label---abbr-text',
+          level: 4
+        },
+        {
+          text: '<!--place_label--> text_anchor text',
+          slug: '--place_label---text_anchor-text',
+          level: 4
+        },
+        {
+          text: 'poi_label',
+          slug: 'poi_label',
+          level: 3
+        },
+        {
+          text: '<!--poi_label--> class text',
+          slug: '--poi_label---class-text',
+          level: 4
+        },
+        {
+          text: '<!--poi_label--> type text',
+          slug: '--poi_label---type-text',
+          level: 4
+        },
+        {
+          text: '<!--poi_label--> category_en text & category_zh-Hans text',
+          slug: '--poi_label---category_en-text--category_zh-hans-text',
+          level: 4
+        },
+        {
+          text: 'road',
+          slug: 'road',
+          level: 3
+        },
+        {
+          text: '<!--road--> class text',
+          slug: '--road---class-text',
+          level: 4
+        },
+        {
+          text: '<!--road--> oneway text',
+          slug: '--road---oneway-text',
+          level: 4
+        },
+        {
+          text: '<!--road--> structure text',
+          slug: '--road---structure-text',
+          level: 4
+        },
+        {
+          text: '<!--road--> bike_lane text',
+          slug: '--road---bike_lane-text',
+          level: 4
+        },
+        {
+          text: '<!--road--> iso_3166_1 text',
+          slug: '--road---iso_3166_1-text',
+          level: 4
+        },
+        {
+          text: '<!--road--> iso_3166_2 text',
+          slug: '--road---iso_3166_2-text',
+          level: 4
+        },
+        {
+          text: '<!--road--> ref text & reflen number',
+          slug: '--road---ref-text--reflen-number',
+          level: 4
+        },
+        {
+          text: '<!--road--> shield text',
+          slug: '--road---shield-text',
+          level: 4
+        },
+        {
+          text: '<!--road--> shield_text_color text',
+          slug: '--road---shield_text_color-text',
+          level: 4
+        },
+        {
+          text: '<!--road--> type text',
+          slug: '--road---type-text',
+          level: 4
+        },
+        {
+          text: '<!--road--> layer number',
+          slug: '--road---layer-number',
+          level: 4
+        },
+        {
+          text: '<!--road--> len number',
+          slug: '--road---len-number',
+          level: 4
+        },
+        {
+          text: 'structure',
+          slug: 'structure',
+          level: 3
+        },
+        {
+          text: '<!--structure--> class text',
+          slug: '--structure---class-text',
+          level: 4
+        },
+        {
+          text: '<!--structure--> type text',
+          slug: '--structure---type-text',
+          level: 4
+        },
+        {
+          text: 'transit_stop_label',
+          slug: 'transit_stop_label',
+          level: 3
+        },
+        {
+          text: '<!--transit_stop_label--> stop_type text',
+          slug: '--transit_stop_label---stop_type-text',
+          level: 4
+        },
+        {
+          text: '<!--transit_stop_label--> mode text',
+          slug: '--transit_stop_label---mode-text',
+          level: 4
+        },
+        {
+          text: '<!--transit_stop_label--> maki text',
+          slug: '--transit_stop_label---maki-text',
+          level: 4
+        },
+        {
+          text: '<!--transit_stop_label--> network text',
+          slug: '--transit_stop_label---network-text',
+          level: 4
+        },
+        {
+          text: 'water',
+          slug: 'water',
+          level: 3
+        },
+        {
+          text: 'waterway',
+          slug: 'waterway',
+          level: 3
+        },
+        {
+          text: '<!--waterway--> class text & type text',
+          slug: '--waterway---class-text--type-text',
+          level: 4
+        },
+        {
+          text: 'Changelog',
+          slug: 'changelog',
+          level: 2
+        }
+      ])
+    ).toEqual([
+      {
+        title: 'Overview',
+        path: 'overview',
+        thirdLevelItems: [
+          {
+            title: 'Data sources & updates',
+            path: 'data-sources--updates'
+          },
+          {
+            title: 'Multiple geometry types',
+            path: 'multiple-geometry-types'
+          },
+          {
+            title: 'OpenStreetMap IDs',
+            path: 'openstreetmap-ids'
+          }
+        ]
+      },
+      {
+        title: 'Data stability',
+        path: 'data-stability',
+        thirdLevelItems: []
+      },
+      {
+        title: 'Common fields',
+        path: 'common-fields',
+        thirdLevelItems: [
+          {
+            title: 'name text & name_<lang-code> text',
+            path: 'name-text--name_lang-code-text'
+          },
+          {
+            title: 'name_script text',
+            path: 'name_script-text'
+          },
+          {
+            title: 'sizerank number',
+            path: 'sizerank-number'
+          },
+          {
+            title: 'filterrank number',
+            path: 'filterrank-number'
+          },
+          {
+            title: 'maki text',
+            path: 'maki-text'
+          }
+        ]
+      },
+      {
+        title: 'Layer Reference',
+        path: 'layer-reference',
+        thirdLevelItems: [
+          {
+            title: 'admin',
+            path: 'admin'
+          },
+          {
+            title: 'aeroway',
+            path: 'aeroway'
+          },
+          {
+            title: 'airport_label',
+            path: 'airport_label'
+          },
+          {
+            title: 'building',
+            path: 'building'
+          },
+          {
+            title: 'housenum_label',
+            path: 'housenum_label'
+          },
+          {
+            title: 'landuse_overlay',
+            path: 'landuse_overlay'
+          },
+          {
+            title: 'landuse',
+            path: 'landuse'
+          },
+          {
+            title: 'motorway_junction',
+            path: 'motorway_junction'
+          },
+          {
+            title: 'natural_label',
+            path: 'natural_label'
+          },
+          {
+            title: 'place_label',
+            path: 'place_label'
+          },
+          {
+            title: 'poi_label',
+            path: 'poi_label'
+          },
+          {
+            title: 'road',
+            path: 'road'
+          },
+          {
+            title: 'structure',
+            path: 'structure'
+          },
+          {
+            title: 'transit_stop_label',
+            path: 'transit_stop_label'
+          },
+          {
+            title: 'water',
+            path: 'water'
+          },
+          {
+            title: 'waterway',
+            path: 'waterway'
+          }
+        ]
+      },
+      {
+        title: 'Changelog',
+        path: 'changelog',
+        thirdLevelItems: []
+      }
+    ]);
+  });
+
+  it('Example: Mapbox GL JS > Overview', () => {
+    expect(
+      build.buildSecondLevelItems([
+        { text: 'Quickstart', slug: 'quickstart', level: 2 },
+        { text: 'CSP Directives', slug: 'csp-directives', level: 2 },
+        { text: 'Mapbox CSS', slug: 'mapbox-css', level: 2 }
+      ])
+    ).toEqual([
+      { path: 'quickstart', thirdLevelItems: [], title: 'Quickstart' },
+      { path: 'csp-directives', thirdLevelItems: [], title: 'CSP Directives' },
+      { path: 'mapbox-css', thirdLevelItems: [], title: 'Mapbox CSS' }
+    ]);
+  });
 });

--- a/tests/second-level-items.test.js
+++ b/tests/second-level-items.test.js
@@ -1,0 +1,1269 @@
+'use strict';
+
+const build = require('../src/helpers/second-level-items.js');
+
+describe('buildSecondLevelItems', () => {
+  it('Example: Android > Maps SDK', () => {
+    expect(
+      build.buildSecondLevelItems([
+        {
+          text: 'Install the Maps SDK',
+          slug: 'install-the-maps-sdk',
+          level: 2
+        },
+        {
+          text: '1. Add the dependency',
+          slug: '1-add-the-dependency',
+          level: 3
+        },
+        {
+          text: '2. Get an access token',
+          slug: '2-get-an-access-token',
+          level: 3
+        },
+        {
+          text: '3. Setup permissions',
+          slug: '3-setup-permissions',
+          level: 3
+        },
+        {
+          text: '4. Add a map',
+          slug: '4-add-a-map',
+          level: 3
+        },
+        {
+          text: '5. Lifecycle methods',
+          slug: '5-lifecycle-methods',
+          level: 3
+        },
+        {
+          text: 'Attribution',
+          slug: 'attribution',
+          level: 2
+        },
+        {
+          text: 'Telemetry opt out',
+          slug: 'telemetry-opt-out',
+          level: 2
+        },
+        {
+          text: 'MapView XML attributes',
+          slug: 'mapview-xml-attributes',
+          level: 2
+        }
+      ])
+    ).toEqual([
+      {
+        title: 'Install the Maps SDK',
+        path: 'install-the-maps-sdk',
+        thirdLevelItems: [
+          {
+            title: '1. Add the dependency',
+            path: '1-add-the-dependency'
+          },
+          {
+            title: '2. Get an access token',
+            path: '2-get-an-access-token'
+          },
+          {
+            title: '3. Setup permissions',
+            path: '3-setup-permissions'
+          },
+          {
+            title: '4. Add a map',
+            path: '4-add-a-map'
+          },
+          {
+            title: '5. Lifecycle methods',
+            path: '5-lifecycle-methods'
+          }
+        ]
+      },
+      {
+        title: 'Attribution',
+        path: 'attribution',
+        thirdLevelItems: []
+      },
+      {
+        title: 'Telemetry opt out',
+        path: 'telemetry-opt-out',
+        thirdLevelItems: []
+      },
+      {
+        title: 'MapView XML attributes',
+        path: 'mapview-xml-attributes',
+        thirdLevelItems: []
+      }
+    ]);
+  });
+
+  it('Example: API > Maps', () => {
+    expect(
+      build.buildSecondLevelItems([
+        {
+          text: 'Vector Tiles',
+          slug: 'vector-tiles',
+          level: 2
+        },
+        {
+          text: 'Retrieve vector tiles',
+          slug: 'retrieve-vector-tiles',
+          level: 3
+        },
+        {
+          text: 'Example request: Retrieve vector tiles',
+          slug: 'example-request-retrieve-vector-tiles',
+          level: 4
+        },
+        {
+          text: 'Response: Retrieve vector tiles',
+          slug: 'response-retrieve-vector-tiles',
+          level: 4
+        },
+        {
+          text: 'Vector Tiles API errors',
+          slug: 'vector-tiles-api-errors',
+          level: 3
+        },
+        {
+          text: 'Vector Tiles API restrictions and limits',
+          slug: 'vector-tiles-api-restrictions-and-limits',
+          level: 3
+        },
+        {
+          text: 'Raster Tiles',
+          slug: 'raster-tiles',
+          level: 2
+        },
+        {
+          text: 'Retrieve raster tiles',
+          slug: 'retrieve-raster-tiles',
+          level: 3
+        },
+        {
+          text: 'Example request: Retrieve raster tiles',
+          slug: 'example-request-retrieve-raster-tiles',
+          level: 4
+        },
+        {
+          text: 'Response: Retrieve raster tiles',
+          slug: 'response-retrieve-raster-tiles',
+          level: 4
+        },
+        {
+          text: 'Raster Tiles API errors',
+          slug: 'raster-tiles-api-errors',
+          level: 3
+        },
+        {
+          text: 'Raster Tiles API restrictions and limits',
+          slug: 'raster-tiles-api-restrictions-and-limits',
+          level: 3
+        },
+        {
+          text: 'Static Images',
+          slug: 'static-images',
+          level: 2
+        },
+        {
+          text: 'Retrieve a static map from a style',
+          slug: 'retrieve-a-static-map-from-a-style',
+          level: 3
+        },
+        {
+          text: 'Example request: Retrieve a static map from a style',
+          slug: 'example-request-retrieve-a-static-map-from-a-style',
+          level: 4
+        },
+        {
+          text: 'Overlay options',
+          slug: 'overlay-options',
+          level: 4
+        },
+        {
+          text: 'GeoJSON',
+          slug: 'geojson',
+          level: 5
+        },
+        {
+          text: 'Marker',
+          slug: 'marker',
+          level: 5
+        },
+        {
+          text: 'Custom marker',
+          slug: 'custom-marker',
+          level: 5
+        },
+        {
+          text: 'Path',
+          slug: 'path',
+          level: 5
+        },
+        {
+          text: 'Response: Retrieve a static map from a style',
+          slug: 'response-retrieve-a-static-map-from-a-style',
+          level: 4
+        },
+        {
+          text: 'Static Images API errors',
+          slug: 'static-images-api-errors',
+          level: 3
+        },
+        {
+          text: 'Static Images API restrictions and limits',
+          slug: 'static-images-api-restrictions-and-limits',
+          level: 3
+        },
+        {
+          text: 'Static Tiles',
+          slug: 'static-tiles',
+          level: 2
+        },
+        {
+          text: 'Retrieve raster tiles from styles',
+          slug: 'retrieve-raster-tiles-from-styles',
+          level: 3
+        },
+        {
+          text: 'Example request: Retrieve raster tiles from styles',
+          slug: 'example-request-retrieve-raster-tiles-from-styles',
+          level: 4
+        },
+        {
+          text: 'Response: Retrieve raster tiles from styles',
+          slug: 'response-retrieve-raster-tiles-from-styles',
+          level: 4
+        },
+        {
+          text: 'Static Tiles API errors',
+          slug: 'static-tiles-api-errors',
+          level: 3
+        },
+        {
+          text: 'Static Tiles API restrictions and limits',
+          slug: 'static-tiles-api-restrictions-and-limits',
+          level: 3
+        },
+        {
+          text: 'Styles',
+          slug: 'styles',
+          level: 2
+        },
+        {
+          text: 'Mapbox styles',
+          slug: 'mapbox-styles',
+          level: 3
+        },
+        {
+          text: 'The style object',
+          slug: 'the-style-object',
+          level: 3
+        },
+        {
+          text: 'Drafts',
+          slug: 'drafts',
+          level: 3
+        },
+        {
+          text: 'Example style object',
+          slug: 'example-style-object',
+          level: 4
+        },
+        {
+          text: 'Retrieve a style',
+          slug: 'retrieve-a-style',
+          level: 3
+        },
+        {
+          text: 'Example request: Retrieve a style',
+          slug: 'example-request-retrieve-a-style',
+          level: 4
+        },
+        {
+          text: 'Response: Retrieve a style',
+          slug: 'response-retrieve-a-style',
+          level: 4
+        },
+        {
+          text: 'Example response: Retrieve a style',
+          slug: 'example-response-retrieve-a-style',
+          level: 4
+        },
+        {
+          text: 'List styles',
+          slug: 'list-styles',
+          level: 3
+        },
+        {
+          text: 'Example request: List styles',
+          slug: 'example-request-list-styles',
+          level: 4
+        },
+        {
+          text: 'Response: List styles',
+          slug: 'response-list-styles',
+          level: 4
+        },
+        {
+          text: 'Example response: List styles',
+          slug: 'example-response-list-styles',
+          level: 4
+        },
+        {
+          text: 'Create a style',
+          slug: 'create-a-style',
+          level: 3
+        },
+        {
+          text: 'Example request: Create a style',
+          slug: 'example-request-create-a-style',
+          level: 4
+        },
+        {
+          text: 'Example request body: Create a style',
+          slug: 'example-request-body-create-a-style',
+          level: 4
+        },
+        {
+          text: 'Response: Create a style',
+          slug: 'response-create-a-style',
+          level: 4
+        },
+        {
+          text: 'Example response: Create a style',
+          slug: 'example-response-create-a-style',
+          level: 4
+        },
+        {
+          text: 'Update a style',
+          slug: 'update-a-style',
+          level: 3
+        },
+        {
+          text: 'Example request: Update a style',
+          slug: 'example-request-update-a-style',
+          level: 4
+        },
+        {
+          text: 'Example request body: Update a style',
+          slug: 'example-request-body-update-a-style',
+          level: 4
+        },
+        {
+          text: 'Response: Update a style',
+          slug: 'response-update-a-style',
+          level: 4
+        },
+        {
+          text: 'Example response: Update a style',
+          slug: 'example-response-update-a-style',
+          level: 4
+        },
+        {
+          text: 'Delete a style',
+          slug: 'delete-a-style',
+          level: 3
+        },
+        {
+          text: 'Example request: Delete a style',
+          slug: 'example-request-delete-a-style',
+          level: 4
+        },
+        {
+          text: 'Response: Delete a style',
+          slug: 'response-delete-a-style',
+          level: 4
+        },
+        {
+          text: 'Request embeddable HTML',
+          slug: 'request-embeddable-html',
+          level: 3
+        },
+        {
+          text: 'Example: Request embeddable HTML',
+          slug: 'example-request-embeddable-html',
+          level: 4
+        },
+        {
+          text: "Retrieve a map's WMTS document",
+          slug: 'retrieve-a-maps-wmts-document',
+          level: 3
+        },
+        {
+          text: "Example request: Retrieve a map's WMTS document",
+          slug: 'example-request-retrieve-a-maps-wmts-document',
+          level: 4
+        },
+        {
+          text: "Response: Retrieve a map's WMTS document",
+          slug: 'response-retrieve-a-maps-wmts-document',
+          level: 4
+        },
+        {
+          text: 'Sprites',
+          slug: 'sprites',
+          level: 3
+        },
+        {
+          text: 'Retrieve a sprite image or JSON',
+          slug: 'retrieve-a-sprite-image-or-json',
+          level: 3
+        },
+        {
+          text: 'Example request: Retrieve a sprite image or JSON',
+          slug: 'example-request-retrieve-a-sprite-image-or-json',
+          level: 4
+        },
+        {
+          text: 'Response: Retrieve a sprite image or JSON',
+          slug: 'response-retrieve-a-sprite-image-or-json',
+          level: 4
+        },
+        {
+          text: 'Example response: Retrieve a sprite image or JSON',
+          slug: 'example-response-retrieve-a-sprite-image-or-json',
+          level: 4
+        },
+        {
+          text: 'Add new image to sprite',
+          slug: 'add-new-image-to-sprite',
+          level: 3
+        },
+        {
+          text: 'Example request: Add new image to sprite',
+          slug: 'example-request-add-new-image-to-sprite',
+          level: 4
+        },
+        {
+          text: 'Response: Add new image to sprite',
+          slug: 'response-add-new-image-to-sprite',
+          level: 4
+        },
+        {
+          text: 'Example response: Add new image to sprite',
+          slug: 'example-response-add-new-image-to-sprite',
+          level: 4
+        },
+        {
+          text: 'Delete image from sprite',
+          slug: 'delete-image-from-sprite',
+          level: 3
+        },
+        {
+          text: 'Example request: Delete image from sprite',
+          slug: 'example-request-delete-image-from-sprite',
+          level: 4
+        },
+        {
+          text: 'Response: Delete image from sprite',
+          slug: 'response-delete-image-from-sprite',
+          level: 4
+        },
+        {
+          text: 'Example response: Delete image from sprite',
+          slug: 'example-response-delete-image-from-sprite',
+          level: 4
+        },
+        {
+          text: 'Styles API errors',
+          slug: 'styles-api-errors',
+          level: 3
+        },
+        {
+          text: 'Styles API restrictions and limits',
+          slug: 'styles-api-restrictions-and-limits',
+          level: 3
+        },
+        {
+          text: 'Styles API sprites restrictions and limits',
+          slug: 'styles-api-sprites-restrictions-and-limits',
+          level: 3
+        },
+        {
+          text: 'Tilequery',
+          slug: 'tilequery',
+          level: 2
+        },
+        {
+          text: 'Retrieve features from vector tiles',
+          slug: 'retrieve-features-from-vector-tiles',
+          level: 3
+        },
+        {
+          text: 'Point-in-polygon queries',
+          slug: 'point-in-polygon-queries',
+          level: 4
+        },
+        {
+          text: 'Example request: Retrieve features from vector tiles',
+          slug: 'example-request-retrieve-features-from-vector-tiles',
+          level: 4
+        },
+        {
+          text: 'Response: Retrieve features from vector tiles',
+          slug: 'response-retrieve-features-from-vector-tiles',
+          level: 4
+        },
+        {
+          text: 'Example response: Retrieve features from vector tiles',
+          slug: 'example-response-retrieve-features-from-vector-tiles',
+          level: 4
+        },
+        {
+          text: 'Tilequery API errors',
+          slug: 'tilequery-api-errors',
+          level: 3
+        },
+        {
+          text: 'Tilequery API restrictions and limits',
+          slug: 'tilequery-api-restrictions-and-limits',
+          level: 3
+        },
+        {
+          text: 'Uploads',
+          slug: 'uploads',
+          level: 2
+        },
+        {
+          text: 'Retrieve S3 credentials',
+          slug: 'retrieve-s3-credentials',
+          level: 3
+        },
+        {
+          text: 'Example request: Retrieve S3 credentials',
+          slug: 'example-request-retrieve-s3-credentials',
+          level: 4
+        },
+        {
+          text: 'Example AWS CLI usage',
+          slug: 'example-aws-cli-usage',
+          level: 4
+        },
+        {
+          text: 'Response: Retrieve S3 credentials',
+          slug: 'response-retrieve-s3-credentials',
+          level: 4
+        },
+        {
+          text: 'Example response: Retrieve S3 credentials',
+          slug: 'example-response-retrieve-s3-credentials',
+          level: 4
+        },
+        {
+          text: 'Create an upload',
+          slug: 'create-an-upload',
+          level: 3
+        },
+        {
+          text: 'Example request: Create an upload',
+          slug: 'example-request-create-an-upload',
+          level: 4
+        },
+        {
+          text:
+            'Example request body: Create an upload (AWS S3 bucket not required)',
+          slug:
+            'example-request-body-create-an-upload-aws-s3-bucket-not-required',
+          level: 4
+        },
+        {
+          text: 'Response: Create an upload',
+          slug: 'response-create-an-upload',
+          level: 4
+        },
+        {
+          text: 'Example response: Create an upload',
+          slug: 'example-response-create-an-upload',
+          level: 4
+        },
+        {
+          text: 'Retrieve upload status',
+          slug: 'retrieve-upload-status',
+          level: 3
+        },
+        {
+          text: 'Example request: Retrieve upload status',
+          slug: 'example-request-retrieve-upload-status',
+          level: 4
+        },
+        {
+          text: 'Response: Retrieve upload status',
+          slug: 'response-retrieve-upload-status',
+          level: 4
+        },
+        {
+          text: 'Example response: Retrieve upload status',
+          slug: 'example-response-retrieve-upload-status',
+          level: 4
+        },
+        {
+          text: 'Retrieve recent upload statuses',
+          slug: 'retrieve-recent-upload-statuses',
+          level: 3
+        },
+        {
+          text: 'Example request: Retrieve recent upload statuses',
+          slug: 'example-request-retrieve-recent-upload-statuses',
+          level: 4
+        },
+        {
+          text: 'Response: Retrieve recent upload statuses',
+          slug: 'response-retrieve-recent-upload-statuses',
+          level: 4
+        },
+        {
+          text: 'Example response: Retrieve recent upload statuses',
+          slug: 'example-response-retrieve-recent-upload-statuses',
+          level: 4
+        },
+        {
+          text: 'Remove an upload status',
+          slug: 'remove-an-upload-status',
+          level: 3
+        },
+        {
+          text: 'Example request: Remove an upload status',
+          slug: 'example-request-remove-an-upload-status',
+          level: 4
+        },
+        {
+          text: 'Response: Remove an upload status',
+          slug: 'response-remove-an-upload-status',
+          level: 4
+        },
+        {
+          text: 'Uploads API errors',
+          slug: 'uploads-api-errors',
+          level: 3
+        },
+        {
+          text: 'Uploads API restrictions and limits',
+          slug: 'uploads-api-restrictions-and-limits',
+          level: 3
+        },
+        {
+          text: 'Tilesets',
+          slug: 'tilesets',
+          level: 2
+        },
+        {
+          text: 'List tilesets',
+          slug: 'list-tilesets',
+          level: 3
+        },
+        {
+          text: 'Example request: List tilesets',
+          slug: 'example-request-list-tilesets',
+          level: 4
+        },
+        {
+          text: 'Response: List tilesets',
+          slug: 'response-list-tilesets',
+          level: 4
+        },
+        {
+          text: 'Example response: List tilesets',
+          slug: 'example-response-list-tilesets',
+          level: 4
+        },
+        {
+          text: 'Delete tileset',
+          slug: 'delete-tileset',
+          level: 3
+        },
+        {
+          text: 'Example request: Delete tileset',
+          slug: 'example-request-delete-tileset',
+          level: 4
+        },
+        {
+          text: 'Response: Delete tileset',
+          slug: 'response-delete-tileset',
+          level: 4
+        },
+        {
+          text: 'Retrieve TileJSON metadata',
+          slug: 'retrieve-tilejson-metadata',
+          level: 3
+        },
+        {
+          text: 'Example request: Retrieve TileJSON metadata',
+          slug: 'example-request-retrieve-tilejson-metadata',
+          level: 4
+        },
+        {
+          text: 'Response: Retrieve TileJSON metadata',
+          slug: 'response-retrieve-tilejson-metadata',
+          level: 4
+        },
+        {
+          text: 'Example response: Retrieve TileJSON metadata',
+          slug: 'example-response-retrieve-tilejson-metadata',
+          level: 4
+        },
+        {
+          text: 'Tilesets API errors',
+          slug: 'tilesets-api-errors',
+          level: 3
+        },
+        {
+          text: 'Tilesets API restrictions and limits',
+          slug: 'tilesets-api-restrictions-and-limits',
+          level: 3
+        },
+        {
+          text: 'Datasets',
+          slug: 'datasets',
+          level: 2
+        },
+        {
+          text: 'The dataset object',
+          slug: 'the-dataset-object',
+          level: 3
+        },
+        {
+          text: 'Example dataset object',
+          slug: 'example-dataset-object',
+          level: 4
+        },
+        {
+          text: 'List datasets',
+          slug: 'list-datasets',
+          level: 3
+        },
+        {
+          text: 'Example request: List datasets',
+          slug: 'example-request-list-datasets',
+          level: 4
+        },
+        {
+          text: 'Response: List datasets',
+          slug: 'response-list-datasets',
+          level: 4
+        },
+        {
+          text: 'Example response: List datasets',
+          slug: 'example-response-list-datasets',
+          level: 4
+        },
+        {
+          text: 'Create a dataset',
+          slug: 'create-a-dataset',
+          level: 3
+        },
+        {
+          text: 'Example request: Create a dataset',
+          slug: 'example-request-create-a-dataset',
+          level: 4
+        },
+        {
+          text: 'Example request body: Create a dataset',
+          slug: 'example-request-body-create-a-dataset',
+          level: 4
+        },
+        {
+          text: 'Response: Create a dataset',
+          slug: 'response-create-a-dataset',
+          level: 4
+        },
+        {
+          text: 'Example response: Create a dataset',
+          slug: 'example-response-create-a-dataset',
+          level: 4
+        },
+        {
+          text: 'Retrieve a dataset',
+          slug: 'retrieve-a-dataset',
+          level: 3
+        },
+        {
+          text: 'Example request: Retrieve a dataset',
+          slug: 'example-request-retrieve-a-dataset',
+          level: 4
+        },
+        {
+          text: 'Response: Retrieve a dataset',
+          slug: 'response-retrieve-a-dataset',
+          level: 4
+        },
+        {
+          text: 'Example response: Retrieve a dataset',
+          slug: 'example-response-retrieve-a-dataset',
+          level: 4
+        },
+        {
+          text: 'Update a dataset',
+          slug: 'update-a-dataset',
+          level: 3
+        },
+        {
+          text: 'Example request: Update a dataset',
+          slug: 'example-request-update-a-dataset',
+          level: 4
+        },
+        {
+          text: 'Example request body: Update a dataset',
+          slug: 'example-request-body-update-a-dataset',
+          level: 4
+        },
+        {
+          text: 'Response: Update a dataset',
+          slug: 'response-update-a-dataset',
+          level: 4
+        },
+        {
+          text: 'Example response: Update a dataset',
+          slug: 'example-response-update-a-dataset',
+          level: 4
+        },
+        {
+          text: 'Delete a dataset',
+          slug: 'delete-a-dataset',
+          level: 3
+        },
+        {
+          text: 'Example request: Delete a dataset',
+          slug: 'example-request-delete-a-dataset',
+          level: 4
+        },
+        {
+          text: 'Response: Delete a dataset',
+          slug: 'response-delete-a-dataset',
+          level: 4
+        },
+        {
+          text: 'The feature object',
+          slug: 'the-feature-object',
+          level: 3
+        },
+        {
+          text: 'Example feature object',
+          slug: 'example-feature-object',
+          level: 4
+        },
+        {
+          text: 'List features',
+          slug: 'list-features',
+          level: 3
+        },
+        {
+          text: 'Example request: List features',
+          slug: 'example-request-list-features',
+          level: 4
+        },
+        {
+          text: 'Response: List features',
+          slug: 'response-list-features',
+          level: 4
+        },
+        {
+          text: 'Example response: List features',
+          slug: 'example-response-list-features',
+          level: 4
+        },
+        {
+          text: 'Insert or update a feature',
+          slug: 'insert-or-update-a-feature',
+          level: 3
+        },
+        {
+          text: 'Example request: Insert or update a feature',
+          slug: 'example-request-insert-or-update-a-feature',
+          level: 4
+        },
+        {
+          text: 'Example request body: Insert or update a feature',
+          slug: 'example-request-body-insert-or-update-a-feature',
+          level: 4
+        },
+        {
+          text: 'Response: Insert or update a feature',
+          slug: 'response-insert-or-update-a-feature',
+          level: 4
+        },
+        {
+          text: 'Example response: Insert or update a feature',
+          slug: 'example-response-insert-or-update-a-feature',
+          level: 4
+        },
+        {
+          text: 'Retrieve a feature',
+          slug: 'retrieve-a-feature',
+          level: 3
+        },
+        {
+          text: 'Example request: Retrieve a feature',
+          slug: 'example-request-retrieve-a-feature',
+          level: 4
+        },
+        {
+          text: 'Response: Retrieve a feature',
+          slug: 'response-retrieve-a-feature',
+          level: 4
+        },
+        {
+          text: 'Example response: Retrieve a feature',
+          slug: 'example-response-retrieve-a-feature',
+          level: 4
+        },
+        {
+          text: 'Delete a feature',
+          slug: 'delete-a-feature',
+          level: 3
+        },
+        {
+          text: 'Example request: Delete a feature',
+          slug: 'example-request-delete-a-feature',
+          level: 4
+        },
+        {
+          text: 'Response: Delete a feature',
+          slug: 'response-delete-a-feature',
+          level: 4
+        },
+        {
+          text: 'Datasets API errors',
+          slug: 'datasets-api-errors',
+          level: 3
+        },
+        {
+          text: 'Datasets API restrictions and limits',
+          slug: 'datasets-api-restrictions-and-limits',
+          level: 3
+        },
+        {
+          text: 'Fonts',
+          slug: 'fonts',
+          level: 2
+        },
+        {
+          text: 'Retrieve font glyph ranges',
+          slug: 'retrieve-font-glyph-ranges',
+          level: 3
+        },
+        {
+          text: 'Example request: Retrieve font glyph ranges',
+          slug: 'example-request-retrieve-font-glyph-ranges',
+          level: 4
+        },
+        {
+          text: 'Response: Retrieve font glyph ranges',
+          slug: 'response-retrieve-font-glyph-ranges',
+          level: 4
+        },
+        {
+          text: 'Fonts API errors',
+          slug: 'fonts-api-errors',
+          level: 3
+        },
+        {
+          text: 'Fonts API restrictions and limits',
+          slug: 'fonts-api-restrictions-and-limits',
+          level: 3
+        }
+      ])
+    ).toEqual([
+      {
+        title: 'Vector Tiles',
+        path: 'vector-tiles',
+        thirdLevelItems: [
+          {
+            title: 'Retrieve vector tiles',
+            path: 'retrieve-vector-tiles'
+          },
+          {
+            title: 'Vector Tiles API errors',
+            path: 'vector-tiles-api-errors'
+          },
+          {
+            title: 'Vector Tiles API restrictions and limits',
+            path: 'vector-tiles-api-restrictions-and-limits'
+          }
+        ]
+      },
+      {
+        title: 'Raster Tiles',
+        path: 'raster-tiles',
+        thirdLevelItems: [
+          {
+            title: 'Retrieve raster tiles',
+            path: 'retrieve-raster-tiles'
+          },
+          {
+            title: 'Raster Tiles API errors',
+            path: 'raster-tiles-api-errors'
+          },
+          {
+            title: 'Raster Tiles API restrictions and limits',
+            path: 'raster-tiles-api-restrictions-and-limits'
+          }
+        ]
+      },
+      {
+        title: 'Static Images',
+        path: 'static-images',
+        thirdLevelItems: [
+          {
+            title: 'Retrieve a static map from a style',
+            path: 'retrieve-a-static-map-from-a-style'
+          },
+          {
+            title: 'Static Images API errors',
+            path: 'static-images-api-errors'
+          },
+          {
+            title: 'Static Images API restrictions and limits',
+            path: 'static-images-api-restrictions-and-limits'
+          }
+        ]
+      },
+      {
+        title: 'Static Tiles',
+        path: 'static-tiles',
+        thirdLevelItems: [
+          {
+            title: 'Retrieve raster tiles from styles',
+            path: 'retrieve-raster-tiles-from-styles'
+          },
+          {
+            title: 'Static Tiles API errors',
+            path: 'static-tiles-api-errors'
+          },
+          {
+            title: 'Static Tiles API restrictions and limits',
+            path: 'static-tiles-api-restrictions-and-limits'
+          }
+        ]
+      },
+      {
+        title: 'Styles',
+        path: 'styles',
+        thirdLevelItems: [
+          {
+            title: 'Mapbox styles',
+            path: 'mapbox-styles'
+          },
+          {
+            title: 'The style object',
+            path: 'the-style-object'
+          },
+          {
+            title: 'Drafts',
+            path: 'drafts'
+          },
+          {
+            title: 'Retrieve a style',
+            path: 'retrieve-a-style'
+          },
+          {
+            title: 'List styles',
+            path: 'list-styles'
+          },
+          {
+            title: 'Create a style',
+            path: 'create-a-style'
+          },
+          {
+            title: 'Update a style',
+            path: 'update-a-style'
+          },
+          {
+            title: 'Delete a style',
+            path: 'delete-a-style'
+          },
+          {
+            title: 'Request embeddable HTML',
+            path: 'request-embeddable-html'
+          },
+          {
+            title: "Retrieve a map's WMTS document",
+            path: 'retrieve-a-maps-wmts-document'
+          },
+          {
+            title: 'Sprites',
+            path: 'sprites'
+          },
+          {
+            title: 'Retrieve a sprite image or JSON',
+            path: 'retrieve-a-sprite-image-or-json'
+          },
+          {
+            title: 'Add new image to sprite',
+            path: 'add-new-image-to-sprite'
+          },
+          {
+            title: 'Delete image from sprite',
+            path: 'delete-image-from-sprite'
+          },
+          {
+            title: 'Styles API errors',
+            path: 'styles-api-errors'
+          },
+          {
+            title: 'Styles API restrictions and limits',
+            path: 'styles-api-restrictions-and-limits'
+          },
+          {
+            title: 'Styles API sprites restrictions and limits',
+            path: 'styles-api-sprites-restrictions-and-limits'
+          }
+        ]
+      },
+      {
+        title: 'Tilequery',
+        path: 'tilequery',
+        thirdLevelItems: [
+          {
+            title: 'Retrieve features from vector tiles',
+            path: 'retrieve-features-from-vector-tiles'
+          },
+          {
+            title: 'Tilequery API errors',
+            path: 'tilequery-api-errors'
+          },
+          {
+            title: 'Tilequery API restrictions and limits',
+            path: 'tilequery-api-restrictions-and-limits'
+          }
+        ]
+      },
+      {
+        title: 'Uploads',
+        path: 'uploads',
+        thirdLevelItems: [
+          {
+            title: 'Retrieve S3 credentials',
+            path: 'retrieve-s3-credentials'
+          },
+          {
+            title: 'Create an upload',
+            path: 'create-an-upload'
+          },
+          {
+            title: 'Retrieve upload status',
+            path: 'retrieve-upload-status'
+          },
+          {
+            title: 'Retrieve recent upload statuses',
+            path: 'retrieve-recent-upload-statuses'
+          },
+          {
+            title: 'Remove an upload status',
+            path: 'remove-an-upload-status'
+          },
+          {
+            title: 'Uploads API errors',
+            path: 'uploads-api-errors'
+          },
+          {
+            title: 'Uploads API restrictions and limits',
+            path: 'uploads-api-restrictions-and-limits'
+          }
+        ]
+      },
+      {
+        title: 'Tilesets',
+        path: 'tilesets',
+        thirdLevelItems: [
+          {
+            title: 'List tilesets',
+            path: 'list-tilesets'
+          },
+          {
+            title: 'Delete tileset',
+            path: 'delete-tileset'
+          },
+          {
+            title: 'Retrieve TileJSON metadata',
+            path: 'retrieve-tilejson-metadata'
+          },
+          {
+            title: 'Tilesets API errors',
+            path: 'tilesets-api-errors'
+          },
+          {
+            title: 'Tilesets API restrictions and limits',
+            path: 'tilesets-api-restrictions-and-limits'
+          }
+        ]
+      },
+      {
+        title: 'Datasets',
+        path: 'datasets',
+        thirdLevelItems: [
+          {
+            title: 'The dataset object',
+            path: 'the-dataset-object'
+          },
+          {
+            title: 'List datasets',
+            path: 'list-datasets'
+          },
+          {
+            title: 'Create a dataset',
+            path: 'create-a-dataset'
+          },
+          {
+            title: 'Retrieve a dataset',
+            path: 'retrieve-a-dataset'
+          },
+          {
+            title: 'Update a dataset',
+            path: 'update-a-dataset'
+          },
+          {
+            title: 'Delete a dataset',
+            path: 'delete-a-dataset'
+          },
+          {
+            title: 'The feature object',
+            path: 'the-feature-object'
+          },
+          {
+            title: 'List features',
+            path: 'list-features'
+          },
+          {
+            title: 'Insert or update a feature',
+            path: 'insert-or-update-a-feature'
+          },
+          {
+            title: 'Retrieve a feature',
+            path: 'retrieve-a-feature'
+          },
+          {
+            title: 'Delete a feature',
+            path: 'delete-a-feature'
+          },
+          {
+            title: 'Datasets API errors',
+            path: 'datasets-api-errors'
+          },
+          {
+            title: 'Datasets API restrictions and limits',
+            path: 'datasets-api-restrictions-and-limits'
+          }
+        ]
+      },
+      {
+        title: 'Fonts',
+        path: 'fonts',
+        thirdLevelItems: [
+          {
+            title: 'Retrieve font glyph ranges',
+            path: 'retrieve-font-glyph-ranges'
+          },
+          {
+            title: 'Fonts API errors',
+            path: 'fonts-api-errors'
+          },
+          {
+            title: 'Fonts API restrictions and limits',
+            path: 'fonts-api-restrictions-and-limits'
+          }
+        ]
+      }
+    ]);
+  });
+});


### PR DESCRIPTION
This helper function will build the `secondLevelItems` prop for `NavigationAccordion`.

To test this function, I pulled real data from 4 sites (android, api, vector-tiles, gl-js) and then used the function to make sure it returns the same data that the site currently returns. (This work is shown in the test file in this PR.)

🐌 