### PR TITLE
Add syntax highlighting functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Master
+* Add syntax highlighting helper functions for HTML, Java, JSON, JSX, Objective-C, Swift, and XML. [#172](https://github.com/mapbox/dr-ui/pull/172)
 * Add a new `Note` style with a green background that will be used to show off new or updated products or features. [#162](https://github.com/mapbox/dr-ui/pull/162)
 * Fix `window.scroll()` on `BackToTopButton`. [#167](https://github.com/mapbox/dr-ui/pull/167)
 * Enable babel polyfill on `Search` component. [#165](https://github.com/mapbox/dr-ui/pull/165)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5451,8 +5451,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5473,14 +5472,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5495,20 +5492,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5625,8 +5619,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5638,7 +5631,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5653,7 +5645,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5661,14 +5652,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5687,7 +5676,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5768,8 +5756,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5781,7 +5768,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5867,8 +5853,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5904,7 +5889,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5924,7 +5908,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5968,14 +5951,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -10194,6 +10175,14 @@
         "is-finite": "^1.0.1",
         "parse-ms": "^1.0.0",
         "plur": "^1.0.0"
+      }
+    },
+    "prismjs": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.15.0.tgz",
+      "integrity": "sha512-Lf2JrFYx8FanHrjoV5oL8YHCclLQgbJcVZR+gikGGMqz6ub5QVWDTM6YIwm3BuPxM/LOV+rKns3LssXNLIf+DA==",
+      "requires": {
+        "clipboard": "^2.0.0"
       }
     },
     "private": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "debounce": "^1.2.0",
     "downshift": "^3.2.7",
     "hastscript": "^5.0.0",
+    "prismjs": "^1.15.0",
     "react-html-parser": "^2.0.2",
     "react-stickynode": "^2.1.1",
     "rehype-sectionize-headings": "^1.0.0-rc.1",

--- a/src/components/syntax-highlighting/__tests__/__snapshots__/syntax-highlighting.test.js.snap
+++ b/src/components/syntax-highlighting/__tests__/__snapshots__/syntax-highlighting.test.js.snap
@@ -1,0 +1,938 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`syntax-highlighting Java highlighting renders as expected 1`] = `
+<div
+  className="relative round z0 scroll-styled"
+  style={Object {}}
+>
+  <pre>
+    <code
+      className="px0 hljs"
+    >
+      <div
+        className="relative z2"
+        data-chunk-code="chunk-0"
+      >
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 12,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token keyword\\">public</span> <span class=\\"token keyword\\">class</span> <span class=\\"token class-name\\">MainActivity</span> <span class=\\"token keyword\\">extends</span> <span class=\\"token class-name\\">AppCompatActivity</span> <span class=\\"token punctuation\\">{</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token keyword\\">private</span> MapView mapView<span class=\\"token punctuation\\">;</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 12,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": " ",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token annotation punctuation\\">@Override</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token keyword\\">protected</span> <span class=\\"token keyword\\">void</span> <span class=\\"token function\\">onCreate</span><span class=\\"token punctuation\\">(</span>Bundle savedInstanceState<span class=\\"token punctuation\\">)</span> <span class=\\"token punctuation\\">{</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token keyword\\">super</span><span class=\\"token punctuation\\">.</span><span class=\\"token function\\">onCreate</span><span class=\\"token punctuation\\">(</span>savedInstanceState<span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "Mapbox<span class=\\"token punctuation\\">.</span><span class=\\"token function\\">getInstance</span><span class=\\"token punctuation\\">(</span><span class=\\"token keyword\\">this</span><span class=\\"token punctuation\\">,</span> <span class=\\"token string\\">\\"token!\\"</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token function\\">setContentView</span><span class=\\"token punctuation\\">(</span>R<span class=\\"token punctuation\\">.</span>layout<span class=\\"token punctuation\\">.</span>activity_main<span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "mapView <span class=\\"token operator\\">=</span> <span class=\\"token punctuation\\">(</span>MapView<span class=\\"token punctuation\\">)</span> <span class=\\"token function\\">findViewById</span><span class=\\"token punctuation\\">(</span>R<span class=\\"token punctuation\\">.</span>id<span class=\\"token punctuation\\">.</span>mapView<span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "mapView<span class=\\"token punctuation\\">.</span><span class=\\"token function\\">onCreate</span><span class=\\"token punctuation\\">(</span>savedInstanceState<span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 12,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token punctuation\\">}</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+      </div>
+    </code>
+  </pre>
+</div>
+`;
+
+exports[`syntax-highlighting Objective C highlighting renders as expected 1`] = `
+<div
+  className="relative round z0 scroll-styled"
+  style={Object {}}
+>
+  <pre>
+    <code
+      className="px0 hljs"
+    >
+      <div
+        className="relative z2"
+        data-chunk-code="chunk-0"
+      >
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 12,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token macro property\\">#<span class=\\"token directive keyword\\">import</span> \\"ViewController.h\\"</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 12,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token operator\\">@</span>import Mapbox<span class=\\"token punctuation\\">;</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 12,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": " ",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 12,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token keyword\\">@implementation</span> ViewController",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 12,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": " ",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 12,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token operator\\">-</span> <span class=\\"token punctuation\\">(</span><span class=\\"token keyword\\">void</span><span class=\\"token punctuation\\">)</span>viewDidLoad <span class=\\"token punctuation\\">{</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token punctuation\\">[</span><span class=\\"token keyword\\">super</span> viewDidLoad<span class=\\"token punctuation\\">]</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 12,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": " ",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "NSURL <span class=\\"token operator\\">*</span>url <span class=\\"token operator\\">=</span> <span class=\\"token punctuation\\">[</span>NSURL URLWithString<span class=\\"token punctuation\\">:</span><span class=\\"token string\\">@\\"mapbox://styles/mapbox/streets-v10\\"</span><span class=\\"token punctuation\\">]</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "MGLMapView <span class=\\"token operator\\">*</span>mapView <span class=\\"token operator\\">=</span> <span class=\\"token punctuation\\">[</span><span class=\\"token punctuation\\">[</span>MGLMapView alloc<span class=\\"token punctuation\\">]</span> initWithFrame<span class=\\"token punctuation\\">:</span><span class=\\"token keyword\\">self</span><span class=\\"token punctuation\\">.</span>view<span class=\\"token punctuation\\">.</span>bounds styleURL<span class=\\"token punctuation\\">:</span>url<span class=\\"token punctuation\\">]</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "mapView<span class=\\"token punctuation\\">.</span>autoresizingMask <span class=\\"token operator\\">=</span> UIViewAutoresizingFlexibleWidth <span class=\\"token operator\\">|</span> UIViewAutoresizingFlexibleHeight<span class=\\"token punctuation\\">;</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token punctuation\\">[</span>mapView setCenterCoordinate<span class=\\"token punctuation\\">:</span><span class=\\"token function\\">CLLocationCoordinate2DMake</span><span class=\\"token punctuation\\">(</span><span class=\\"token number\\">59.31</span><span class=\\"token punctuation\\">,</span> <span class=\\"token number\\">18.06</span><span class=\\"token punctuation\\">)</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "zoomLevel<span class=\\"token punctuation\\">:</span><span class=\\"token number\\">9</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "animated<span class=\\"token punctuation\\">:</span>NO<span class=\\"token punctuation\\">]</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token punctuation\\">[</span><span class=\\"token keyword\\">self</span><span class=\\"token punctuation\\">.</span>view addSubview<span class=\\"token punctuation\\">:</span>mapView<span class=\\"token punctuation\\">]</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 12,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token punctuation\\">}</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 12,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": " ",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 12,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token keyword\\">@end</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+      </div>
+    </code>
+  </pre>
+</div>
+`;
+
+exports[`syntax-highlighting Swift highlighting renders as expected 1`] = `
+<div
+  className="relative round z0 scroll-styled"
+  style={Object {}}
+>
+  <pre>
+    <code
+      className="px0 hljs"
+    >
+      <div
+        className="relative z2"
+        data-chunk-code="chunk-0"
+      >
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 12,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token keyword\\">import</span> <span class=\\"token builtin\\">Mapbox</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token keyword\\">class</span> <span class=\\"token class-name\\">ViewController</span><span class=\\"token punctuation\\">:</span> <span class=\\"token builtin\\">UIViewController</span> <span class=\\"token punctuation\\">{</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token keyword\\">override</span> <span class=\\"token keyword\\">func</span> <span class=\\"token function\\">viewDidLoad</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token punctuation\\">{</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token keyword\\">super</span><span class=\\"token punctuation\\">.</span><span class=\\"token function\\">viewDidLoad</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 12,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": " ",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token keyword\\">let</span> url <span class=\\"token operator\\">=</span> <span class=\\"token function\\">URL</span><span class=\\"token punctuation\\">(</span>string<span class=\\"token punctuation\\">:</span> <span class=\\"token string\\">\\"mapbox://styles/mapbox/streets-v10\\"</span><span class=\\"token punctuation\\">)</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token keyword\\">let</span> mapView <span class=\\"token operator\\">=</span> <span class=\\"token function\\">MGLMapView</span><span class=\\"token punctuation\\">(</span>frame<span class=\\"token punctuation\\">:</span> view<span class=\\"token punctuation\\">.</span>bounds<span class=\\"token punctuation\\">,</span> styleURL<span class=\\"token punctuation\\">:</span> url<span class=\\"token punctuation\\">)</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "mapView<span class=\\"token punctuation\\">.</span>autoresizingMask <span class=\\"token operator\\">=</span> <span class=\\"token punctuation\\">[</span><span class=\\"token punctuation\\">.</span>flexibleWidth<span class=\\"token punctuation\\">,</span> <span class=\\"token punctuation\\">.</span>flexibleHeight<span class=\\"token punctuation\\">]</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "mapView<span class=\\"token punctuation\\">.</span><span class=\\"token function\\">setCenter</span><span class=\\"token punctuation\\">(</span><span class=\\"token function\\">CLLocationCoordinate2D</span><span class=\\"token punctuation\\">(</span>latitude<span class=\\"token punctuation\\">:</span> <span class=\\"token number\\">59.31</span><span class=\\"token punctuation\\">,</span> longitude<span class=\\"token punctuation\\">:</span> <span class=\\"token number\\">18.06</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">,</span> zoomLevel<span class=\\"token punctuation\\">:</span> <span class=\\"token number\\">9</span><span class=\\"token punctuation\\">,</span> animated<span class=\\"token punctuation\\">:</span> <span class=\\"token boolean\\">false</span><span class=\\"token punctuation\\">)</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 26.45,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "view<span class=\\"token punctuation\\">.</span><span class=\\"token function\\">addSubview</span><span class=\\"token punctuation\\">(</span>mapView<span class=\\"token punctuation\\">)</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+        <div
+          className="pr12"
+          style={
+            Object {
+              "paddingLeft": 12,
+            }
+          }
+        >
+          <div
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token punctuation\\">}</span>",
+              }
+            }
+            style={
+              Object {
+                "marginLeft": 14.45,
+                "textIndent": -14.45,
+              }
+            }
+          />
+        </div>
+      </div>
+    </code>
+  </pre>
+</div>
+`;

--- a/src/components/syntax-highlighting/__tests__/syntax-highlighting-test-cases.js
+++ b/src/components/syntax-highlighting/__tests__/syntax-highlighting-test-cases.js
@@ -1,0 +1,350 @@
+import CodeSnippet from '@mapbox/mr-ui/code-snippet';
+import { highlightSwift } from '../../../helpers/highlight-swift';
+import { highlightObjectivec } from '../../../helpers/highlight-objectivec';
+import { highlightJava } from '../../../helpers/highlight-java';
+import { highlightJson } from '../../../helpers/highlight-json';
+import { highlightJsx } from '../../../helpers/highlight-jsx';
+import { highlightHtml } from '../../../helpers/highlight-html';
+import { highlightXml } from '../../../helpers/highlight-xml';
+
+const testCases = {};
+const noRenderCases = {};
+
+const css = `code[class*='language-'],
+pre[class*='language-'] {
+  color: #273d56;
+  background: none;
+  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  line-height: 1.5;
+
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+}
+
+/* Code blocks */
+pre[class*='language-'] {
+  padding: 1em;
+  margin: 0.5em 0;
+  overflow: auto;
+  border-radius: 0.3em;
+}
+
+:not(pre) > code[class*='language-'],
+pre[class*='language-'] {
+  background: #272822;
+}
+
+/* Inline code */
+:not(pre) > code[class*='language-'] {
+  padding: 0.1em;
+  border-radius: 0.3em;
+  white-space: normal;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #53708e;
+}
+
+.token.punctuation {
+  color: #273d56;
+}
+
+.namespace {
+  opacity: 0.7;
+}
+
+.token.property,
+.token.tag,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #314ccd;
+}
+
+.token.boolean,
+.token.number {
+  color: #7753eb;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #ce2c69;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string,
+.token.variable {
+  color: #273d56;
+}
+
+.token.atrule,
+.token.attr-value,
+.token.function,
+.token.class-name {
+  color: #4264fb;
+}
+
+.token.keyword {
+  color: #314ccd;
+}
+
+.token.regex,
+.token.important {
+  color: #fd971f;
+}
+
+.token.important,
+.token.bold {
+  font-weight: bold;
+}
+.token.italic {
+  font-style: italic;
+}
+
+.token.entity {
+  cursor: help;
+}
+`;
+
+const swiftCodeSnippet = `
+import Mapbox
+  class ViewController: UIViewController {
+  override func viewDidLoad() {
+  super.viewDidLoad()
+
+  let url = URL(string: "mapbox://styles/mapbox/streets-v10")
+  let mapView = MGLMapView(frame: view.bounds, styleURL: url)
+  mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+  mapView.setCenter(CLLocationCoordinate2D(latitude: 59.31, longitude: 18.06), zoomLevel: 9, animated: false)
+  view.addSubview(mapView)
+}
+`;
+
+const objectiveCCodeSnippet = `
+#import "ViewController.h"
+@import Mapbox;
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  NSURL *url = [NSURL URLWithString:@"mapbox://styles/mapbox/streets-v10"];
+  MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:url];
+  mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  [mapView setCenterCoordinate:CLLocationCoordinate2DMake(59.31, 18.06)
+  zoomLevel:9
+  animated:NO];
+  [self.view addSubview:mapView];
+}
+
+@end
+`;
+
+const javaCodeSnippet = `
+public class MainActivity extends AppCompatActivity {
+  private MapView mapView;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+  super.onCreate(savedInstanceState);
+  Mapbox.getInstance(this, "token!");
+  setContentView(R.layout.activity_main);
+  mapView = (MapView) findViewById(R.id.mapView);
+  mapView.onCreate(savedInstanceState);
+}
+`;
+
+const jsonCodeSnippet = `{
+  json: {
+    this: "is",
+    json: [ 1, 2, 3 ]
+  },
+  "json-two": {
+    "this-is": "also",
+    json: [ true, false ]
+  }
+}`;
+
+const jsxCodeSnippet = `import React from 'react';
+import Button from '@mapbox/mr-ui/button';
+import Icon from '@mapbox/mr-ui/icon';
+import PopoverTrigger from '@mapbox/mr-ui/popover-trigger';
+
+export default class BackToTopButton extends React.Component {
+  getPopoverContent = () => {
+    return <div className="txt-s">Back to top!</div>;
+  };
+  render() {
+    return (
+      <div className="block mx24 my24 z5">
+        <PopoverTrigger
+          respondsToClick={false}
+          respondsToHover={true}
+          content={this.getPopoverContent}
+          popoverProps={{
+            alignment: 'center',
+            placement: 'top',
+            padding: 'small'
+          }}
+        >
+          <Button
+            onClick={() => {
+              document.documentElement.scrollTop = 0; // fallback
+              window.scroll(0, 0);
+            }}
+            passthroughProps={{
+              className:
+                'btn--blue w60 h60 px0 round-full shadow-darken25 color-white flex-parent flex-parent--center-main flex-parent--center-cross'
+            }}
+          >
+            <Icon name="arrow-up" size={30} />
+          </Button>
+        </PopoverTrigger>
+      </div>
+    );
+  }
+}`;
+
+const htmlCodeSnippet = `<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8' />
+    <title>Display a map</title>
+    <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.2.0/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.2.0/mapbox-gl.css' rel='stylesheet' />
+    <style>
+        body { margin:0; padding:0; }
+        #map { position:absolute; top:0; bottom:0; width:100%; }
+    </style>
+</head>
+<body>
+
+<div id='map'></div>
+<script>
+mapboxgl.accessToken = 'token!';
+var map = new mapboxgl.Map({
+    container: 'map', // container id
+    style: 'mapbox://styles/mapbox/streets-v11', // stylesheet location
+    center: [-74.50, 40], // starting position [lng, lat]
+    zoom: 9 // starting zoom
+});
+</script>
+
+</body>
+</html>`;
+
+const xmlCodeSnippet = `<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        mapbox:layout_constraintBottom_toBottomOf="parent"
+        mapbox:layout_constraintEnd_toEndOf="parent"
+        mapbox:layout_constraintStart_toStartOf="parent"
+        mapbox:layout_constraintTop_toTopOf="parent"
+        mapbox:mapbox_cameraTargetLat="41.885"
+        mapbox:mapbox_cameraTargetLng="-87.679"
+        mapbox:mapbox_cameraTilt="60"
+        mapbox:mapbox_cameraZoom="12" />
+
+</android.support.constraint.ConstraintLayout>`;
+
+testCases.basic = {
+  component: CodeSnippet,
+  description: 'Swift highlighting',
+  props: {
+    code: swiftCodeSnippet,
+    highlightedCode: highlightSwift(swiftCodeSnippet),
+    highlightThemeCss: css
+  }
+};
+
+testCases.objc = {
+  component: CodeSnippet,
+  description: 'Objective C highlighting',
+  props: {
+    code: objectiveCCodeSnippet,
+    highlightedCode: highlightObjectivec(objectiveCCodeSnippet),
+    highlightThemeCss: css
+  }
+};
+
+testCases.java = {
+  component: CodeSnippet,
+  description: 'Java highlighting',
+  props: {
+    code: javaCodeSnippet,
+    highlightedCode: highlightJava(javaCodeSnippet),
+    highlightThemeCss: css
+  }
+};
+
+testCases.json = {
+  component: CodeSnippet,
+  description: 'JSON highlighting',
+  props: {
+    code: jsonCodeSnippet,
+    highlightedCode: highlightJson(jsonCodeSnippet),
+    highlightThemeCss: css
+  }
+};
+
+testCases.jsx = {
+  component: CodeSnippet,
+  description: 'JSX highlighting',
+  props: {
+    code: jsxCodeSnippet,
+    highlightedCode: highlightJsx(jsxCodeSnippet),
+    highlightThemeCss: css
+  }
+};
+
+testCases.html = {
+  component: CodeSnippet,
+  description: 'HTML highlighting',
+  props: {
+    code: htmlCodeSnippet,
+    highlightedCode: highlightHtml(htmlCodeSnippet),
+    highlightThemeCss: css
+  }
+};
+
+testCases.xml = {
+  component: CodeSnippet,
+  description: 'XML highlighting',
+  props: {
+    code: xmlCodeSnippet,
+    highlightedCode: highlightXml(xmlCodeSnippet),
+    highlightThemeCss: css
+  }
+};
+
+export { testCases, noRenderCases };

--- a/src/components/syntax-highlighting/__tests__/syntax-highlighting.test.js
+++ b/src/components/syntax-highlighting/__tests__/syntax-highlighting.test.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { testCases } from './syntax-highlighting-test-cases.js';
+
+describe('syntax-highlighting', () => {
+  describe(testCases.basic.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.basic;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe(testCases.objc.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.objc;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe(testCases.java.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.java;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/helpers/highlight-html.js
+++ b/src/helpers/highlight-html.js
@@ -1,0 +1,7 @@
+import Prism from 'prismjs';
+
+function highlightHtml(rawCode) {
+  return rawCode ? Prism.highlight(rawCode, Prism.languages['html']) : '';
+}
+
+export { highlightHtml };

--- a/src/helpers/highlight-java.js
+++ b/src/helpers/highlight-java.js
@@ -1,0 +1,8 @@
+import Prism from 'prismjs';
+import 'prismjs/components/prism-java';
+
+function highlightJava(rawCode) {
+  return rawCode ? Prism.highlight(rawCode, Prism.languages['java']) : '';
+}
+
+export { highlightJava };

--- a/src/helpers/highlight-json.js
+++ b/src/helpers/highlight-json.js
@@ -1,0 +1,8 @@
+import Prism from 'prismjs';
+import 'prismjs/components/prism-json';
+
+function highlightJson(rawCode) {
+  return rawCode ? Prism.highlight(rawCode, Prism.languages['json']) : '';
+}
+
+export { highlightJson };

--- a/src/helpers/highlight-jsx.js
+++ b/src/helpers/highlight-jsx.js
@@ -1,0 +1,8 @@
+import Prism from 'prismjs';
+import 'prismjs/components/prism-jsx';
+
+function highlightJsx(rawCode) {
+  return rawCode ? Prism.highlight(rawCode, Prism.languages['jsx']) : '';
+}
+
+export { highlightJsx };

--- a/src/helpers/highlight-objectivec.js
+++ b/src/helpers/highlight-objectivec.js
@@ -1,0 +1,9 @@
+import Prism from 'prismjs';
+import 'prismjs/components/prism-c';
+import 'prismjs/components/prism-objectivec';
+
+function highlightObjectivec(rawCode) {
+  return rawCode ? Prism.highlight(rawCode, Prism.languages['objectivec']) : '';
+}
+
+export { highlightObjectivec };

--- a/src/helpers/highlight-swift.js
+++ b/src/helpers/highlight-swift.js
@@ -1,0 +1,8 @@
+import Prism from 'prismjs';
+import 'prismjs/components/prism-swift';
+
+function highlightSwift(rawCode) {
+  return rawCode ? Prism.highlight(rawCode, Prism.languages['swift']) : '';
+}
+
+export { highlightSwift };

--- a/src/helpers/highlight-xml.js
+++ b/src/helpers/highlight-xml.js
@@ -1,0 +1,7 @@
+import Prism from 'prismjs';
+
+function highlightXml(rawCode) {
+  return rawCode ? Prism.highlight(rawCode, Prism.languages['markup']) : '';
+}
+
+export { highlightXml };


### PR DESCRIPTION
After reviewing https://github.com/mapbox/android-docs/pull/1037 I realized there were several other docs sites using this pattern. This PR pulls them all together in a central place and adds the same check as in https://github.com/mapbox/android-docs/pull/1037 to each to avoid errors.

@katydecorah I wasn't sure how to test these. I wanted to have something visual so I could confirm that the highlighting looked right. I made a new folder in `src/components/` that only had a `__tests__` folder (no js file with a component) so I could visually test. I feel like this is `wrong` but I think that the build script ignores the `__tests__` folder so maybe it's ok? Let me know what you think! 

![screencapture-192-168-137-202-9966-SyntaxHighlighting-2019-08-14-10_15_20](https://user-images.githubusercontent.com/10479155/63041329-746c7d80-be7c-11e9-9990-cd86c874fe86.png)
