### PR TITLE
Create GL Support wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fix `window.scroll()` on `BackToTopButton`. [#167](https://github.com/mapbox/dr-ui/pull/167)
 * Enable babel polyfill on `Search` component. [#165](https://github.com/mapbox/dr-ui/pull/165)
 * Add babel config to helpers and plugins, add eslint plugins to catch new JavaScript features. [#164](https://github.com/mapbox/dr-ui/pull/164)
+* Add `GLWrapper` and `DemoIframe` components. [#166](https://github.com/mapbox/dr-ui/pull/166)
 
 ## 0.19.3
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1439,6 +1439,11 @@
         "xtend": "^4.0.1"
       }
     },
+    "@mapbox/mapbox-gl-supported": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.4.1.tgz",
+      "integrity": "sha512-yyKza9S6z3ELKuf6w5n6VNUB0Osu6Z93RXPfMHLIlNWohu3KqxewLOq4lMXseYJ92GwkRAxd207Pr/Z98cwmvw=="
+    },
     "@mapbox/mbx-assembly": {
       "version": "0.28.2",
       "resolved": "https://registry.npmjs.org/@mapbox/mbx-assembly/-/mbx-assembly-0.28.2.tgz",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@elastic/react-search-ui": "^1.0.0",
     "@elastic/react-search-ui-views": "^1.0.0",
     "@elastic/search-ui-site-search-connector": "^1.0.0",
+    "@mapbox/mapbox-gl-supported": "^1.4.1",
     "@mapbox/mr-ui": "^0.7.0",
     "classnames": "^2.2.6",
     "compare-versions": "^3.4.0",

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -12,7 +12,8 @@
     "prettier"
   ],
   "globals": {
-    "analytics": true
+    "analytics": true,
+    "MapboxPageShell": true
   },
   "rules": {
     "prefer-const": "off",

--- a/src/components/demo-iframe/__tests__/__snapshots__/demo-iframe.test.js.snap
+++ b/src/components/demo-iframe/__tests__/__snapshots__/demo-iframe.test.js.snap
@@ -4,12 +4,12 @@ exports[`demo-iframe \`gl\` is false renders as expected 1`] = `
 <div>
   <iframe
     height="400px"
-    src="https://api.mapbox.com/styles/v1/examples/cjj0b5ie80ec32so5uo8ox21m.html?fresh=true&title=true&access_token=p.key10101010101010101010#15/40.751589/-73.986485/-28/60"
+    src="https://giphy.com/embed/ule4vhcY1xEKQ"
     width="100%"
   />
   <a
     className="link"
-    href="https://api.mapbox.com/styles/v1/examples/cjj0b5ie80ec32so5uo8ox21m.html?fresh=true&title=true&access_token=p.key10101010101010101010#15/40.751589/-73.986485/-28/60"
+    href="https://giphy.com/embed/ule4vhcY1xEKQ"
   >
     <span>
       View fullscreen

--- a/src/components/demo-iframe/__tests__/__snapshots__/demo-iframe.test.js.snap
+++ b/src/components/demo-iframe/__tests__/__snapshots__/demo-iframe.test.js.snap
@@ -1,5 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`demo-iframe \`gl\` is false renders as expected 1`] = `
+<div>
+  <iframe
+    height="400px"
+    src="https://api.mapbox.com/styles/v1/examples/cjj0b5ie80ec32so5uo8ox21m.html?fresh=true&title=true&access_token=p.key10101010101010101010#15/40.751589/-73.986485/-28/60"
+    width="100%"
+  />
+  <a
+    className="link"
+    href="https://api.mapbox.com/styles/v1/examples/cjj0b5ie80ec32so5uo8ox21m.html?fresh=true&title=true&access_token=p.key10101010101010101010#15/40.751589/-73.986485/-28/60"
+  >
+    <span>
+      View fullscreen
+       
+      <span
+        className="txt-nowrap"
+      >
+        demo
+        <svg
+          className="events-none icon inline-block align-t"
+          focusable="false"
+          role="presentation"
+          style={
+            Object {
+              "height": "1.5em",
+              "width": "1.5em",
+            }
+          }
+        >
+          <use
+            xlinkHref="#icon-chevron-right"
+            xmlnsXlink="http://www.w3.org/1999/xlink"
+          />
+        </svg>
+      </span>
+    </span>
+  </a>
+</div>
+`;
+
 exports[`demo-iframe Basic renders as expected 1`] = `
 <div
   className="flex-parent flex-parent--row mb18"

--- a/src/components/demo-iframe/__tests__/__snapshots__/demo-iframe.test.js.snap
+++ b/src/components/demo-iframe/__tests__/__snapshots__/demo-iframe.test.js.snap
@@ -1,0 +1,159 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`demo-iframe Basic renders as expected 1`] = `
+<div
+  className="flex-parent flex-parent--row mb18"
+  style={
+    Object {
+      "background": "#feefe2",
+      "borderRadius": "4px",
+      "color": "#945823",
+      "fontSize": "13px",
+      "lineHeight": "20px",
+      "padding": "18px",
+    }
+  }
+>
+  <div
+    className="flex-child mr12"
+  >
+    <div
+      style={
+        Object {
+          "height": "60px",
+          "padding": "5px",
+          "width": "60px",
+        }
+      }
+    >
+      <div
+        className="bg-orange-light px3 round-full"
+      >
+        <svg
+          className="color-orange"
+          viewBox="0 0 18 18"
+        >
+          <title>
+            warning
+          </title>
+          <path
+            d="M9,3C8.4,3,7.8,3.3,7.5,3.8L3.2,13c-0.5,0.8,0,2,1.1,2H9h4.7c1.1,0,1.6-1.2,1.1-2l-4.3-9.2C10.2,3.3,9.6,3,9,3z M9,6
+c0.6,0,1,0.4,1,1v2c0,0.6-0.4,1-1,1S8,9.6,8,9V7C8,6.4,8.4,6,9,6z M9,11c0.6,0,1,0.4,1,1s-0.4,1-1,1s-1-0.4-1-1S8.4,11,9,11z"
+            style={
+              Object {
+                "fill": "currentColor",
+              }
+            }
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div
+    className="flex-child"
+  >
+    <div
+      className="txt-bold txt-m mb6"
+    >
+      Mapbox GL unsupported
+    </div>
+    Mapbox GL requires
+     
+    <a
+      className="link"
+      href="https://caniuse.com/#feat=webgl"
+    >
+      WebGL support
+    </a>
+    . Please check that you are using a supported browser and that
+     
+    <a
+      className="link"
+      href="https://get.webgl.org/"
+    >
+      WebGL is enabled
+    </a>
+    .
+  </div>
+</div>
+`;
+
+exports[`demo-iframe Missing token will return null component renders as expected 1`] = `null`;
+
+exports[`demo-iframe With token renders as expected 1`] = `
+<div
+  className="flex-parent flex-parent--row mb18"
+  style={
+    Object {
+      "background": "#feefe2",
+      "borderRadius": "4px",
+      "color": "#945823",
+      "fontSize": "13px",
+      "lineHeight": "20px",
+      "padding": "18px",
+    }
+  }
+>
+  <div
+    className="flex-child mr12"
+  >
+    <div
+      style={
+        Object {
+          "height": "60px",
+          "padding": "5px",
+          "width": "60px",
+        }
+      }
+    >
+      <div
+        className="bg-orange-light px3 round-full"
+      >
+        <svg
+          className="color-orange"
+          viewBox="0 0 18 18"
+        >
+          <title>
+            warning
+          </title>
+          <path
+            d="M9,3C8.4,3,7.8,3.3,7.5,3.8L3.2,13c-0.5,0.8,0,2,1.1,2H9h4.7c1.1,0,1.6-1.2,1.1-2l-4.3-9.2C10.2,3.3,9.6,3,9,3z M9,6
+c0.6,0,1,0.4,1,1v2c0,0.6-0.4,1-1,1S8,9.6,8,9V7C8,6.4,8.4,6,9,6z M9,11c0.6,0,1,0.4,1,1s-0.4,1-1,1s-1-0.4-1-1S8.4,11,9,11z"
+            style={
+              Object {
+                "fill": "currentColor",
+              }
+            }
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div
+    className="flex-child"
+  >
+    <div
+      className="txt-bold txt-m mb6"
+    >
+      Mapbox GL unsupported
+    </div>
+    Mapbox GL requires
+     
+    <a
+      className="link"
+      href="https://caniuse.com/#feat=webgl"
+    >
+      WebGL support
+    </a>
+    . Please check that you are using a supported browser and that
+     
+    <a
+      className="link"
+      href="https://get.webgl.org/"
+    >
+      WebGL is enabled
+    </a>
+    .
+  </div>
+</div>
+`;

--- a/src/components/demo-iframe/__tests__/demo-iframe-test-cases.js
+++ b/src/components/demo-iframe/__tests__/demo-iframe-test-cases.js
@@ -21,6 +21,17 @@ testCases.token = {
   }
 };
 
+testCases.nogl = {
+  component: DemoIframe,
+  description: '`gl` is false',
+  props: {
+    src:
+      'https://api.mapbox.com/styles/v1/examples/cjj0b5ie80ec32so5uo8ox21m.html?fresh=true&title=true&access_token=MapboxAccessToken#15/40.751589/-73.986485/-28/60',
+    MapboxAccessToken: 'p.key10101010101010101010',
+    gl: false
+  }
+};
+
 testCases.missing = {
   component: DemoIframe,
   description: 'Missing token will return null component',

--- a/src/components/demo-iframe/__tests__/demo-iframe-test-cases.js
+++ b/src/components/demo-iframe/__tests__/demo-iframe-test-cases.js
@@ -1,0 +1,33 @@
+import DemoIframe from '../demo-iframe';
+
+const testCases = {};
+const noRenderCases = {};
+
+testCases.basic = {
+  component: DemoIframe,
+  description: 'Basic',
+  props: {
+    src: 'https://giphy.com/embed/JIX9t2j0ZTN9S'
+  }
+};
+
+testCases.token = {
+  component: DemoIframe,
+  description: 'With token',
+  props: {
+    src:
+      'https://api.mapbox.com/styles/v1/examples/cjj0b5ie80ec32so5uo8ox21m.html?fresh=true&title=true&access_token=MapboxAccessToken#15/40.751589/-73.986485/-28/60',
+    MapboxAccessToken: 'p.key10101010101010101010'
+  }
+};
+
+testCases.missing = {
+  component: DemoIframe,
+  description: 'Missing token will return null component',
+  props: {
+    src:
+      'https://api.mapbox.com/styles/v1/examples/cjj0b5ie80ec32so5uo8ox21m.html?fresh=true&title=true&access_token=MapboxAccessToken#15/40.751589/-73.986485/-28/60'
+  }
+};
+
+export { testCases, noRenderCases };

--- a/src/components/demo-iframe/__tests__/demo-iframe-test-cases.js
+++ b/src/components/demo-iframe/__tests__/demo-iframe-test-cases.js
@@ -25,9 +25,7 @@ testCases.nogl = {
   component: DemoIframe,
   description: '`gl` is false',
   props: {
-    src:
-      'https://api.mapbox.com/styles/v1/examples/cjj0b5ie80ec32so5uo8ox21m.html?fresh=true&title=true&access_token=MapboxAccessToken#15/40.751589/-73.986485/-28/60',
-    MapboxAccessToken: 'p.key10101010101010101010',
+    src: 'https://giphy.com/embed/ule4vhcY1xEKQ',
     gl: false
   }
 };

--- a/src/components/demo-iframe/__tests__/demo-iframe.test.js
+++ b/src/components/demo-iframe/__tests__/demo-iframe.test.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { testCases } from './demo-iframe-test-cases.js';
+
+describe('demo-iframe', () => {
+  describe(testCases.basic.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.basic;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe(testCases.token.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.token;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe(testCases.missing.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.missing;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toBe(null);
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/demo-iframe/__tests__/demo-iframe.test.js
+++ b/src/components/demo-iframe/__tests__/demo-iframe.test.js
@@ -57,4 +57,23 @@ describe('demo-iframe', () => {
       expect(tree).toMatchSnapshot();
     });
   });
+
+  describe(testCases.nogl.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.nogl;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree.children[0].type).toBe('iframe');
+      expect(tree).toMatchSnapshot();
+    });
+  });
 });

--- a/src/components/demo-iframe/demo-iframe.js
+++ b/src/components/demo-iframe/demo-iframe.js
@@ -4,6 +4,10 @@ import ChevronousText from '@mapbox/mr-ui/chevronous-text';
 import GLWrapper from '../gl-wrapper/gl-wrapper';
 
 export default class DemoIframe extends React.Component {
+  static defaultProps = {
+    gl: true
+  };
+
   constructor(props) {
     super(props);
     this.state = {
@@ -36,18 +40,21 @@ export default class DemoIframe extends React.Component {
       ? props.src.replace('MapboxAccessToken', this.state.mapboxAccessToken)
       : props.src;
 
-    return (
-      <GLWrapper>
+    const contents = (
+      <div>
         <iframe src={src} width="100%" height="400px" />
         <a href={src} className="link">
           <ChevronousText text="View fullscreen demo" />
         </a>
-      </GLWrapper>
+      </div>
     );
+
+    return props.gl ? <GLWrapper>{contents}</GLWrapper> : contents;
   }
 }
 
 DemoIframe.propTypes = {
-  src: PropTypes.string.isRequired,
-  MapboxAccessToken: PropTypes.string
+  src: PropTypes.string.isRequired, // absolute URL src for iframe
+  gl: PropTypes.bool, // set to false if the iframe does not use GL
+  MapboxAccessToken: PropTypes.string // optional token value
 };

--- a/src/components/demo-iframe/demo-iframe.js
+++ b/src/components/demo-iframe/demo-iframe.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ChevronousText from '@mapbox/mr-ui/chevronous-text';
+import GLWrapper from '../gl-wrapper/gl-wrapper';
+
+export default class DemoIframe extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      mapboxAccessToken: this.props.MapboxAccessToken || undefined
+    };
+  }
+
+  componentDidMount() {
+    if (typeof MapboxPageShell !== 'undefined') {
+      MapboxPageShell.afterUserCheck(() => {
+        this.setState({
+          mapboxAccessToken: MapboxPageShell.getMapboxAccessToken()
+        });
+      });
+    }
+  }
+
+  render() {
+    const { props } = this;
+    // check to see if the src is making a request to mapbox api
+    const makeRequest = props.src.indexOf('MapboxAccessToken') > -1;
+    // if it's making a request and the mapboxAccessToken hasn't loaded yet
+    // return null (nothing) until it has loaded
+    if (makeRequest && !this.state.mapboxAccessToken) {
+      return null;
+    }
+    // if the src has an `access_token` value, replace it with mapboxAccessToken
+    // otherwise use the src as is
+    const src = makeRequest
+      ? props.src.replace('MapboxAccessToken', this.state.mapboxAccessToken)
+      : props.src;
+
+    return (
+      <GLWrapper>
+        <iframe src={src} width="100%" height="400px" />
+        <a href={src} className="link">
+          <ChevronousText text="View fullscreen demo" />
+        </a>
+      </GLWrapper>
+    );
+  }
+}
+
+DemoIframe.propTypes = {
+  src: PropTypes.string.isRequired,
+  MapboxAccessToken: PropTypes.string
+};

--- a/src/components/demo-iframe/index.js
+++ b/src/components/demo-iframe/index.js
@@ -1,0 +1,3 @@
+import main from './demo-iframe';
+
+export default main;

--- a/src/components/gl-wrapper/__tests__/__snapshots__/gl-wrapper.test.js.snap
+++ b/src/components/gl-wrapper/__tests__/__snapshots__/gl-wrapper.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`back-top-top-button Basic renders as expected 1`] = `
+exports[`gl-wrapper Basic renders as expected 1`] = `
 <div
   className="flex-parent flex-parent--row mb18"
   style={

--- a/src/components/gl-wrapper/__tests__/__snapshots__/gl-wrapper.test.js.snap
+++ b/src/components/gl-wrapper/__tests__/__snapshots__/gl-wrapper.test.js.snap
@@ -1,0 +1,76 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`back-top-top-button Basic renders as expected 1`] = `
+<div
+  className="flex-parent flex-parent--row mb18"
+  style={
+    Object {
+      "background": "#feefe2",
+      "borderRadius": "4px",
+      "color": "#945823",
+      "fontSize": "13px",
+      "lineHeight": "20px",
+      "padding": "18px",
+    }
+  }
+>
+  <div
+    className="flex-child mr12"
+  >
+    <div
+      style={
+        Object {
+          "height": "60px",
+          "padding": "5px",
+          "width": "60px",
+        }
+      }
+    >
+      <div
+        className="bg-orange-light px3 round-full"
+      >
+        <svg
+          className="color-orange"
+          viewBox="0 0 18 18"
+        >
+          <title>
+            warning
+          </title>
+          <path
+            d="M9,3C8.4,3,7.8,3.3,7.5,3.8L3.2,13c-0.5,0.8,0,2,1.1,2H9h4.7c1.1,0,1.6-1.2,1.1-2l-4.3-9.2C10.2,3.3,9.6,3,9,3z M9,6
+c0.6,0,1,0.4,1,1v2c0,0.6-0.4,1-1,1S8,9.6,8,9V7C8,6.4,8.4,6,9,6z M9,11c0.6,0,1,0.4,1,1s-0.4,1-1,1s-1-0.4-1-1S8.4,11,9,11z"
+            style={
+              Object {
+                "fill": "currentColor",
+              }
+            }
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div
+    className="flex-child"
+  >
+    <div
+      className="txt-bold txt-m mb6"
+    >
+      Mapbox GL unsupported
+    </div>
+    Mapbox GL requires 
+    <a
+      href="http://caniuse.com/webgl"
+    >
+      WebGL support
+    </a>
+    . Please check that you are using a supported browser and that WebGL is
+     
+    <a
+      href="http://get.webgl.org/"
+    >
+      enabled
+    </a>
+    .
+  </div>
+</div>
+`;

--- a/src/components/gl-wrapper/__tests__/__snapshots__/gl-wrapper.test.js.snap
+++ b/src/components/gl-wrapper/__tests__/__snapshots__/gl-wrapper.test.js.snap
@@ -57,18 +57,20 @@ c0.6,0,1,0.4,1,1v2c0,0.6-0.4,1-1,1S8,9.6,8,9V7C8,6.4,8.4,6,9,6z M9,11c0.6,0,1,0.
     >
       Mapbox GL unsupported
     </div>
-    Mapbox GL requires 
+    Mapbox GL requires
+     
     <a
-      href="http://caniuse.com/webgl"
+      className="link"
+      href="https://caniuse.com/#feat=webgl"
     >
       WebGL support
     </a>
-    . Please check that you are using a supported browser and that WebGL is
-     
+    . Please check that you are using a supported browser and that 
     <a
-      href="http://get.webgl.org/"
+      className="link"
+      href="https://get.webgl.org/"
     >
-      enabled
+      WebGL is enabled
     </a>
     .
   </div>

--- a/src/components/gl-wrapper/__tests__/__snapshots__/gl-wrapper.test.js.snap
+++ b/src/components/gl-wrapper/__tests__/__snapshots__/gl-wrapper.test.js.snap
@@ -65,7 +65,8 @@ c0.6,0,1,0.4,1,1v2c0,0.6-0.4,1-1,1S8,9.6,8,9V7C8,6.4,8.4,6,9,6z M9,11c0.6,0,1,0.
     >
       WebGL support
     </a>
-    . Please check that you are using a supported browser and that 
+    . Please check that you are using a supported browser and that
+     
     <a
       className="link"
       href="https://get.webgl.org/"

--- a/src/components/gl-wrapper/__tests__/gl-wrapper-test-cases.js
+++ b/src/components/gl-wrapper/__tests__/gl-wrapper-test-cases.js
@@ -9,7 +9,13 @@ testCases.basic = {
   description: 'Basic',
   props: {
     map: (
-      <iframe src="https://docs.mapbox.com/help/demos/how-mapbox-works/map-design.html" />
+      <iframe
+        src="https://giphy.com/embed/JIX9t2j0ZTN9S"
+        width="480"
+        height="480"
+        frameBorder="0"
+        allowFullScreen
+      />
     )
   }
 };

--- a/src/components/gl-wrapper/__tests__/gl-wrapper-test-cases.js
+++ b/src/components/gl-wrapper/__tests__/gl-wrapper-test-cases.js
@@ -1,0 +1,17 @@
+import GLWrapper from '../gl-wrapper';
+import React from 'react';
+
+const testCases = {};
+const noRenderCases = {};
+
+testCases.basic = {
+  component: GLWrapper,
+  description: 'Basic',
+  props: {
+    map: (
+      <iframe src="https://docs.mapbox.com/help/demos/how-mapbox-works/map-design.html" />
+    )
+  }
+};
+
+export { testCases, noRenderCases };

--- a/src/components/gl-wrapper/__tests__/gl-wrapper-test-cases.js
+++ b/src/components/gl-wrapper/__tests__/gl-wrapper-test-cases.js
@@ -8,7 +8,7 @@ testCases.basic = {
   component: GLWrapper,
   description: 'Basic',
   props: {
-    map: (
+    children: (
       <iframe
         src="https://giphy.com/embed/JIX9t2j0ZTN9S"
         width="480"

--- a/src/components/gl-wrapper/__tests__/gl-wrapper.test.js
+++ b/src/components/gl-wrapper/__tests__/gl-wrapper.test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { testCases } from './gl-wrapper-test-cases.js';
+
+describe('back-top-top-button', () => {
+  describe(testCases.basic.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.basic;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/gl-wrapper/__tests__/gl-wrapper.test.js
+++ b/src/components/gl-wrapper/__tests__/gl-wrapper.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { testCases } from './gl-wrapper-test-cases.js';
 
-describe('back-top-top-button', () => {
+describe('gl-wrapper', () => {
   describe(testCases.basic.description, () => {
     let testCase;
     let wrapper;

--- a/src/components/gl-wrapper/gl-wrapper.js
+++ b/src/components/gl-wrapper/gl-wrapper.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import supported from '@mapbox/mapbox-gl-supported';
+import Note from '../note';
+import WarningImage from '../warning-image';
+
+export default class GLWrapper extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      supported: undefined
+    };
+  }
+  componentDidMount() {
+    this.setState({ supported: supported() });
+  }
+  render() {
+    return this.state.supported ? (
+      this.props.map
+    ) : (
+      <Note
+        title="Mapbox GL unsupported"
+        theme="warning"
+        imageComponent={<WarningImage color="orange" size="60" />}
+      >
+        Mapbox GL requires <a href="http://caniuse.com/webgl">WebGL support</a>.
+        Please check that you are using a supported browser and that WebGL is{' '}
+        <a href="http://get.webgl.org/">enabled</a>.
+      </Note>
+    );
+  }
+}
+
+GLWrapper.propTypes = {
+  map: PropTypes.object
+};

--- a/src/components/gl-wrapper/gl-wrapper.js
+++ b/src/components/gl-wrapper/gl-wrapper.js
@@ -25,9 +25,15 @@ export default class GLWrapper extends React.Component {
         theme="warning"
         imageComponent={<WarningImage color="orange" size="60" />}
       >
-        Mapbox GL requires <a href="http://caniuse.com/webgl">WebGL support</a>.
-        Please check that you are using a supported browser and that WebGL is{' '}
-        <a href="http://get.webgl.org/">enabled</a>.
+        Mapbox GL requires{' '}
+        <a className="link" href="https://caniuse.com/#feat=webgl">
+          WebGL support
+        </a>
+        . Please check that you are using a supported browser and that{' '}
+        <a className="link" href="https://get.webgl.org/">
+          WebGL is enabled
+        </a>
+        .
       </Note>
     );
   }

--- a/src/components/gl-wrapper/gl-wrapper.js
+++ b/src/components/gl-wrapper/gl-wrapper.js
@@ -15,6 +15,8 @@ export default class GLWrapper extends React.Component {
     this.setState({ supported: supported() });
   }
   render() {
+    // wait for supported() to push to state
+    if (this.state.supported === undefined) return <div />;
     return this.state.supported ? (
       this.props.map
     ) : (

--- a/src/components/gl-wrapper/gl-wrapper.js
+++ b/src/components/gl-wrapper/gl-wrapper.js
@@ -18,7 +18,7 @@ export default class GLWrapper extends React.Component {
     // wait for supported() to push to state
     if (this.state.supported === undefined) return <div />;
     return this.state.supported ? (
-      this.props.map
+      this.props.children
     ) : (
       <Note
         title="Mapbox GL unsupported"
@@ -34,5 +34,5 @@ export default class GLWrapper extends React.Component {
 }
 
 GLWrapper.propTypes = {
-  map: PropTypes.object
+  children: PropTypes.node.isRequired
 };

--- a/src/components/gl-wrapper/index.js
+++ b/src/components/gl-wrapper/index.js
@@ -1,0 +1,3 @@
+import main from './gl-wrapper';
+
+export default main;


### PR DESCRIPTION
This component is a wrapper where we can pass HTML/Component to it as a prop. The wrapper will decide if the browser supports webgl. If it does then it'll show whatever code you passed to it, if it doesn't then it'll display a note with a warning.

Refs https://github.com/mapbox/documentation/issues/236

WebGL supported:
![image](https://user-images.githubusercontent.com/2180540/62716948-fe29d000-b9d0-11e9-9cff-8647a25ccd97.png)

WebGL unsupported:
![image](https://user-images.githubusercontent.com/2180540/62716988-0bdf5580-b9d1-11e9-9892-356238176903.png)


How to test:
1. npm install
2. npm start
3. Open the component in a browser you know to have GL support (your regular browser) you should see a typing cat.
4. Open the component in a browser that doesn't support GL or disable GL support. Here's how you can disable GL in Firefox:
    - Open the browser settings page. To do this, type in the address bar: about:config.
    - In the search box, type in: webgl.
    - Find line “webgl.disabled”. It has the “false” value. It is necessary to change it to “true”. To do this simply click twice on this line.

OR!

1. Visit `/help/how-mapbox-works/` on staging
    - I copied this component into /help on this branch https://github.com/mapbox/help/tree/gl-catch and pushed it to staging. 
    - There are [three maps on this page only](https://github.com/mapbox/help/commit/d7f03f162874f87a8c5819b0a80badb28b5c75e0#diff-b2646caced569cf312ab27163dd8b52a) with the wrapper. 
2. Test that page in a browser with GL and without GL support.

 🐌 No rush on review 🐌 