### PR TITLE
[search] polyfill search component to catch errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 * Add a new `Note` style with a green background that will be used to show off new or updated products or features. [#162](https://github.com/mapbox/dr-ui/pull/162)
 * Fix `window.scroll()` on `BackToTopButton`. [#167](https://github.com/mapbox/dr-ui/pull/167)
+* Enable babel polyfill on `Search` component. [#165](https://github.com/mapbox/dr-ui/pull/165)
 
 ## 0.19.3
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2469,6 +2469,12 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
+    "babel-plugin-transform-react-remove-prop-types": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
+      "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==",
+      "dev": true
+    },
     "babel-preset-jest": {
       "version": "24.6.0",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2488,6 +2488,11 @@
         "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+        },
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -3476,9 +3481,10 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
+      "integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.0.1",
@@ -10523,9 +10529,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
     "regenerator-transform": {
       "version": "0.13.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2469,12 +2469,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
-    "babel-plugin-transform-react-remove-prop-types": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
-      "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==",
-      "dev": true
-    },
     "babel-preset-jest": {
       "version": "24.6.0",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@mapbox/mbx-assembly": "^0.28.2",
     "@mapbox/react-test-kitchen": "^0.1.3",
     "babel-eslint": "^8.2.6",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "babelify": "^10.0.0",
     "budo": "^11.6.0",
     "core-js": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@mapbox/mbx-assembly": "^0.28.2",
     "@mapbox/react-test-kitchen": "^0.1.3",
     "babel-eslint": "^8.2.6",
-    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "babelify": "^10.0.0",
     "budo": "^11.6.0",
     "core-js": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-eslint": "^8.2.6",
     "babelify": "^10.0.0",
     "budo": "^11.6.0",
+    "core-js": "^3.1.4",
     "cpy": "^7.0.1",
     "cpy-cli": "^2.0.0",
     "del": "^3.0.0",
@@ -61,6 +62,7 @@
     "react-aria-modal": "^3.0.0",
     "react-dom": "^16.7.0",
     "react-test-renderer": "^16.8.6",
+    "regenerator-runtime": "^0.13.3",
     "unist-util-visit": "^1.4.0"
   },
   "dependencies": {

--- a/src/components/search/search.js
+++ b/src/components/search/search.js
@@ -1,3 +1,5 @@
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 import React from 'react';
 import PropTypes from 'prop-types';
 import SiteSearchAPIConnector from '@elastic/search-ui-site-search-connector';


### PR DESCRIPTION
While reviewing Sentry errors, I noticed that the search component is throwing errors in older browser versions like Firefox 44. 

* Adding [babel's poyfill](https://babeljs.io/docs/en/babel-polyfill) to the search component fixes this issue with older browsers versions (just not IE11 because it's out of scope for the search library).
* Ref: https://sentry.io/organizations/mapboxcom/issues/1131166287/?referrer=slack

I built this PR locally and tested on /geographic-analytics:
* [x] IE 11 works 
![image](https://user-images.githubusercontent.com/2180540/62657090-a8ebb100-b933-11e9-8dac-8a1fb0cf8000.png)

* [x] Firefox 44 works (The search component works , too. I'm not concerned about that weird icon positioning since it doesn't appear in the latest versions of Firefox.)
![image](https://user-images.githubusercontent.com/2180540/62657194-e6503e80-b933-11e9-9bd6-0530b230b096.png)

You can test this PR by:
1. npm install
1. npm run build
1. Opening another repo to test locally, like geographic-analytics, and replacing the dr-ui version number in package.json with the path to your local dr-ui repo: `"@mapbox/dr-ui": "file:/Users/katydecorah/Documents/GitHub/dr-ui/pkg",`
1. run npm install (you may need to delete node_modules first) on the tester repo and then npm start
1. open browserstack with Firefox 44 to confirm the site loads locally.
