### PR TITLE
Update style of BetaFlag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * Add IE11 compatibility for the `Search` component.
+* Update `BetaFlag` component styling. [#207](https://github.com/mapbox/dr-ui/pull/207)
 
 ## 0.24.0
 

--- a/src/components/beta-flag/__tests__/__snapshots__/beta-flag.test.js.snap
+++ b/src/components/beta-flag/__tests__/__snapshots__/beta-flag.test.js.snap
@@ -10,7 +10,13 @@ exports[`back-top-top-button Basic renders as expected 1`] = `
 >
   <div
     aria-describedby="tooltip-1"
-    className="txt-s txt-bold round px6 py3 inline-block cursor-default bg-orange-faint color-orange-dark "
+    className="txt-s txt-bold round px6 ml6 inline-block cursor-default border border--green-light"
+    style={
+      Object {
+        "backgroundColor": "rgb(232, 245, 238)",
+        "color": "rgb(27, 125, 79)",
+      }
+    }
   >
     Beta
   </div>
@@ -22,7 +28,7 @@ exports[`back-top-top-button Basic renders as expected 1`] = `
     <div
       className="txt-s wmax120"
     >
-      This feature is in public beta and is subject to potential changes.
+      This feature is in public beta and is subject to changes.
     </div>
   </div>
 </div>

--- a/src/components/beta-flag/beta-flag.js
+++ b/src/components/beta-flag/beta-flag.js
@@ -1,11 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Badge from '@mapbox/mr-ui/badge';
+import Tooltip from '@mapbox/mr-ui/tooltip';
 
 export default class BetaFlag extends React.Component {
   render() {
-    const { props } = this;
-    return <Badge badgeText="Beta" tooltipText={props.tooltipText} />;
+    return (
+      <Tooltip
+        content={this.props.tooltipText}
+        maxWidth="small"
+        placement="top"
+      >
+        <div
+          style={{
+            backgroundColor: 'rgb(232, 245, 238)',
+            color: 'rgb(27, 125, 79)'
+          }}
+          className="txt-s txt-bold round px6 ml6 inline-block cursor-default border border--green-light"
+        >
+          Beta
+        </div>
+      </Tooltip>
+    );
   }
 }
 
@@ -14,6 +29,5 @@ BetaFlag.propTypes = {
 };
 
 BetaFlag.defaultProps = {
-  tooltipText:
-    'This feature is in public beta and is subject to potential changes.'
+  tooltipText: 'This feature is in public beta and is subject to changes.'
 };

--- a/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
+++ b/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
@@ -549,7 +549,13 @@ exports[`overview-header Beta product renders as expected 1`] = `
       >
         <div
           aria-describedby="tooltip-1"
-          className="txt-s txt-bold round px6 py3 inline-block cursor-default bg-orange-faint color-orange-dark "
+          className="txt-s txt-bold round px6 ml6 inline-block cursor-default border border--green-light"
+          style={
+            Object {
+              "backgroundColor": "rgb(232, 245, 238)",
+              "color": "rgb(27, 125, 79)",
+            }
+          }
         >
           Beta
         </div>
@@ -561,7 +567,7 @@ exports[`overview-header Beta product renders as expected 1`] = `
           <div
             className="txt-s wmax120"
           >
-            This feature is in public beta and is subject to potential changes.
+            This feature is in public beta and is subject to changes.
           </div>
         </div>
       </div>

--- a/src/components/product-menu/__tests__/__snapshots__/product-menu.test.js.snap
+++ b/src/components/product-menu/__tests__/__snapshots__/product-menu.test.js.snap
@@ -23,7 +23,13 @@ exports[`product-menu Beta product renders as expected 1`] = `
     >
       <div
         aria-describedby="tooltip-1"
-        className="txt-s txt-bold round px6 py3 inline-block cursor-default bg-orange-faint color-orange-dark "
+        className="txt-s txt-bold round px6 ml6 inline-block cursor-default border border--green-light"
+        style={
+          Object {
+            "backgroundColor": "rgb(232, 245, 238)",
+            "color": "rgb(27, 125, 79)",
+          }
+        }
       >
         Beta
       </div>
@@ -35,7 +41,7 @@ exports[`product-menu Beta product renders as expected 1`] = `
         <div
           className="txt-s wmax120"
         >
-          This feature is in public beta and is subject to potential changes.
+          This feature is in public beta and is subject to changes.
         </div>
       </div>
     </div>


### PR DESCRIPTION
Updates the style of the `BetaFlag` component to:

- Match the color of the `Note` component's `new` theme.
- Increase the contrast when used with the `NavigationAccordion` component. 

<img width="478" alt="Screen Shot 2019-12-16 at 4 25 31 PM" src="https://user-images.githubusercontent.com/10479155/70954119-b5d68a80-2020-11ea-8425-51fa46b29ef9.png">
