### PR TITLE
[BackToTop] use `window.scroll(x-coord, y-coord)` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Master
-* Add a new `Note` style with a green background that will be used to show off new or updated products or features. [#162](https://github.com/mapbox/dr-ui/pull/162) 
+* Add a new `Note` style with a green background that will be used to show off new or updated products or features. [#162](https://github.com/mapbox/dr-ui/pull/162)
+* Fix `window.scroll()` on `BackToTopButton`. [#167](https://github.com/mapbox/dr-ui/pull/167)
 
 ## 0.19.3
 

--- a/src/components/back-to-top-button/__tests__/back-to-top-button-test-cases.js
+++ b/src/components/back-to-top-button/__tests__/back-to-top-button-test-cases.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import BackToTopButton from '../back-to-top-button';
 
 const testCases = {};
@@ -7,6 +8,15 @@ testCases.basic = {
   component: BackToTopButton,
   description: 'Just the button',
   props: {}
+};
+
+testCases.tall = {
+  description: 'Gave this button some breathing room',
+  element: (
+    <div style={{ marginTop: '1000px' }}>
+      <BackToTopButton />
+    </div>
+  )
 };
 
 noRenderCases.basic = {

--- a/src/components/back-to-top-button/back-to-top-button.js
+++ b/src/components/back-to-top-button/back-to-top-button.js
@@ -23,10 +23,7 @@ export default class BackToTopButton extends React.Component {
           <Button
             onClick={() => {
               document.documentElement.scrollTop = 0; // fallback
-              window.scroll({
-                top: 0,
-                left: 0
-              });
+              window.scroll(0, 0);
             }}
             passthroughProps={{
               className:


### PR DESCRIPTION
Found this bug in Sentry related to the BackToTop button, where a slight change in syntax will give us better browser coverage:

* `window.scroll(x-coord, y-coord)` works in most browsers
* `window.scroll(options)` does not work in most browser

Ref https://developer.mozilla.org/en-US/docs/Web/API/Window/scroll#Browser_Compatibility

Ref https://sentry.io/organizations/mapboxcom/issues/929306724/

🐌 no rush in review 🐌 

