### PR TITLE
Add glossary components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * Add a CSS highlighter option to the `Highlight` component. [#191](https://github.com/mapbox/dr-ui/pull/191)
+* Add `GlossaryCard`, `GlossarySection`, and `GlossaryPage` components. [#192](https://github.com/mapbox/dr-ui/pull/192)
 
 ## 0.21.2
 

--- a/src/components/glossary-card/__tests__/__snapshots__/glossary-card.test.js.snap
+++ b/src/components/glossary-card/__tests__/__snapshots__/glossary-card.test.js.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`glossary-card Basic renders as expected 1`] = `
+<div
+  className="mb6 w240 flex-child"
+>
+  <a
+    className="color-gray-dark transition shadow-darken10-on-hover round clip inline-block w-full px12 py12 unprose"
+    href="#donut"
+    style={
+      Object {
+        "verticalAlign": "top",
+      }
+    }
+  >
+    <div
+      className="px6 pb6"
+    >
+      <div
+        className="mb6 txt-l"
+      >
+        Donut
+      </div>
+      <div
+        className="txt-s color-gray"
+      >
+        A delicious fried dough treat typically shaped as a circle with a hole in the middle.
+      </div>
+    </div>
+  </a>
+</div>
+`;

--- a/src/components/glossary-card/__tests__/glossary-card-test-cases.js
+++ b/src/components/glossary-card/__tests__/glossary-card-test-cases.js
@@ -1,0 +1,16 @@
+import GlossaryCard from '../glossary-card';
+
+const testCases = {};
+
+testCases.basic = {
+  component: GlossaryCard,
+  description: 'Basic',
+  props: {
+    entryUrl: '#donut',
+    entryTitle: 'Donut',
+    entryDescription:
+      'A delicious fried dough treat typically shaped as a circle with a hole in the middle.'
+  }
+};
+
+export { testCases };

--- a/src/components/glossary-card/__tests__/glossary-card.test.js
+++ b/src/components/glossary-card/__tests__/glossary-card.test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { testCases } from './glossary-card-test-cases.js';
+
+describe('glossary-card', () => {
+  describe(testCases.basic.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.basic;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/glossary-card/glossary-card.js
+++ b/src/components/glossary-card/glossary-card.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class GlossaryCard extends React.Component {
+  render() {
+    return (
+      <div className="mb6 w240 flex-child">
+        <a
+          className="color-gray-dark transition shadow-darken10-on-hover round clip inline-block w-full px12 py12 unprose"
+          href={this.props.entryUrl}
+          style={{ verticalAlign: 'top' }}
+        >
+          <div className="px6 pb6">
+            <div className="mb6 txt-l">{this.props.entryTitle}</div>
+            <div className="txt-s color-gray">
+              {this.props.entryDescription}
+            </div>
+          </div>
+        </a>
+      </div>
+    );
+  }
+}
+
+GlossaryCard.propTypes = {
+  entryTitle: PropTypes.string.isRequired,
+  entryUrl: PropTypes.string.isRequired,
+  entryDescription: PropTypes.string.isRequired
+};

--- a/src/components/glossary-page/__tests__/__snapshots__/glossary-page.test.js.snap
+++ b/src/components/glossary-page/__tests__/__snapshots__/glossary-page.test.js.snap
@@ -1,0 +1,159 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`glossary-page GlossaryPage renders as expected 1`] = `
+<div
+  className="mt36"
+>
+  <div
+    className="mb60"
+  >
+    <h3
+      className="ml18 mb6 txt-l color-gray"
+    >
+      C
+    </h3>
+    <div
+      className="flex-parent flex-parent--wrap"
+    >
+      <div
+        className="mb6 w240 flex-child"
+      >
+        <a
+          className="color-gray-dark transition shadow-darken10-on-hover round clip inline-block w-full px12 py12 unprose"
+          href="#candy"
+          style={
+            Object {
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            className="px6 pb6"
+          >
+            <div
+              className="mb6 txt-l"
+            >
+              Candy
+            </div>
+            <div
+              className="txt-s color-gray"
+            >
+              A sweet snack that is often fruity or chocolately or both!
+            </div>
+          </div>
+        </a>
+      </div>
+      <div
+        className="mb6 w240 flex-child"
+      >
+        <a
+          className="color-gray-dark transition shadow-darken10-on-hover round clip inline-block w-full px12 py12 unprose"
+          href="#chip"
+          style={
+            Object {
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            className="px6 pb6"
+          >
+            <div
+              className="mb6 txt-l"
+            >
+              Chip
+            </div>
+            <div
+              className="txt-s color-gray"
+            >
+              A thin, crispy, and typically savory snack. It can be made of potatoes, corn, or a variety of other foods.
+            </div>
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+  <div
+    className="mb60"
+  >
+    <h3
+      className="ml18 mb6 txt-l color-gray"
+    >
+      D
+    </h3>
+    <div
+      className="flex-parent flex-parent--wrap"
+    >
+      <div
+        className="mb6 w240 flex-child"
+      >
+        <a
+          className="color-gray-dark transition shadow-darken10-on-hover round clip inline-block w-full px12 py12 unprose"
+          href="#donut"
+          style={
+            Object {
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            className="px6 pb6"
+          >
+            <div
+              className="mb6 txt-l"
+            >
+              Donut
+            </div>
+            <div
+              className="txt-s color-gray"
+            >
+              A delicious fried dough treat typically shaped as a circle with a hole in the middle.
+            </div>
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+  <div
+    className="mb60"
+  >
+    <h3
+      className="ml18 mb6 txt-l color-gray"
+    >
+      G
+    </h3>
+    <div
+      className="flex-parent flex-parent--wrap"
+    >
+      <div
+        className="mb6 w240 flex-child"
+      >
+        <a
+          className="color-gray-dark transition shadow-darken10-on-hover round clip inline-block w-full px12 py12 unprose"
+          href="#granola-bar"
+          style={
+            Object {
+              "verticalAlign": "top",
+            }
+          }
+        >
+          <div
+            className="px6 pb6"
+          >
+            <div
+              className="mb6 txt-l"
+            >
+              Granola bar
+            </div>
+            <div
+              className="txt-s color-gray"
+            >
+              Like granola, but pressed together in a rectangular bar. It can be crunchy or chewy.
+            </div>
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/glossary-page/__tests__/glossary-page-test-cases.js
+++ b/src/components/glossary-page/__tests__/glossary-page-test-cases.js
@@ -1,0 +1,38 @@
+import GlossaryPage from '../glossary-page';
+
+const testCases = {};
+
+testCases.basic = {
+  component: GlossaryPage,
+  description: 'GlossaryPage',
+  props: {
+    entries: [
+      {
+        path: '#donut',
+        title: 'Donut',
+        description:
+          'A delicious fried dough treat typically shaped as a circle with a hole in the middle.'
+      },
+      {
+        path: '#chip',
+        title: 'Chip',
+        description:
+          'A thin, crispy, and typically savory snack. It can be made of potatoes, corn, or a variety of other foods.'
+      },
+      {
+        path: '#candy',
+        title: 'Candy',
+        description:
+          'A sweet snack that is often fruity or chocolately or both!'
+      },
+      {
+        path: '#granola-bar',
+        title: 'Granola bar',
+        description:
+          'Like granola, but pressed together in a rectangular bar. It can be crunchy or chewy.'
+      }
+    ]
+  }
+};
+
+export { testCases };

--- a/src/components/glossary-page/__tests__/glossary-page.test.js
+++ b/src/components/glossary-page/__tests__/glossary-page.test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { testCases } from './glossary-page-test-cases';
+
+describe('glossary-page', () => {
+  describe(testCases.basic.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.basic;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/glossary-page/glossary-page.js
+++ b/src/components/glossary-page/glossary-page.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import GlossarySection from '../glossary-section/glossary-section';
+import PropTypes from 'prop-types';
+
+export default class GlossaryPage extends React.PureComponent {
+  makeSectionComponents(termsArr) {
+    let builtSections = [];
+    let currentLetterEntries = [];
+
+    for (let i = 0; i < termsArr.length; i++) {
+      const thisLetter = termsArr[i].title.charAt(0).toLowerCase();
+      const nextLetter =
+        i === termsArr.length - 1
+          ? termsArr[i].title.charAt(0).toLowerCase()
+          : termsArr[i + 1].title.charAt(0).toLowerCase();
+
+      if (thisLetter < nextLetter) {
+        currentLetterEntries.push(termsArr[i]);
+        const thisLetterSectionComp = (
+          <GlossarySection
+            key={thisLetter}
+            letter={thisLetter}
+            entries={currentLetterEntries}
+          />
+        );
+        builtSections.push(thisLetterSectionComp);
+        currentLetterEntries = [];
+      } else if (thisLetter === nextLetter) {
+        if (i === termsArr.length - 1) {
+          // last entry
+          currentLetterEntries.push(termsArr[i]);
+          const thisLetterSectionComp = (
+            <GlossarySection
+              key={thisLetter}
+              letter={thisLetter}
+              entries={currentLetterEntries}
+            />
+          );
+          builtSections.push(thisLetterSectionComp);
+        } else {
+          currentLetterEntries.push(termsArr[i]);
+        }
+      }
+    }
+    return builtSections;
+  }
+
+  render() {
+    // double-check for sorted terms
+    const alphabetizedTerms = this.props.entries.sort((a, b) => {
+      const titleA = a.title.toUpperCase();
+      const titleB = b.title.toUpperCase();
+      if (titleA < titleB) {
+        return -1;
+      }
+      if (titleA > titleB) {
+        return 1;
+      }
+      return 0;
+    });
+
+    return (
+      <div className="mt36">
+        {this.makeSectionComponents(alphabetizedTerms)}
+      </div>
+    );
+  }
+}
+
+GlossaryPage.propTypes = {
+  entries: PropTypes.arrayOf(
+    PropTypes.shape({
+      path: PropTypes.string.isRequired,
+      title: PropTypes.string.isRequired,
+      description: PropTypes.string.isRequired
+    })
+  ).isRequired
+};

--- a/src/components/glossary-page/glossary-page.js
+++ b/src/components/glossary-page/glossary-page.js
@@ -3,61 +3,41 @@ import GlossarySection from '../glossary-section/glossary-section';
 import PropTypes from 'prop-types';
 
 export default class GlossaryPage extends React.PureComponent {
-  makeSectionComponents(termsArr) {
-    let builtSections = [];
-    let currentLetterEntries = [];
-
-    for (let i = 0; i < termsArr.length; i++) {
-      const thisLetter = termsArr[i].title.charAt(0).toLowerCase();
-      const nextLetter =
-        i === termsArr.length - 1
-          ? termsArr[i].title.charAt(0).toLowerCase()
-          : termsArr[i + 1].title.charAt(0).toLowerCase();
-
-      if (thisLetter < nextLetter) {
-        currentLetterEntries.push(termsArr[i]);
-        const thisLetterSectionComp = (
-          <GlossarySection
-            key={thisLetter}
-            letter={thisLetter}
-            entries={currentLetterEntries}
-          />
-        );
-        builtSections.push(thisLetterSectionComp);
-        currentLetterEntries = [];
-      } else if (thisLetter === nextLetter) {
-        if (i === termsArr.length - 1) {
-          // last entry
-          currentLetterEntries.push(termsArr[i]);
-          const thisLetterSectionComp = (
-            <GlossarySection
-              key={thisLetter}
-              letter={thisLetter}
-              entries={currentLetterEntries}
-            />
-          );
-          builtSections.push(thisLetterSectionComp);
-        } else {
-          currentLetterEntries.push(termsArr[i]);
-        }
-      }
-    }
-    return builtSections;
+  makeSectionComponents(terms) {
+    return terms.map(term => {
+      return (
+        <GlossarySection
+          key={term.letter}
+          letter={term.letter}
+          entries={term.entries}
+        />
+      );
+    });
   }
 
   render() {
-    // double-check for sorted terms
-    const alphabetizedTerms = this.props.entries.sort((a, b) => {
-      const titleA = a.title.toUpperCase();
-      const titleB = b.title.toUpperCase();
-      if (titleA < titleB) {
-        return -1;
-      }
-      if (titleA > titleB) {
-        return 1;
-      }
-      return 0;
-    });
+    const sortBy = key => (a, b) =>
+      a[key].toLowerCase() > b[key].toLowerCase()
+        ? 1
+        : b[key].toLowerCase() > a[key].toLowerCase()
+        ? -1
+        : 0;
+
+    // alphabetized the list of terms
+    const alphabetizedTerms = this.props.entries
+      .reduce((arr, entry) => {
+        // get the first letter
+        const letter = entry.title[0].toLowerCase();
+        // find all the entries that start with "letter" and then sort by title
+        const entries = this.props.entries
+          .filter(e => e.title[0].toLowerCase() === letter)
+          .sort(sortBy('title'));
+        // if the letter doesn't exist in "arr" yet, push the letter with matching entries
+        if (!arr.filter(l => l.letter === letter).length)
+          arr.push({ letter, entries });
+        return arr;
+      }, [])
+      .sort(sortBy('letter'));
 
     return (
       <div className="mt36">

--- a/src/components/glossary-section/__tests__/__snapshots__/glossary-section.test.js.snap
+++ b/src/components/glossary-section/__tests__/__snapshots__/glossary-section.test.js.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`glossary-section Basic renders as expected 1`] = `
+<div
+  className="mb60"
+>
+  <h3
+    className="ml18 mb6 txt-l color-gray"
+  >
+    C
+  </h3>
+  <div
+    className="flex-parent flex-parent--wrap"
+  >
+    <div
+      className="mb6 w240 flex-child"
+    >
+      <a
+        className="color-gray-dark transition shadow-darken10-on-hover round clip inline-block w-full px12 py12 unprose"
+        href="#chip"
+        style={
+          Object {
+            "verticalAlign": "top",
+          }
+        }
+      >
+        <div
+          className="px6 pb6"
+        >
+          <div
+            className="mb6 txt-l"
+          >
+            Chip
+          </div>
+          <div
+            className="txt-s color-gray"
+          >
+            A thin, crispy, and typically savory snack. It can be made of potatoes, corn, or a variety of other foods.
+          </div>
+        </div>
+      </a>
+    </div>
+    <div
+      className="mb6 w240 flex-child"
+    >
+      <a
+        className="color-gray-dark transition shadow-darken10-on-hover round clip inline-block w-full px12 py12 unprose"
+        href="#candy"
+        style={
+          Object {
+            "verticalAlign": "top",
+          }
+        }
+      >
+        <div
+          className="px6 pb6"
+        >
+          <div
+            className="mb6 txt-l"
+          >
+            Candy
+          </div>
+          <div
+            className="txt-s color-gray"
+          >
+            A sweet snack that is often fruity or chocolately or both!
+          </div>
+        </div>
+      </a>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/glossary-section/__tests__/glossary-section-test-cases.js
+++ b/src/components/glossary-section/__tests__/glossary-section-test-cases.js
@@ -1,0 +1,27 @@
+import GlossarySection from '../glossary-section';
+
+const testCases = {};
+
+testCases.basic = {
+  component: GlossarySection,
+  description: 'Basic',
+  props: {
+    letter: 'C',
+    entries: [
+      {
+        path: '#chip',
+        title: 'Chip',
+        description:
+          'A thin, crispy, and typically savory snack. It can be made of potatoes, corn, or a variety of other foods.'
+      },
+      {
+        path: '#candy',
+        title: 'Candy',
+        description:
+          'A sweet snack that is often fruity or chocolately or both!'
+      }
+    ]
+  }
+};
+
+export { testCases };

--- a/src/components/glossary-section/__tests__/glossary-section.test.js
+++ b/src/components/glossary-section/__tests__/glossary-section.test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { testCases } from './glossary-section-test-cases';
+
+describe('glossary-section', () => {
+  describe(testCases.basic.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.basic;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/glossary-section/glossary-section.js
+++ b/src/components/glossary-section/glossary-section.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import GlossaryCard from '../glossary-card/glossary-card';
+
+export default class GlossarySection extends React.PureComponent {
+  render() {
+    const { letter, entries } = this.props;
+
+    const entryList = entries.map((entry, i) => {
+      return (
+        <GlossaryCard
+          key={i}
+          entryTitle={entry.title}
+          entryUrl={entry.path}
+          entryDescription={entry.description}
+        />
+      );
+    });
+
+    return (
+      <div className="mb60">
+        <h3 className="ml18 mb6 txt-l color-gray">{letter.toUpperCase()}</h3>
+        <div className="flex-parent flex-parent--wrap">{entryList}</div>
+      </div>
+    );
+  }
+}
+
+GlossarySection.propTypes = {
+  letter: PropTypes.string.isRequired,
+  entries: PropTypes.arrayOf(
+    PropTypes.shape({
+      path: PropTypes.string.isRequired,
+      title: PropTypes.string.isRequired,
+      description: PropTypes.string.isRequired
+    })
+  ).isRequired
+};


### PR DESCRIPTION
Adds three components for building pages with an alphabetized list of terms (currently used to build the [Glossary page](https://docs.mapbox.com/help/glossary/)):

**`GlossaryCard`** for a single term.

![image](https://user-images.githubusercontent.com/10479155/66075730-128dd300-e511-11e9-9554-d26348031d56.png)

**`GlossarySection`** for defining the layout for each letter including the letter and `GlossaryCard`s for relevant cards.

![image](https://user-images.githubusercontent.com/10479155/66075751-1ae60e00-e511-11e9-8749-b8b72b6b9452.png)

**`GlossaryPage`** for defining the layout for all `GlossarySection`s.

![image](https://user-images.githubusercontent.com/10479155/66075789-2afded80-e511-11e9-9e6d-5f829b5a408b.png)
