### PR TITLE
create `npm run start-legacy` to test in IE11

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Here are some commands you'll probably want to use:
 ```bash
 # Start the test-cases app.
 npm start
-# Stare the test-cases app, compatible with IE11 (removes Search component).
+# Start the test-cases app, compatible with IE11 (removes Search component).
 npm run start-legacy
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Here are some commands you'll probably want to use:
 ```bash
 # Start the test-cases app.
 npm start
-
+# Stare the test-cases app, compatible with IE11 (removes Search component).
+npm run start-legacy
 ```
 
 Docs build process and automated testing coming soon.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "pretest": "npm run lint",
     "precommit": "lint-staged",
     "format": "prettier '**/*.js' --write",
-    "build": "scripts/build-module-indexes.js && scripts/build-package.js"
+    "build": "scripts/build-module-indexes.js && scripts/build-package.js",
+    "start-legacy": "npm run build-component-index && node scripts/rm-search.js && npm run cp-assembly && budo ./src/test-cases-app/test-cases-app.js --dir ./src/test-cases-app --live --debug --pushstate -- -t babelify"
   },
   "repository": {
     "type": "git",

--- a/scripts/rm-search.js
+++ b/scripts/rm-search.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+'use strict';
+const fs = require('fs');
+const app = fs.readFileSync('./src/test-cases-app/component-index.js', 'utf-8');
+const removeSearch = app.replace(/{ title: 'Search'.*/, '');
+fs.writeFileSync('./src/test-cases-app/component-index.js', removeSearch);

--- a/src/test-cases-app/test-cases-app.js
+++ b/src/test-cases-app/test-cases-app.js
@@ -1,3 +1,6 @@
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestKitchen from '@mapbox/react-test-kitchen';


### PR DESCRIPTION
Fixes #170

This PR adds a new script `npm run start-legacy` so that we can run the test-cases app in IE11. It's a little hacky (it uses the same script for npm run start, but removes the Search module so it doesn't get built), but I think it gets the jobs done and makes it easier for us to test.

🐌 