### PR TITLE
Fix Video build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master
+
+* Fix build error in `Video` component. [#186](https://github.com/mapbox/dr-ui/pull/186)
+
 ## 0.21.1
 
 * Add `environment` and `location` to the request in `Feedback`. [#184](https://github.com/mapbox/dr-ui/pull/184)

--- a/src/components/video/__tests__/__snapshots__/video.test.js.snap
+++ b/src/components/video/__tests__/__snapshots__/video.test.js.snap
@@ -7,7 +7,7 @@ exports[`video Basic renders as expected 1`] = `
     className="block mx-auto"
     loop={true}
     muted={true}
-    src="https://github.com/mapbox/android-docs/blob/publisher-production/src/video/example-bathymetry-activity.mp4?raw=true"
+    src="./assets/browser-example.mp4"
     title="A video!"
     type="video/mp4"
     width="100%"
@@ -16,7 +16,7 @@ exports[`video Basic renders as expected 1`] = `
       Your browser doesn't support HTML5 video. Here is a
        
       <a
-        href="https://github.com/mapbox/android-docs/blob/publisher-production/src/video/example-bathymetry-activity.mp4?raw=true"
+        href="./assets/browser-example.mp4"
       >
         link to the video
       </a>
@@ -32,7 +32,7 @@ exports[`video Reduced motion renders as expected 1`] = `
     className="block mx-auto"
     controls={true}
     muted={true}
-    src="https://github.com/mapbox/android-docs/blob/publisher-production/src/video/example-bathymetry-activity.mp4?raw=true"
+    src="./assets/browser-example.mp4"
     title="A video!"
     type="video/mp4"
     width="100%"
@@ -41,7 +41,7 @@ exports[`video Reduced motion renders as expected 1`] = `
       Your browser doesn't support HTML5 video. Here is a
        
       <a
-        href="https://github.com/mapbox/android-docs/blob/publisher-production/src/video/example-bathymetry-activity.mp4?raw=true"
+        href="./assets/browser-example.mp4"
       >
         link to the video
       </a>

--- a/src/components/video/__tests__/__snapshots__/video.test.js.snap
+++ b/src/components/video/__tests__/__snapshots__/video.test.js.snap
@@ -7,7 +7,7 @@ exports[`video Basic renders as expected 1`] = `
     className="block mx-auto"
     loop={true}
     muted={true}
-    src="./assets/browser-example.mp4"
+    src="https://github.com/mapbox/android-docs/blob/publisher-production/src/video/example-bathymetry-activity.mp4?raw=true"
     title="A video!"
     type="video/mp4"
     width="100%"
@@ -16,7 +16,7 @@ exports[`video Basic renders as expected 1`] = `
       Your browser doesn't support HTML5 video. Here is a
        
       <a
-        href="./assets/browser-example.mp4"
+        href="https://github.com/mapbox/android-docs/blob/publisher-production/src/video/example-bathymetry-activity.mp4?raw=true"
       >
         link to the video
       </a>
@@ -32,7 +32,7 @@ exports[`video Reduced motion renders as expected 1`] = `
     className="block mx-auto"
     controls={true}
     muted={true}
-    src="./assets/browser-example.mp4"
+    src="https://github.com/mapbox/android-docs/blob/publisher-production/src/video/example-bathymetry-activity.mp4?raw=true"
     title="A video!"
     type="video/mp4"
     width="100%"
@@ -41,7 +41,7 @@ exports[`video Reduced motion renders as expected 1`] = `
       Your browser doesn't support HTML5 video. Here is a
        
       <a
-        href="./assets/browser-example.mp4"
+        href="https://github.com/mapbox/android-docs/blob/publisher-production/src/video/example-bathymetry-activity.mp4?raw=true"
       >
         link to the video
       </a>

--- a/src/components/video/__tests__/video-test-cases.js
+++ b/src/components/video/__tests__/video-test-cases.js
@@ -7,7 +7,8 @@ testCases.basic = {
   component: Video,
   description: 'Basic',
   props: {
-    src: './assets/browser-example.mp4',
+    src:
+      'https://github.com/mapbox/android-docs/blob/publisher-production/src/video/example-bathymetry-activity.mp4?raw=true',
     title: 'A video!'
   }
 };
@@ -16,7 +17,8 @@ noRenderCases.reducedMotion = {
   component: Video,
   description: 'Reduced motion',
   props: {
-    src: './assets/browser-example.mp4',
+    src:
+      'https://github.com/mapbox/android-docs/blob/publisher-production/src/video/example-bathymetry-activity.mp4?raw=true',
     title: 'A video!'
   }
 };

--- a/src/components/video/__tests__/video-test-cases.js
+++ b/src/components/video/__tests__/video-test-cases.js
@@ -7,8 +7,7 @@ testCases.basic = {
   component: Video,
   description: 'Basic',
   props: {
-    src:
-      'https://github.com/mapbox/android-docs/blob/publisher-production/src/video/example-bathymetry-activity.mp4?raw=true',
+    src: './assets/browser-example.mp4',
     title: 'A video!'
   }
 };
@@ -17,8 +16,7 @@ noRenderCases.reducedMotion = {
   component: Video,
   description: 'Reduced motion',
   props: {
-    src:
-      'https://github.com/mapbox/android-docs/blob/publisher-production/src/video/example-bathymetry-activity.mp4?raw=true',
+    src: './assets/browser-example.mp4',
     title: 'A video!'
   }
 };

--- a/src/components/video/video.js
+++ b/src/components/video/video.js
@@ -8,7 +8,7 @@ export default class Video extends React.Component {
       loop: true
     };
     const reducedMotion =
-      window !== 'undefined'
+      typeof window !== 'undefined'
         ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
         : false;
     if (reducedMotion) {

--- a/src/components/video/video.js
+++ b/src/components/video/video.js
@@ -1,39 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import getWindow from '@mapbox/mr-ui/utils/get-window';
 
 export default class Video extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      videoProps: {
-        autoPlay: true,
-        loop: true,
-        controls: undefined
-      }
-    };
-  }
-
-  componentDidMount() {
-    const reducedMotion =
-      getWindow().matchMedia('(prefers-reduced-motion: reduce)').matches ||
-      false;
-    if (reducedMotion) {
-      this.setState({
-        videoProps: {
-          autoPlay: undefined,
-          loop: undefined,
-          controls: true
-        }
-      });
-    }
-  }
-
   render() {
+    let videoProps = {
+      autoPlay: true,
+      loop: true
+    };
+    const reducedMotion =
+      window !== 'undefined'
+        ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+        : false;
+    if (reducedMotion) {
+      videoProps = {
+        autoPlay: undefined,
+        loop: undefined,
+        controls: true
+      };
+    }
     return (
       <div>
         <video
-          {...this.state.videoProps}
+          {...videoProps}
           muted
           width="100%"
           className="block mx-auto"

--- a/src/components/video/video.js
+++ b/src/components/video/video.js
@@ -1,27 +1,39 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import getWindow from '@mapbox/mr-ui/utils/get-window';
 
 export default class Video extends React.Component {
-  render() {
-    let videoProps = {
-      autoPlay: true,
-      loop: true
+  constructor(props) {
+    super(props);
+    this.state = {
+      videoProps: {
+        autoPlay: true,
+        loop: true,
+        controls: undefined
+      }
     };
+  }
+
+  componentDidMount() {
     const reducedMotion =
-      window !== 'undefined'
-        ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
-        : false;
+      getWindow().matchMedia('(prefers-reduced-motion: reduce)').matches ||
+      false;
     if (reducedMotion) {
-      videoProps = {
-        autoPlay: undefined,
-        loop: undefined,
-        controls: true
-      };
+      this.setState({
+        videoProps: {
+          autoPlay: undefined,
+          loop: undefined,
+          controls: true
+        }
+      });
     }
+  }
+
+  render() {
     return (
       <div>
         <video
-          {...videoProps}
+          {...this.state.videoProps}
           muted
           width="100%"
           className="block mx-auto"


### PR DESCRIPTION
When rolling out v0.21.1 to all repos, I came across a build error related to the Video component (catching on [this use of `window`](https://github.com/mapbox/dr-ui/blob/master/src/components/video/video.js#L10-L13)). I did two things in this PR to address it:

- Use /mr-ui's `getWindow` (for consistency).
- Check for the `window` within `componentDidMount` (this seems to be the important part).
  - I chose to store the videoProps (which depend on the results the part that uses `getWindow`) in `state` because that seemed to be a pattern used in mr-ui components that use `getWindow`. Up for other suggestions, though! 

I tested this by building and installing this locally in /ios-sdk and /android-docs. I was able to build both sites successfully and the resulting static site worked as expected. 