### PR TITLE
Create a note "flavor" for new products or features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Master
+* Add a new `Note` style with a green background that will be used to show off new or updated products or features. [#162](https://github.com/mapbox/dr-ui/pull/162) 
+
 ## 0.19.3
 
 * Fix `Note` in IE11 by replacing Object.assign with a function.[#159](https://github.com/mapbox/dr-ui/pull/159)

--- a/src/components/new-image/_tests_/__snapshots__/new-image.test.js.snap
+++ b/src/components/new-image/_tests_/__snapshots__/new-image.test.js.snap
@@ -14,7 +14,7 @@ exports[`new-image Basic renders as expected 1`] = `
     className="bg-blue-light px3 round-full"
   >
     <svg
-      className="color-blue"
+      className="color-blue mt3"
       viewBox="0 0 18 18"
     >
       <title>

--- a/src/components/new-image/_tests_/__snapshots__/new-image.test.js.snap
+++ b/src/components/new-image/_tests_/__snapshots__/new-image.test.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`new-image Basic renders as expected 1`] = `
+<div
+  style={
+    Object {
+      "height": "60px",
+      "padding": "5px",
+      "width": "60px",
+    }
+  }
+>
+  <div
+    className="bg-blue-light px3 round-full"
+  >
+    <svg
+      className="color-blue"
+      viewBox="0 0 18 18"
+    >
+      <title>
+        warning
+      </title>
+      <path
+        d="M13.7,6.7c0,2.5-3.6,6.9-4.7,8.3c-1.1-1.4-4.7-5.8-4.7-8.3S6.7,2,9,2S13.7,4.2,13.7,6.7z"
+        style={
+          Object {
+            "fill": "currentColor",
+          }
+        }
+      />
+    </svg>
+  </div>
+</div>
+`;

--- a/src/components/new-image/_tests_/new-image-test-cases.js
+++ b/src/components/new-image/_tests_/new-image-test-cases.js
@@ -1,0 +1,13 @@
+import NewImage from '../new-image';
+
+const testCases = {};
+
+testCases.basic = {
+  component: NewImage,
+  description: 'Basic',
+  props: {
+    size: '60'
+  }
+};
+
+export { testCases };

--- a/src/components/new-image/_tests_/new-image.test.js
+++ b/src/components/new-image/_tests_/new-image.test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { testCases } from './new-image-test-cases.js';
+
+describe('new-image', () => {
+  describe(testCases.basic.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.basic;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/new-image/index.js
+++ b/src/components/new-image/index.js
@@ -1,0 +1,3 @@
+import main from './new-image';
+
+export default main;

--- a/src/components/new-image/new-image.js
+++ b/src/components/new-image/new-image.js
@@ -13,7 +13,7 @@ export default class NewImage extends React.Component {
         }}
       >
         <div className={`bg-${props.color || 'blue'}-light px3 round-full`}>
-          <svg viewBox="0 0 18 18" className={`color-${props.color || 'blue'}`}>
+          <svg viewBox="0 0 18 18" className={`color-${props.color || 'blue'} mt3`}>
             <title>warning</title>
             <path
               style={{ fill: 'currentColor' }}

--- a/src/components/new-image/new-image.js
+++ b/src/components/new-image/new-image.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class NewImage extends React.Component {
+  render() {
+    const { props } = this;
+    return (
+      <div
+        style={{
+          padding: '5px',
+          width: `${props.size}px`,
+          height: `${props.size}px`
+        }}
+      >
+        <div className={`bg-${props.color || 'blue'}-light px3 round-full`}>
+          <svg viewBox="0 0 18 18" className={`color-${props.color || 'blue'}`}>
+            <title>warning</title>
+            <path
+              style={{ fill: 'currentColor' }}
+              d="M13.7,6.7c0,2.5-3.6,6.9-4.7,8.3c-1.1-1.4-4.7-5.8-4.7-8.3S6.7,2,9,2S13.7,4.2,13.7,6.7z"
+            />
+          </svg>
+        </div>
+      </div>
+    );
+  }
+}
+
+NewImage.propTypes = {
+  size: PropTypes.string.isRequired,
+  color: PropTypes.string
+};

--- a/src/components/note/__tests__/note-test-cases.js
+++ b/src/components/note/__tests__/note-test-cases.js
@@ -82,4 +82,20 @@ testCases.error = {
   }
 };
 
+testCases.new = {
+  component: Note,
+  description:
+    'A note to display with a message about new products or features.',
+  props: {
+    theme: 'new',
+    title: 'New!',
+    children: (
+      <p>
+        Check out the new <a href="#">Pizza API</a>. Build the perfect pie!
+      </p>
+    ),
+    imageComponent: <WarningImage color="green" size="60" />
+  }
+};
+
 export { testCases, noRenderCases };

--- a/src/components/note/__tests__/note-test-cases.js
+++ b/src/components/note/__tests__/note-test-cases.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Note from '../note';
 import BookImage from '../../book-image/book-image';
 import WarningImage from '../../warning-image/warning-image';
+import NewImage from '../../new-image/new-image';
 
 const testCases = {};
 const noRenderCases = {};
@@ -94,7 +95,7 @@ testCases.new = {
         Check out the new <a href="#">Pizza API</a>. Build the perfect pie!
       </p>
     ),
-    imageComponent: <WarningImage color="green" size="60" />
+    imageComponent: <NewImage color="green" size="60" />
   }
 };
 

--- a/src/components/note/note.js
+++ b/src/components/note/note.js
@@ -27,7 +27,7 @@ class Note extends React.Component {
       },
       new: {
         background: '#e8f5ee',
-        color: '#269561'
+        color: '#1b7d4f'
       }
     };
     if (props.title) {

--- a/src/components/note/note.js
+++ b/src/components/note/note.js
@@ -24,6 +24,10 @@ class Note extends React.Component {
       error: {
         background: '#fbe5e5',
         color: '#ba3b3f'
+      },
+      new: {
+        background: '#e8f5ee',
+        color: '#269561'
       }
     };
     if (props.title) {


### PR DESCRIPTION
@brsbl noted in our update of the Tilesets API docs that:

> we usually use orange to denote things like deprecation/bad things and I wonder if a different color signifying a good thing (light green?) might make more sense?

This makes sense to me! This PR creates a new Note flavor to indicate that _a product or feature is new_.  

![Screen Shot 2019-08-02 at 4 59 00 PM](https://user-images.githubusercontent.com/8186438/62404418-ed98d600-b548-11e9-8989-5df47334eb2e.png)

@mapbox/docs to review, please 🙏 
