### PR TITLE
[WIP] iOS and Android toggleable code snippets

### DIFF
--- a/src/components/android-layout-code-block/__tests__/android-layout-code-block-test-cases.js
+++ b/src/components/android-layout-code-block/__tests__/android-layout-code-block-test-cases.js
@@ -1,0 +1,75 @@
+import AndroidLayoutCodeBlock from '../android-layout-code-block';
+
+const testCases = {};
+
+testCases.basic = {
+  component: AndroidLayoutCodeBlock,
+  description: 'Basic',
+  props: {
+    code: `<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+android:layout_width="match_parent"
+android:layout_height="match_parent">
+ 
+<com.mapbox.mapboxsdk.maps.MapView
+android:id="@+id/mapView"
+android:layout_width="match_parent"
+android:layout_height="match_parent"
+mapbox:mapbox_cameraTargetLat="38.9098"
+mapbox:mapbox_cameraTargetLng="-77.0295"
+mapbox:mapbox_cameraZoom="12" />
+ 
+<Button
+android:id="@+id/startButton"
+android:layout_width="fill_parent"
+android:layout_height="wrap_content"
+android:layout_marginStart="16dp"
+android:layout_marginLeft="16dp"
+android:layout_marginTop="16dp"
+android:layout_marginEnd="16dp"
+android:background="@color/mapboxGrayLight"
+android:enabled="false"
+android:text="Start navigation"
+android:textColor="@color/mapboxWhite"
+mapbox:layout_constraintStart_toStartOf="parent"
+mapbox:layout_constraintTop_toTopOf="parent" />
+</android.support.constraint.ConstraintLayout>`
+  }
+};
+
+testCases.custom = {
+  component: AndroidLayoutCodeBlock,
+  description: 'With link to GitHub file',
+  props: {
+    filename: 'activity_styles_runtime_styling',
+    link: '#',
+    code: `<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/runtime_mapview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        mapbox:mapbox_cameraTargetLat="19.948045"
+        mapbox:mapbox_cameraTargetLng="-84.654463"
+        mapbox:mapbox_cameraZoom="3.371717" />
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/floatingActionButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginBottom="16dp"
+        mapbox:layout_constraintBottom_toBottomOf="parent"
+        mapbox:layout_constraintEnd_toEndOf="parent" />
+
+</android.support.constraint.ConstraintLayout>`
+  }
+};
+
+export { testCases };

--- a/src/components/android-layout-code-block/__tests__/android-layout-code-block.test.js
+++ b/src/components/android-layout-code-block/__tests__/android-layout-code-block.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { testCases } from './android-layout-code-block-test-cases.js';
+
+describe('android-layout-code-block', () => {
+  describe(testCases.basic.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.basic;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe(testCases.custom.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.custom;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/android-layout-code-block/android-layout-code-block.js
+++ b/src/components/android-layout-code-block/android-layout-code-block.js
@@ -1,3 +1,10 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import CodeSnippet from '@mapbox/mr-ui/code-snippet';
+import CodeSnippetTitle from '../code-snippet-title/code-snippet-title';
+import { highlightXml } from '../../helpers/highlight-xml';
+
+let highlightTheme = `
 code[class*='language-'],
 pre[class*='language-'] {
   color: #273d56;
@@ -113,8 +120,43 @@ pre[class*='language-'] {
 .token.entity {
   cursor: help;
 }
+`;
 
-/* Line numbers */
-[data-content]::before {
-  content: attr(data-content);
+export default class AndroidLayoutCodeBlock extends React.Component {
+  renderTitle = () => {
+    const titleProps = {
+      filename: this.props.filename,
+      link: this.props.link ? this.props.link : undefined
+    };
+    return <CodeSnippetTitle {...titleProps} />;
+  };
+
+  render() {
+    return (
+      <div className="unprose my24">
+        {this.props.filename && this.renderTitle()}
+        {this.props.code && (
+          <div className="round" style={{ backgroundColor: '#f4f7fb' }}>
+            <CodeSnippet
+              code={this.props.code}
+              highlightedCode={highlightXml(this.props.code)}
+              highlightThemeCss={highlightTheme}
+              onCopy={() => {}}
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
 }
+
+AndroidLayoutCodeBlock.propTypes = {
+  /* Optional `filename` to be displayed as a kind of title for the code snippet. */
+  filename: PropTypes.string,
+  /* Optional `link` to a GitHub file. */
+  link: PropTypes.string,
+  /* Raw (unhighlighted) code. When the user clicks a copy
+  button, this is what they'll get. If no highlightedCode
+  is provided, code is displayed. */
+  code: PropTypes.string.isRequired
+};

--- a/src/components/android-layout-code-block/index.js
+++ b/src/components/android-layout-code-block/index.js
@@ -1,0 +1,3 @@
+import main from './android-layout-code-block';
+
+export default main;

--- a/src/components/code-snippet-title/__tests__/code-snippet-title-test-cases.js
+++ b/src/components/code-snippet-title/__tests__/code-snippet-title-test-cases.js
@@ -1,0 +1,22 @@
+import CodeSnippetTitle from '../code-snippet-title';
+
+const testCases = {};
+
+testCases.basic = {
+  component: CodeSnippetTitle,
+  description: 'Basic',
+  props: {
+    filename: 'MainActivity.java'
+  }
+};
+
+testCases.withLink = {
+  component: CodeSnippetTitle,
+  description: 'With a link',
+  props: {
+    filename: 'MainActivity.java',
+    link: '#'
+  }
+};
+
+export { testCases };

--- a/src/components/code-snippet-title/__tests__/code-snippet-title.test.js
+++ b/src/components/code-snippet-title/__tests__/code-snippet-title.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { testCases } from './code-snippet-title-test-cases.js';
+
+describe('code-snippet-title', () => {
+  describe(testCases.basic.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.basic;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe(testCases.withLink.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.withLink;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/code-snippet-title/code-snippet-title.js
+++ b/src/components/code-snippet-title/code-snippet-title.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Icon from '@mapbox/mr-ui/icon';
+
+export default class CodeSnippetTitle extends React.Component {
+  renderFilename = () => {
+    return (
+      <div className="txt-bold mb6" style={{ color: '#273d56' }}>
+        {this.props.filename}
+      </div>
+    );
+  };
+
+  renderLink = () => {
+    return (
+      <div className="flex-child">
+        <a className="unprose link" href={this.props.link}>
+          <Icon name="github" inline={true} /> View on GitHub
+        </a>
+      </div>
+    );
+  };
+
+  render() {
+    const { link } = this.props;
+    return (
+      <div
+        className={`${
+          link ? 'flex-parent flex-parent--space-between-main ' : ''
+        }mb6`}
+      >
+        <div className={link ? 'flex-child' : ''}>{this.renderFilename()}</div>
+        {link && <div className="flex-child">{this.renderLink()}</div>}
+      </div>
+    );
+  }
+}
+
+CodeSnippetTitle.propTypes = {
+  /* Filename to be displayed as a kind of title. Can be a specific filename like
+  `RuntimeStylingActivity.java` or a general filename like `Activity`. */
+  filename: PropTypes.string.isRequired,
+  /* Optional `link` to a GitHub file. If this is set, the rendered component
+  will include a "View on Github" link. */
+  link: PropTypes.string
+};

--- a/src/components/code-snippet-title/index.js
+++ b/src/components/code-snippet-title/index.js
@@ -1,0 +1,3 @@
+import main from './code-snippet-title';
+
+export default main;

--- a/src/components/code-toggle/__tests__/code-toggle-test-cases.js
+++ b/src/components/code-toggle/__tests__/code-toggle-test-cases.js
@@ -11,11 +11,13 @@ testCases.basic = {
     onChange: () => {},
     options: [
       {
+        label: 'Swift',
         language: 'swift',
         preferredLanguage: true
       },
       {
-        language: 'objective-c',
+        label: 'Objective-C',
+        language: 'objectiveC',
         preferredLanguage: false
       }
     ]
@@ -30,11 +32,13 @@ testCases.objectiveC = {
     onChange: () => {},
     options: [
       {
+        label: 'Swift',
         language: 'swift',
         preferredLanguage: false
       },
       {
-        language: 'objective-c',
+        label: 'Objective-C',
+        language: 'objectiveC',
         preferredLanguage: true
       }
     ]
@@ -43,25 +47,29 @@ testCases.objectiveC = {
 
 testCases.objectiveC2 = {
   component: CodeToggle,
-  description: 'Objective C preferred',
+  description: 'Java preferred',
   props: {
     id: 'three',
     onChange: () => {},
     options: [
       {
+        label: 'JavaScript',
         language: 'javascript',
         preferredLanguage: false
       },
       {
+        label: 'Java',
         language: 'java',
         preferredLanguage: true
       },
       {
+        label: 'Swift',
         language: 'swift',
         preferredLanguage: false
       },
       {
-        language: 'objective-c',
+        label: 'Objective-C',
+        language: 'objectiveC',
         preferredLanguage: false
       }
     ]

--- a/src/components/code-toggle/code-toggle.js
+++ b/src/components/code-toggle/code-toggle.js
@@ -10,7 +10,7 @@ class CodeToggle extends React.Component {
     })[0].language;
     const options = props.options.map(option => {
       return {
-        label: option.language,
+        label: option.label,
         value: option.language
       };
     });
@@ -34,13 +34,8 @@ CodeToggle.propTypes = {
   onChange: PropTypes.func.isRequired,
   options: PropTypes.arrayOf(
     PropTypes.shape({
-      language: PropTypes.oneOf([
-        'swift',
-        'objective-c',
-        'java',
-        'kotlin',
-        'javascript'
-      ]).isRequired,
+      label: PropTypes.string.isRequired,
+      language: PropTypes.string.isRequired,
       preferredLanguage: PropTypes.bool.isRequired
     })
   ).isRequired

--- a/src/components/contextless-android-activity-toggle/__tests__/contextless-android-activity-toggle-test-cases.js
+++ b/src/components/contextless-android-activity-toggle/__tests__/contextless-android-activity-toggle-test-cases.js
@@ -1,0 +1,119 @@
+import ContextlessAndroidActivityToggle from '../contextless-android-activity-toggle';
+
+const testCases = {};
+
+const contextJava = {
+  languages: {
+    android: [
+      {
+        label: 'Java',
+        value: 'java'
+      },
+      {
+        label: 'Kotlin',
+        value: 'kotlin'
+      }
+    ]
+  },
+  preferredLanguage: {
+    android: 'java'
+  },
+  changeLanguage: () => {}
+};
+
+const contextKotlin = {
+  languages: {
+    android: [
+      {
+        label: 'Java',
+        value: 'java'
+      },
+      {
+        label: 'Kotlin',
+        value: 'kotlin'
+      }
+    ]
+  },
+  preferredLanguage: {
+    android: 'kotlin'
+  },
+  changeLanguage: () => {}
+};
+
+const java = `map.getStyle(new Style.OnStyleLoaded() {
+  @Override
+  public void onStyleLoaded(@NonNull Style style) {
+  
+    Layer settlementLabelLayer = style.getLayer("settlement-label");
+    
+    if (settlementLabelLayer != null) {
+      settlementLabelLayer.setProperties(textField("{name_ru}"));
+    }
+  }
+});`;
+
+const kotlin = `map?.getStyle {
+  val settlementLabelLayer = it.getLayer("settlement-label")
+  settlementLabelLayer?.setProperties(textField("{name_ru}"))
+}`;
+
+testCases.basic = {
+  component: ContextlessAndroidActivityToggle,
+  description: 'Basic',
+  props: {
+    context: contextJava,
+    id: 'test-java-only',
+    java: java,
+    limitHeight: true,
+    onCopy: () => {}
+  }
+};
+
+testCases.twoLang = {
+  component: ContextlessAndroidActivityToggle,
+  description: 'Two languages',
+  props: {
+    context: contextJava,
+    id: 'test-java-kotlin',
+    java: java,
+    kotlin: kotlin,
+    limitHeight: true,
+    onCopy: () => {}
+  }
+};
+
+testCases.filename = {
+  component: ContextlessAndroidActivityToggle,
+  description: 'Two languages with filename',
+  props: {
+    context: contextKotlin,
+    id: 'test-java-kotlin-filename',
+    filename: 'MainActivity',
+    link: '#',
+    java: java,
+    kotlin: kotlin,
+    limitHeight: true,
+    onCopy: () => {}
+  }
+};
+
+testCases.copyRange = {
+  component: ContextlessAndroidActivityToggle,
+  description: 'Two languages with copy ranges',
+  props: {
+    context: contextKotlin,
+    id: 'test-java-kotlin-copy-range',
+    filename: 'MainActivity',
+    link: '#',
+    java: java,
+    kotlin: kotlin,
+    limitHeight: true,
+    onCopy: () => {},
+    copyRanges: {
+      java: [[3, 4]],
+      kotlin: [[2, 3]]
+    }
+  }
+};
+
+export { testCases };

--- a/src/components/contextless-android-activity-toggle/__tests__/contextless-android-activity-toggle.test.js
+++ b/src/components/contextless-android-activity-toggle/__tests__/contextless-android-activity-toggle.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { testCases } from './contextless-android-activity-toggle-test-cases.js';
+
+describe('contextless-android-activity-toggle', () => {
+  describe(testCases.basic.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.basic;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe(testCases.twoLang.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.twoLang;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/contextless-android-activity-toggle/contextless-android-activity-toggle.js
+++ b/src/components/contextless-android-activity-toggle/contextless-android-activity-toggle.js
@@ -1,0 +1,116 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ToggleableCodeBlock from '../toggleable-code-block/toggleable-code-block';
+import { highlightJava } from '../../helpers/highlight-java';
+import { highlightKotlin } from '../../helpers/highlight-kotlin';
+
+export default class ContextlessAndroidActivityToggle extends React.Component {
+  checkPreference = language => {
+    return this.props.context.preferredLanguage.android === language;
+  };
+
+  render() {
+    const {
+      context,
+      id,
+      java,
+      kotlin,
+      copyRanges,
+      filename,
+      link,
+      limitHeight
+    } = this.props;
+
+    let selectedCode = '';
+    if (context) {
+      selectedCode = this.checkPreference('kotlin') ? kotlin : java;
+    }
+
+    const snippetProps = {
+      copyRanges: copyRanges || undefined,
+      filename: filename || undefined,
+      link: link || undefined,
+      options:
+        kotlin && java
+          ? [
+              {
+                label: 'Java',
+                language: 'java',
+                preferredLanguage: this.checkPreference('java')
+              },
+              {
+                label: 'Kotlin',
+                language: 'kotlin',
+                preferredLanguage: this.checkPreference('kotlin')
+              }
+            ]
+          : undefined
+    };
+
+    return (
+      <div className="my24">
+        <ToggleableCodeBlock
+          {...snippetProps}
+          id={id}
+          code={selectedCode}
+          highlightedCode={
+            this.checkPreference('kotlin')
+              ? highlightKotlin(selectedCode)
+              : highlightJava(selectedCode)
+          }
+          changeLanguage={context.changeLanguage['android']}
+          limitHeight={limitHeight}
+          selectedLanguage={context.preferredLanguage.android}
+        />
+      </div>
+    );
+  }
+}
+
+ContextlessAndroidActivityToggle.propTypes = {
+  /* Intended to be hooked up to `context` in the format
+  used throughout Mapbox docs sites. */
+  context: PropTypes.shape({
+    languages: PropTypes.shape({
+      android: PropTypes.arrayOf(
+        PropTypes.shape({
+          label: PropTypes.oneOf(['Kotlin', 'Java']).isRequired,
+          value: PropTypes.oneOf(['kotlin', 'java']).isRequired
+        }).isRequired
+      ).isRequired
+    }).isRequired,
+    preferredLanguage: PropTypes.shape({
+      android: PropTypes.oneOf(['kotlin', 'java']).isRequired
+    }).isRequired,
+    changeLanguage: PropTypes.shape({
+      android: PropTypes.func.isRequired
+    }).isRequired
+  }).isRequired,
+  /* A unique `id` is required for the language toggle. */
+  id: PropTypes.string.isRequired,
+  /* Every code snippet must include raw Java code. */
+  java: PropTypes.string.isRequired,
+  /* Optionally, the code snippet can include raw Kotlin code.
+  If this is included, the language toggle will be displayed. */
+  kotlin: PropTypes.string,
+  /* Optional code ranges can be included to highlight specific
+  lines within the code snippet. */
+  copyRanges: PropTypes.shape({
+    /* Lines that should be highlighted when the Java code is displayed.
+    This is an array of arrays. For example, `[[2,3],[5,10]]` indicates that
+    lines 2-3 and 5-10 should be highlighted. */
+    java: PropTypes.array,
+    /* Lines that should be highlighted when the Kotlin code is displayed.
+    This is an array of arrays. For example, `[[2,3],[5,10]]` indicates that
+    lines 2-3 and 5-10 should be highlighted. */
+    kotlin: PropTypes.array
+  }),
+  /* Optional `filename` to be displayed as a kind of title for the code snippet. */
+  filename: PropTypes.string,
+  /* Optional `link` to a GitHub file. */
+  link: PropTypes.string,
+  /* Whether or not a code snippet's height should be limited. Typically
+  inline code snippets should be set to `true` and code snippets on examples
+  pages should be set to `false`. Default is `true`. */
+  limitHeight: PropTypes.bool
+};

--- a/src/components/contextless-android-activity-toggle/index.js
+++ b/src/components/contextless-android-activity-toggle/index.js
@@ -1,0 +1,3 @@
+import main from './contextless-android-activity-toggle';
+
+export default main;

--- a/src/components/contextless-ios-view-controller-toggle/__tests__/contextless-ios-view-controller-toggle-test-cases.js
+++ b/src/components/contextless-ios-view-controller-toggle/__tests__/contextless-ios-view-controller-toggle-test-cases.js
@@ -1,0 +1,109 @@
+import ContextlessIosViewControllerToggle from '../contextless-ios-view-controller-toggle';
+
+const testCases = {};
+
+const contextSwift = {
+  languages: {
+    ios: [
+      {
+        label: 'Swift',
+        value: 'swift'
+      },
+      {
+        label: 'Objective-C',
+        value: 'objectiveC'
+      }
+    ]
+  },
+  preferredLanguage: {
+    ios: 'swift'
+  },
+  changeLanguage: () => {}
+};
+
+const contextObjectiveC = {
+  languages: {
+    ios: [
+      {
+        label: 'Swift',
+        value: 'swift'
+      },
+      {
+        label: 'Objective-C',
+        value: 'objectiveC'
+      }
+    ]
+  },
+  preferredLanguage: {
+    ios: 'objectiveC'
+  },
+  changeLanguage: () => {}
+};
+
+const swift = `// 'style' in this case refers to an MGLStyle object.
+let layer = style.layer(withIdentifier: "place-city-sm") as! MGLSymbolStyleLayer
+let spanish = Locale(identifier: "es")
+layer.text = layer.text.mgl_expressionLocalized(into: spanish)`;
+
+const objectiveC = `// 'style' in this case refers to an MGLStyle object.
+MGLSymbolStyleLayer *layer = (MGLSymbolStyleLayer *)[style layerWithIdentifier:@"place-city-sm"];
+NSLocale *spanish = [NSLocale localeWithLocaleIdentifier:@"es"];
+layer.text = [layer.text mgl_expressionLocalizedIntoLocale:spanish];`;
+
+testCases.basic = {
+  component: ContextlessIosViewControllerToggle,
+  description: 'Basic',
+  props: {
+    context: contextSwift,
+    id: 'test-java-only',
+    swift: swift,
+    limitHeight: true,
+    onCopy: () => {}
+  }
+};
+
+testCases.twoLang = {
+  component: ContextlessIosViewControllerToggle,
+  description: 'Two languages',
+  props: {
+    context: contextSwift,
+    id: 'test-java-kotlin',
+    swift: swift,
+    objectiveC: objectiveC,
+    limitHeight: true
+  }
+};
+
+testCases.filename = {
+  component: ContextlessIosViewControllerToggle,
+  description: 'Two languages with filename',
+  props: {
+    context: contextObjectiveC,
+    id: 'test-java-kotlin-filename',
+    filename: 'ViewController',
+    link: '#',
+    swift: swift,
+    objectiveC: objectiveC,
+    limitHeight: true
+  }
+};
+
+testCases.copyRange = {
+  component: ContextlessIosViewControllerToggle,
+  description: 'Two languages with copy ranges',
+  props: {
+    context: contextObjectiveC,
+    id: 'test-java-kotlin-copy-range',
+    filename: 'ViewController',
+    link: '#',
+    swift: swift,
+    objectiveC: objectiveC,
+    limitHeight: true,
+    copyRanges: {
+      swift: [[3, 4]],
+      objectiveC: [[2, 3]]
+    }
+  }
+};
+
+export { testCases };

--- a/src/components/contextless-ios-view-controller-toggle/__tests__/contextless-ios-view-controller-toggle.test.js
+++ b/src/components/contextless-ios-view-controller-toggle/__tests__/contextless-ios-view-controller-toggle.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { testCases } from './contextless-ios-view-controller-toggle-test-cases.js';
+
+describe('contextless-ios-view-controller-toggle', () => {
+  describe(testCases.basic.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.basic;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe(testCases.twoLang.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.twoLang;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/contextless-ios-view-controller-toggle/contextless-ios-view-controller-toggle.js
+++ b/src/components/contextless-ios-view-controller-toggle/contextless-ios-view-controller-toggle.js
@@ -1,0 +1,112 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ToggleableCodeBlock from '../toggleable-code-block/toggleable-code-block';
+import { highlightSwift } from '../../helpers/highlight-swift';
+import { highlightObjectivec } from '../../helpers/highlight-objectivec';
+
+export default class ContextlessIosViewControllerToggle extends React.Component {
+  static defaultProps = {
+    limitHeight: true
+  };
+
+  render() {
+    const { id, context, objectiveC, swift, limitHeight } = this.props;
+
+    let selectedCode = '';
+    if (context) {
+      selectedCode =
+        this.props.context.preferredLanguage.ios === 'objectiveC'
+          ? objectiveC
+          : swift;
+    }
+
+    const snippetProps = {
+      copyRanges: this.props.copyRanges || undefined,
+      filename: this.props.filename || undefined,
+      link: this.props.link || undefined,
+      options:
+        objectiveC && swift
+          ? [
+              {
+                label: 'Swift',
+                language: 'swift',
+                preferredLanguage:
+                  this.props.context.preferredLanguage.ios === 'swift'
+              },
+              {
+                label: 'Objective-C',
+                language: 'objectiveC',
+                preferredLanguage:
+                  this.props.context.preferredLanguage.ios === 'objectiveC'
+              }
+            ]
+          : undefined
+    };
+
+    return (
+      <div className="my24">
+        <ToggleableCodeBlock
+          {...snippetProps}
+          id={id}
+          code={selectedCode}
+          highlightedCode={
+            this.props.context.preferredLanguage.ios === 'objectiveC'
+              ? highlightObjectivec(selectedCode)
+              : highlightSwift(selectedCode)
+          }
+          changeLanguage={context.changeLanguage['ios']}
+          limitHeight={limitHeight}
+          selectedLanguage={context.preferredLanguage.ios}
+        />
+      </div>
+    );
+  }
+}
+
+ContextlessIosViewControllerToggle.propTypes = {
+  /* Intended to be hooked up to `context` in the format
+  used throughout Mapbox docs sites. */
+  context: PropTypes.shape({
+    languages: PropTypes.shape({
+      ios: PropTypes.arrayOf(
+        PropTypes.shape({
+          label: PropTypes.oneOf(['Objective-C', 'Swift']).isRequired,
+          value: PropTypes.oneOf(['objectiveC', 'swift']).isRequired
+        }).isRequired
+      ).isRequired
+    }).isRequired,
+    preferredLanguage: PropTypes.shape({
+      ios: PropTypes.oneOf(['objectiveC', 'swift']).isRequired
+    }).isRequired,
+    changeLanguage: PropTypes.shape({
+      ios: PropTypes.func.isRequired
+    }).isRequired
+  }).isRequired,
+  /* A unique `id` is required for the language toggle. */
+  id: PropTypes.string.isRequired,
+  /* Every code snippet must include raw Swift code. */
+  swift: PropTypes.string.isRequired,
+  /* Optionally, the code snippet can include raw Objective-C code.
+  If this is included, the language toggle will be displayed. */
+  objectiveC: PropTypes.string,
+  /* Optional code ranges can be included to highlight specific
+  lines within the code snippet. */
+  copyRanges: PropTypes.shape({
+    /* Lines that should be highlighted when the Swift code is displayed.
+    This is an array of arrays. For example, `[[2,3],[5,10]]` indicates that
+    lines 2-3 and 5-10 should be highlighted. */
+    swift: PropTypes.array,
+    /* Lines that should be highlighted when the Objective-C code is displayed.
+    This is an array of arrays. For example, `[[2,3],[5,10]]` indicates that
+    lines 2-3 and 5-10 should be highlighted. */
+    objectiveC: PropTypes.array
+  }),
+  /* Optional `filename` to be displayed as a kind of title for the code snippet. */
+  filename: PropTypes.string,
+  /* Optional `link` to a GitHub file. */
+  link: PropTypes.string,
+  /* Whether or not a code snippet's height should be limited. Typically
+  inline code snippets should be set to `true` and code snippets on examples
+  pages should be set to `false`. Default is `true`. */
+  limitHeight: PropTypes.bool
+};

--- a/src/components/contextless-ios-view-controller-toggle/index.js
+++ b/src/components/contextless-ios-view-controller-toggle/index.js
@@ -1,0 +1,3 @@
+import main from './contextless-ios-view-controller-toggle';
+
+export default main;

--- a/src/components/numbered-code-snippet/__tests__/numbered-code-snippet-test-cases.js
+++ b/src/components/numbered-code-snippet/__tests__/numbered-code-snippet-test-cases.js
@@ -1,3 +1,14 @@
+import NumberedCodeSnippet from '../numbered-code-snippet';
+import { highlightSwift } from '../../../helpers/highlight-swift';
+
+const testCases = {};
+
+const code = `// 'style' in this case refers to an MGLStyle object.
+let layer = style.layer(withIdentifier: "place-city-sm") as! MGLSymbolStyleLayer
+let spanish = Locale(identifier: "es")
+layer.text = layer.text.mgl_expressionLocalized(into: spanish)`;
+
+let highlightTheme = `
 code[class*='language-'],
 pre[class*='language-'] {
   color: #273d56;
@@ -113,8 +124,19 @@ pre[class*='language-'] {
 .token.entity {
   cursor: help;
 }
+`;
 
-/* Line numbers */
-[data-content]::before {
-  content: attr(data-content);
-}
+testCases.basic = {
+  component: NumberedCodeSnippet,
+  description: 'Basic',
+  props: {
+    code: code,
+    highlightedCode: highlightSwift(code),
+    maxHeight: 450,
+    highlightThemeCss: highlightTheme,
+    copyRanges: [[2, 3]],
+    onCopy: () => {}
+  }
+};
+
+export { testCases };

--- a/src/components/numbered-code-snippet/__tests__/numbered-code-snippet.test.js
+++ b/src/components/numbered-code-snippet/__tests__/numbered-code-snippet.test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { testCases } from './numbered-code-snippet-test-cases.js';
+
+describe('numbered-code-snippet', () => {
+  describe(testCases.basic.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.basic;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/numbered-code-snippet/index.js
+++ b/src/components/numbered-code-snippet/index.js
@@ -1,0 +1,3 @@
+import main from './numbered-code-snippet';
+
+export default main;

--- a/src/components/numbered-code-snippet/numbered-code-snippet.js
+++ b/src/components/numbered-code-snippet/numbered-code-snippet.js
@@ -1,0 +1,323 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import debounce from 'debounce';
+import classnames from 'classnames';
+import CopyButton from '@mapbox/mr-ui/copy-button';
+
+function getWindow() {
+  if (typeof window === undefined) {
+    throw new Error('window not available');
+  }
+  return window;
+}
+
+// Theme cache, used to prevent the creation of multiple <style> elements with the same content.
+const injectedThemes = [];
+
+export default class NumberedCodeSnippet extends React.PureComponent {
+  static propTypes = {
+    /** Raw (unhighlighted) code. When the user clicks a copy button, this is what they'll get. If no `highlightedCode` is provided, `code` is displayed. */
+    code: PropTypes.string.isRequired,
+    /** The HTML output of running code through a syntax highlighter. If this is not provided, `code` is displayed, instead. The default theme CSS assumes the highlighter is [`highlight.js`](https://github.com/isagalaev/highlight.js). If you are using another highlighter, provide your own theme. */
+    highlightedCode: PropTypes.string,
+    /** Specific line ranges that should be independently copiable. Each range is a two-value array, consisting of the starting and ending line. If this is not provided, the entire snippet is copiable. */
+    copyRanges: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
+    /** A maximum height for the snippet. If the code exceeds this height, the snippet will scroll internally. */
+    maxHeight: PropTypes.number,
+    /** A callback that is invoked when the snippet (or a chunk of the snippet) is copied. If `copyRanges` are provided, the callback is passed the index (0-based) of the chunk that was copied. */
+    onCopy: PropTypes.func,
+    /** CSS that styles the highlighted code. The default theme is a [`highlight.js` theme](https://highlightjs.readthedocs.io/en/latest/style-guide.html#defining-a-theme) theme. It is the dark theme used on mapbox.com's installation flow. */
+    highlightThemeCss: PropTypes.string.isRequired,
+    /** The width of a character in the theme's monospace font, used for indentation. If you use a font or font-size different than the default theme, you may need to change this value. */
+    characterWidth: PropTypes.number,
+    /** If the first live chunk (from the `copyRanges` prop) is not visible in the snippet given the `maxHeight`, then autoscroll to make sure the live chunk is in view when the page loads. **/
+    scrollToLive: PropTypes.bool
+  };
+
+  static defaultProps = {
+    characterWidth: 7.225, // Will need to change this if we change font size
+    scrollToLive: true
+  };
+
+  componentDidMount() {
+    this.adjustPositions();
+    getWindow().addEventListener('resize', this.adjustPositions);
+
+    const theme = this.props.highlightThemeCss;
+
+    // Do not load themes that have already been injected.
+    if (injectedThemes.indexOf(theme) !== -1) return;
+    injectedThemes.push(theme);
+    const doc = getWindow().document;
+    this.styleTag = doc.createElement('style');
+    this.styleTag.innerHTML = theme;
+    doc.head.appendChild(this.styleTag);
+  }
+
+  componentDidUpdate() {
+    this.adjustPositions();
+    if (this.props.scrollToLive && this.props.maxHeight) {
+      let offsetFromTop = null;
+      if (this.firstLiveElement && this.firstLiveElement.offsetTop !== null) {
+        /* Get the offset from top of parent element. */
+        offsetFromTop = this.firstLiveElement.offsetTop;
+        if (this.firstLiveElement.offsetParent) {
+          this.firstLiveElement.offsetParent.scrollTop = offsetFromTop - 18;
+        }
+      }
+    }
+  }
+
+  componentWillUnmount() {
+    getWindow().removeEventListener('resize', this.adjustPositions);
+  }
+
+  adjustPositions = debounce(() => {
+    const { containerElement } = this;
+    if (!containerElement) return;
+
+    const chunkOverlays = containerElement.querySelectorAll(
+      '[data-chunk-overlay]'
+    );
+    for (let i = 0, l = chunkOverlays.length; i < l; i++) {
+      const overlayElement = chunkOverlays[i];
+      const chunkId = overlayElement.getAttribute('data-chunk-overlay');
+      const codeElement = containerElement.querySelector(
+        `[data-chunk-code="${chunkId}"]`
+      );
+      if (!codeElement)
+        throw new Error(
+          `No code element found with [data-chunk-code="${chunkId}"]`
+        );
+      const copyElement = containerElement.querySelector(
+        `[data-chunk-copy="${chunkId}"]`
+      );
+      if (!copyElement)
+        throw new Error(
+          `No copy element found with [data-chunk-copy="${chunkId}"]`
+        );
+
+      overlayElement.style.top = `${codeElement.offsetTop}px`;
+      copyElement.style.top = `${codeElement.offsetTop + 2}px`;
+      overlayElement.style.height = `${codeElement.clientHeight}px`;
+
+      // Since these elements move into position a split-second after the component
+      // mounts and renders, we'll fade them in after they're positioned
+      overlayElement.style.opacity = '1';
+      copyElement.style.opacity = '1';
+    }
+  }, 300);
+
+  onContainerElement = element => {
+    this.containerElement = element;
+  };
+
+  onFirstLive = element => {
+    this.firstLiveElement = element;
+  };
+
+  render() {
+    const { props } = this;
+
+    const rawCodeLines = props.code.trim().split('\n');
+    // If highlightedCode is not provided, show raw code.
+    const displayCode = props.highlightedCode || props.code;
+    const splitDisplayCode = displayCode.trim().split('\n');
+
+    // Use copyRanges to split the highlighted code into chunks,
+    // some of which are "live", i.e. copyable, some which are not.
+    // If there are no copyRanges, the whole snippet is copyable and there
+    // is no fancy live-chunk styling.
+    const mutableCopyRanges =
+      props.copyRanges !== undefined && props.copyRanges.slice();
+    let currentLiveRange = mutableCopyRanges && mutableCopyRanges.shift();
+    let currentChunk = [];
+    const allChunks = [];
+    const endCurrentChunk = ({ live }) => {
+      allChunks.push({
+        live,
+        highlightedLines: currentChunk.map(line => line.highlighted),
+        raw: currentChunk.reduce(
+          (result, line) => (result += line.raw + '\n'),
+          ''
+        ),
+        element: undefined
+      });
+      currentChunk = [];
+    };
+    for (let i = 0, l = splitDisplayCode.length; i < l; i++) {
+      const chunk = splitDisplayCode[i];
+      const lineNumber = i + 1;
+      if (currentLiveRange && lineNumber === currentLiveRange[0]) {
+        endCurrentChunk({ live: false });
+      } else if (currentLiveRange && lineNumber > currentLiveRange[1]) {
+        endCurrentChunk({ live: true });
+        currentLiveRange = mutableCopyRanges && mutableCopyRanges.shift();
+      }
+      currentChunk.push({
+        highlighted: chunk,
+        raw: rawCodeLines[i]
+      });
+    }
+    if (currentChunk.length) {
+      endCurrentChunk({ live: false });
+    }
+
+    const codeElements = [];
+    const highlightElements = [];
+    const copyElements = [];
+    let previousCount = 0;
+    let liveChunkCount = -1; // Incremented to give CopyButtons an identifier
+    allChunks.forEach((codeChunk, i) => {
+      const chunkId = `chunk-${i}`;
+
+      const lineEls = codeChunk.highlightedLines.map((line, i) => {
+        // Left padding is determined below
+        let lineClasses = 'pr12';
+        if (codeChunk.live) lineClasses += ' py3';
+        if (!codeChunk.live && props.copyRanges !== undefined)
+          lineClasses += ' opacity50 bg-darken10';
+
+        // Remove leading spaces, which are replaced with padding to avoid
+        // weird behaviors that occur when there are long unbroken strings:
+        // a line break might be introduced between the leading spaces and the
+        // long word, creating an empty line that nobody wanted.
+        const indentingSpacesMatch = line.match(/^[ ]*/);
+        const indentingSpaces = indentingSpacesMatch
+          ? indentingSpacesMatch[0]
+          : '';
+        const indentingSpacesCount = indentingSpaces.length;
+        const paddingLeft = indentingSpacesCount * props.characterWidth + 12;
+        const displayLine = line.replace(/^[ ]*/, '');
+
+        const lineNumberClasses = classnames(
+          'absolute fl color-gray-light align-r pr6',
+          {
+            'w30 py3': codeChunk.live,
+            w36: !codeChunk.live
+          }
+        );
+        let blueLineWidth = 0;
+        if (codeChunk.live) blueLineWidth = 6;
+
+        /* eslint-disable react/no-danger */
+        return (
+          <div key={i} className={lineClasses} style={{ paddingLeft }}>
+            <div
+              className={lineNumberClasses}
+              unselectable="on"
+              style={{
+                marginLeft: -1 * (paddingLeft - blueLineWidth),
+                marginTop: -1 * (blueLineWidth / 2)
+              }}
+              data-content={previousCount + i + 1}
+            />
+            <div
+              // We must use dangerouslySetInnerHTML because we've already
+              // highlighted the code with lowlight, so we have an HTML string
+              dangerouslySetInnerHTML={{ __html: displayLine || ' ' }}
+              // Super fancy hanging indent
+              style={{
+                textIndent: -2 * props.characterWidth,
+                marginLeft: 6 * props.characterWidth
+              }}
+            />
+          </div>
+        );
+        /* eslint-enable react/no-danger */
+      });
+
+      /* For the first live chunk, add a ref. */
+      if (codeChunk.live && i < 2) {
+        codeElements.push(
+          <div
+            key={i}
+            // z-index this line above the highlighted background element for
+            // live chunks
+            ref={this.onFirstLive}
+            className="relative z2"
+            data-chunk-code={chunkId}
+          >
+            {lineEls}
+          </div>
+        );
+      } else {
+        codeElements.push(
+          <div
+            key={i}
+            // z-index this line above the highlighted background element for
+            // live chunks
+            className="relative z2"
+            data-chunk-code={chunkId}
+          >
+            {lineEls}
+          </div>
+        );
+      }
+
+      if (codeChunk.live) {
+        highlightElements.push(
+          <div
+            key={i}
+            data-chunk-overlay={chunkId}
+            className="bg-lighten50 absolute left right"
+            style={{ opacity: 0 }}
+          >
+            <div className="bg-blue h-full w6" />
+          </div>
+        );
+
+        const chunkIndex = ++liveChunkCount;
+        const onCopyChunk = () => this.props.onCopy(chunkIndex);
+
+        if (props.onCopy) {
+          copyElements.push(
+            <div
+              key={i}
+              data-chunk-copy={chunkId}
+              className="absolute z3 right mr3 color-white"
+              style={{ opacity: 0, transition: 'opacity 300ms linear' }}
+            >
+              <CopyButton text={codeChunk.raw} onCopy={onCopyChunk} />
+            </div>
+          );
+        }
+      }
+      previousCount = previousCount + lineEls.length;
+    });
+
+    // Prevent the default x-axis padding because each line pads itself
+    let codeClasses = 'px0 hljs';
+
+    let copyAllButton = null;
+    if (props.copyRanges === undefined && props.onCopy) {
+      copyAllButton = (
+        <div className="absolute z2 top right mr6 mt6 color-white">
+          <CopyButton text={props.code} onCopy={props.onCopy} />
+        </div>
+      );
+    }
+
+    let containerClasses = 'relative round z0 scroll-styled';
+    if (props.maxHeight !== undefined) containerClasses += ' scroll-auto';
+
+    const containerStyles = {};
+    if (props.maxHeight !== undefined)
+      containerStyles.maxHeight = props.maxHeight;
+
+    return (
+      <div
+        className={containerClasses}
+        ref={this.onContainerElement}
+        style={{ ...containerStyles, backgroundColor: '#f4f7fb' }}
+      >
+        <pre className="my-neg12 py12 ml-neg12 pl12 mobile-snippet">
+          <code className={codeClasses}>{codeElements}</code>
+        </pre>
+        {copyAllButton}
+        {highlightElements}
+        {copyElements}
+      </div>
+    );
+  }
+}

--- a/src/components/toggleable-code-block/toggleable-code-block.js
+++ b/src/components/toggleable-code-block/toggleable-code-block.js
@@ -1,52 +1,227 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import CodeSnippet from '@mapbox/mr-ui/code-snippet';
+import NumberedCodeSnippet from '../numbered-code-snippet/numbered-code-snippet';
+import CodeSnippetTitle from '../code-snippet-title/code-snippet-title';
+import CodeToggle from '../code-toggle/code-toggle';
 
-class ToggleableCodeBlock extends React.Component {
-  constructor(props) {
-    super(props);
-    let prefLanguage = 'swift';
-    if (prefLanguage !== 'swift' && prefLanguage !== 'objective-c') {
-      prefLanguage = 'swift';
-    }
-    this.state = {
-      toggleValue: prefLanguage
+let highlightTheme = `
+code[class*='language-'],
+pre[class*='language-'] {
+  color: #273d56;
+  background: none;
+  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  line-height: 1.5;
+
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+}
+
+/* Code blocks */
+pre[class*='language-'] {
+  padding: 1em;
+  margin: 0.5em 0;
+  overflow: auto;
+  border-radius: 0.3em;
+}
+
+:not(pre) > code[class*='language-'],
+pre[class*='language-'] {
+  background: #272822;
+}
+
+/* Inline code */
+:not(pre) > code[class*='language-'] {
+  padding: 0.1em;
+  border-radius: 0.3em;
+  white-space: normal;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #53708e;
+}
+
+.token.punctuation {
+  color: #273d56;
+}
+
+.namespace {
+  opacity: 0.7;
+}
+
+.token.property,
+.token.tag,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #314ccd;
+}
+
+.token.boolean,
+.token.number {
+  color: #7753eb;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #ce2c69;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string,
+.token.variable {
+  color: #273d56;
+}
+
+.token.atrule,
+.token.attr-value,
+.token.function,
+.token.class-name {
+  color: #4264fb;
+}
+
+.token.keyword {
+  color: #314ccd;
+}
+
+.token.regex,
+.token.important {
+  color: #fd971f;
+}
+
+.token.important,
+.token.bold {
+  font-weight: bold;
+}
+.token.italic {
+  font-style: italic;
+}
+
+.token.entity {
+  cursor: help;
+}
+
+[data-content]::before {
+  content: attr(data-content);
+}
+`;
+
+export default class ToggleableCodeBlock extends React.Component {
+  static defaultProps = {
+    limitHeight: true
+  };
+
+  renderSnippet = code => {
+    const {
+      highlightedCode,
+      limitHeight,
+      copyRanges,
+      selectedLanguage
+    } = this.props;
+    const snippetProps = {
+      code: code,
+      highlightedCode: highlightedCode,
+      maxHeight: limitHeight ? 480 : undefined,
+      highlightThemeCss: highlightTheme,
+      onCopy: () => {}
     };
-  }
+    if (copyRanges) {
+      snippetProps.copyRanges = copyRanges[selectedLanguage];
+      return <NumberedCodeSnippet {...snippetProps} />;
+    } else {
+      return <CodeSnippet {...snippetProps} />;
+    }
+  };
+
+  renderTitle = () => {
+    const { filename, link } = this.props;
+    const titleProps = {
+      filename: filename,
+      link: link ? link : undefined
+    };
+    return <CodeSnippetTitle {...titleProps} />;
+  };
+
+  renderToggle = () => {
+    const { id, changeLanguage, options } = this.props;
+    return (
+      <div className="mb12">
+        <CodeToggle
+          id={id}
+          onChange={value => {
+            changeLanguage(value);
+          }}
+          options={options}
+        />
+      </div>
+    );
+  };
+
+  checkPreference = language => {
+    const { selectedLanguage } = this.props;
+    return selectedLanguage === language;
+  };
 
   render() {
-    const { props } = this;
-    const currentCodeSnippet = props.codeSnippet.filter(snippet => {
-      return snippet.preferredLanguage === true;
-    })[0];
-    const renderedCodeBlock = (
-      <CodeSnippet
-        style={{ background: '#273d56' }}
-        code={currentCodeSnippet.rawCode}
-        highlightedCode={currentCodeSnippet.highlightedCode}
-        maxHeight={480}
-        onCopy={() => {}}
-      />
+    const { filename, options, code } = this.props;
+
+    return (
+      <div className="my24">
+        {filename && this.renderTitle()}
+        {options && options.length > 1 ? this.renderToggle() : ''}
+        {code && this.renderSnippet(code)}
+      </div>
     );
-    return <div>{renderedCodeBlock}</div>;
   }
 }
 
 ToggleableCodeBlock.propTypes = {
-  codeSnippet: PropTypes.arrayOf(
-    PropTypes.shape({
-      language: PropTypes.oneOf([
-        'swift',
-        'objective-c',
-        'java',
-        'kotlin',
-        'javascript'
-      ]),
-      rawCode: PropTypes.string.isRequired,
-      highlightedCode: PropTypes.string.isRequired,
-      preferredLanguage: PropTypes.bool.isRequired
-    })
-  ).isRequired
+  /* A unique `id` is required for the language toggle. */
+  id: PropTypes.string.isRequired,
+  /*  */
+  selectedLanguage: PropTypes.string.isRequired,
+  /* Raw (unhighlighted) code. When the user clicks a copy
+  button, this is what they'll get. If no highlightedCode
+  is provided, code is displayed. */
+  code: PropTypes.string.isRequired,
+  /* The HTML output of running code through a syntax highlighter.
+  This should use a /helper/higlight-* function. */
+  highlightedCode: PropTypes.string.isRequired,
+  /* Optional ranges can be included to highlight specific lines within
+  the code snippet. This is an array of arrays. For example, 
+  `[[2,3],[5,10]]` indicates that lines 2-3 and 5-10 should be highlighted. */
+  copyRanges: PropTypes.object,
+  /* Languages to be toggled. */
+  options: PropTypes.array,
+  /* What should happen when the language is toggled. */
+  changeLanguage: PropTypes.func,
+  /* Optional `filename` to be displayed as a kind of title for the code snippet. */
+  filename: PropTypes.string,
+  /* Optional `link` to a GitHub file. */
+  link: PropTypes.string,
+  /* Whether or not a code snippet's height should be limited. Typically
+  inline code snippets should be set to `true` and code snippets on examples
+  pages should be set to `false`. Default is `true`. */
+  limitHeight: PropTypes.bool
 };
-
-export default ToggleableCodeBlock;

--- a/src/helpers/highlight-kotlin.js
+++ b/src/helpers/highlight-kotlin.js
@@ -1,0 +1,8 @@
+import Prism from 'prismjs';
+import 'prismjs/components/prism-kotlin';
+
+function highlightKotlin(rawCode) {
+  return rawCode ? Prism.highlight(rawCode, Prism.languages['kotlin']) : '';
+}
+
+export { highlightKotlin };

--- a/src/util/get-window.js
+++ b/src/util/get-window.js
@@ -1,0 +1,9 @@
+// For the purposes of correctly mocking the window object in Jest,
+// this is a safe way of returning it for tests to work as expected.
+export default function getWindow() {
+  if (typeof window === undefined) {
+    throw new Error('window not available');
+  }
+
+  return window;
+}


### PR DESCRIPTION
## Background

We have a lot of code throughout docs repos for creating toggleable code snippets especially for Android (Java/Kotlin) and iOS (Swift/Objective-C). I don't think we can use a purely dr-ui component if we want to hook these toggles up to [context](https://reactjs.org/docs/context.html), but here I've modified the `ToggleableCodeBlock` component to be used with a `ContextlessAndroidActivityToggle` and `ContextlessIosViewControllerToggle` component. 

## What's included

- **[new] `CodeSnippetTitle`** so there is a consistent format for adding the filename for a code block (for example, distinguishing between the `Layout` and `Activity` code snippets for Android projects). This also includes an optional `link` prop that, when included, adds a "View on GiHub" link that leads to the relevant GitHub file for additional context.
- **[modified] `CodeToggle`** for toggling between programming languages.
- **[modified] `ToggleableCodeBlock`** programming-language-agnostic component that includes logic for whether or not to include a `CodeSnippetTitle` (only if a `filename` prop is provided) and `CodeToggle` (only if more than one language is provided via the `options` prop).
- **[new] `ContextlessAndroidActivityToggle`** that styles the `ToggleableCodeSnippet` specifically for toggling between Activity code written in Java and Kotlin. This reduces the number of decisions that needs to be made at the Markdown file level.
- **[new] `ContextlessIosViewControllerToggle`** that styles the `ToggleableCodeSnippet` specifically for toggling between ViewController code written in Swift and Objective-C. This reduces the number of decisions that needs to be made at the Markdown file level.
- **[new] `NumberedCodeSnippet`** for displaying line numbers and styling designated `copyRanges` inside snippets. This is currently used in mobile /help tutorials. This is used instead of a generic mr-ui `CodeSnippet` when `copyRanges` are specified.
- **[modified] `prism.css`** to add styling for numbered lines in the `NumberedCodeSnippet` component.
- **[new] `AndroidLayoutCodeBlock`** to make a consistently styled code block that includes auto XML highlighting and an option for adding a `CodeSnippetTitle` (including a link to "View on GitHub").
- **[new] `highlight-kotlin`** to add syntax highlighting for Kotlin code snippets.

## Changes at the repo level

- [ ] The two `Contextless*` components are designed to consume context in each individual repo. We will need to:
    - [ ] Update the context format in each repo.
    - [ ] Develop tests that ensure toggle-language-related context items in individual repos are formatted correctly. 
- [ ] Create context-consuming components in each repo.
- [ ] Modify all instances of code blocks in Markdown files.

## Questions

- How can we import prism.css into the `ToggleableCodeSnippet` component? I get an error when using `raw-loader` (syntax error), but it works as expected when the same content is hardcoded in the component as a string.
- Can we simplify `NumberedCodeSnippet`?

## Next steps

👋  @katydecorah would you be up for looking at the proposed approach? I'll work on push a branch to `ios-sdk`, `android-docs`, and `help` to test in context, then request a more in-depth review. 🙂 
