### PR TITLE
[search] make sure window and document are defined before evaluating

### DIFF
--- a/src/components/search/search.js
+++ b/src/components/search/search.js
@@ -13,7 +13,10 @@ const connector = new SiteSearchAPIConnector({
 class Search extends React.Component {
   render() {
     const { props } = this;
-    const isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
+    const isIE11 =
+      typeof window !== 'undefined' &&
+      !!window.MSInputMethodContext &&
+      (typeof document !== 'undefined' && !!document.documentMode);
     // do not load search component on IE 11
     return isIE11 ? (
       ''


### PR DESCRIPTION
This will fail on npm run build if we do not check if window and document are defined before evaluating.

Presently testing package locally and testing with `npm run build`