### PR TITLE
[Feedback] send `environment` and `location` with feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Master
 
-* Add `environment` and `host` (`window.location`) to the request in `Feedback`. [#184](https://github.com/mapbox/dr-ui/pull/184)
+* Add `environment` and `location` to the request in `Feedback`. [#184](https://github.com/mapbox/dr-ui/pull/184)
 
 ## 0.21.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Changelog
+
+## Master
+
+* Add `environment` and `host` (`window.location`) to the request in `Feedback`. [#184](https://github.com/mapbox/dr-ui/pull/184)
+
 ## 0.21.0
 
 * Add `Video` component. [#176](https://github.com/mapbox/dr-ui/pull/176)

--- a/src/components/feedback/feedback.js
+++ b/src/components/feedback/feedback.js
@@ -5,6 +5,7 @@ import forwardEvent from './forward-event';
 import uuidv4 from 'uuid/v4';
 import Icon from '@mapbox/mr-ui/icon';
 import { detect } from 'detect-browser';
+import getWindow from '@mapbox/mr-ui/utils/get-window';
 
 const anonymousId = uuidv4(); // creates an anonymousId fallback if user is not logged or we cant get their info
 
@@ -56,7 +57,11 @@ class Feedback extends React.Component {
         feedback: this.state.feedback, // (optional) textarea feedback
         page: this.props.location || undefined, // get page context
         userId: this.props.userName || undefined, // set user if available
-        preferredLanguage: this.props.preferredLanguage || undefined // set user preferred lanuage if available
+        preferredLanguage: this.props.preferredLanguage || undefined, // set user preferred lanuage if available
+        environment: /(^|\S+\.)mapbox\.com/.test(getWindow().location.host)
+          ? 'production'
+          : 'staging', // staging or production
+        host: getWindow().location || undefined // pull full window.location
       }
     };
     // if user is logged in then associate feedback with them

--- a/src/components/feedback/feedback.js
+++ b/src/components/feedback/feedback.js
@@ -61,7 +61,7 @@ class Feedback extends React.Component {
         environment: /(^|\S+\.)mapbox\.com/.test(getWindow().location.host)
           ? 'production'
           : 'staging', // staging or production
-        host: getWindow().location || undefined // pull full window.location
+        location: getWindow().location || undefined // pull full window.location
       }
     };
     // if user is logged in then associate feedback with them


### PR DESCRIPTION
This PR adds:

* `environment`: staging or production. This uses the same logic that we use to determine which webhook to send the request to.
* `location`: this provides the `window.location` object for full details on the current page.

To test:

1. npm start
2. navigate to http://192.168.7.223:9966/Feedback
3. check #bots for the response

The payload should look like:

```json
{
  "event": "Sent docs feedback",
  "properties": {
    "helpful": true,
    "site": "Help",
    "browser": "chrome",
    "browserVersion": "76.0.3809",
    "os": "Mac OS",
    "page": {},
    "preferredLanguage": "Swift",
    "environment": "staging",
    "location": {
      "href": "http://192.168.7.223:9966/Feedback",
      "ancestorOrigins": {},
      "origin": "http://192.168.7.223:9966",
      "protocol": "http:",
      "host": "192.168.7.223:9966",
      "hostname": "192.168.7.223",
      "port": "9966",
      "pathname": "/Feedback",
      "search": "",
      "hash": ""
    }
  },
  "anonymousId": "..."
}
```

Ref https://github.com/mapbox/documentation/issues/268