### PR TITLE
Add "tag" option to second and third level headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add IE11 compatibility for the `Search` component.
 * Update `BetaFlag` component styling. [#207](https://github.com/mapbox/dr-ui/pull/207)
+* Add an optional `tag` prop for second and third level headings in `NavigationAccordion`. [#212](https://github.com/mapbox/dr-ui/pull/212)
 
 ## 0.24.0
 

--- a/src/components/beta-flag/__tests__/__snapshots__/beta-flag.test.js.snap
+++ b/src/components/beta-flag/__tests__/__snapshots__/beta-flag.test.js.snap
@@ -10,7 +10,7 @@ exports[`back-top-top-button Basic renders as expected 1`] = `
 >
   <div
     aria-describedby="tooltip-1"
-    className="txt-s txt-bold round px6 ml6 inline-block cursor-default border border--green-light"
+    className="txt-s txt-bold round px6 inline-block cursor-default border border--green-light"
     style={
       Object {
         "backgroundColor": "rgb(232, 245, 238)",

--- a/src/components/beta-flag/beta-flag.js
+++ b/src/components/beta-flag/beta-flag.js
@@ -15,7 +15,7 @@ export default class BetaFlag extends React.Component {
             backgroundColor: 'rgb(232, 245, 238)',
             color: 'rgb(27, 125, 79)'
           }}
-          className="txt-s txt-bold round px6 ml6 inline-block cursor-default border border--green-light"
+          className="txt-s txt-bold round px6 inline-block cursor-default border border--green-light"
         >
           Beta
         </div>

--- a/src/components/feedback/__tests__/__snapshots__/feedback.test.js.snap
+++ b/src/components/feedback/__tests__/__snapshots__/feedback.test.js.snap
@@ -182,6 +182,7 @@ exports[`feedback Feedback placement renders as expected 1`] = `
                               href="#heading-one"
                             >
                               Heading one
+                              
                             </a>
                             <ul
                               className="none"
@@ -195,6 +196,7 @@ exports[`feedback Feedback placement renders as expected 1`] = `
                               href="#heading-two"
                             >
                               Heading two
+                              
                             </a>
                             <ul
                               className="none"

--- a/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
+++ b/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
@@ -36,6 +36,7 @@ exports[`navigation-accordion Basic renders as expected 1`] = `
                 href="#heading-one"
               >
                 Heading one
+                
               </a>
               <ul
                 className="none"
@@ -49,6 +50,7 @@ exports[`navigation-accordion Basic renders as expected 1`] = `
                 href="#heading-two"
               >
                 Heading two
+                
               </a>
               <ul
                 className="none"
@@ -266,11 +268,7 @@ exports[`navigation-accordion Shows third level items renders as expected 1`] = 
             className="pl12 py12 txt-bold txt-m flex-child color-black"
           >
             Title one
-            <div
-              className="inline-block ml12 txt-xs txt-bold txt-uppercase px6 round color-pink bg-pink-faint"
-            >
-              Fundamentals
-            </div>
+            
           </div>
         </a>
         <div
@@ -287,18 +285,20 @@ exports[`navigation-accordion Shows third level items renders as expected 1`] = 
                 href="#heading-one"
               >
                 Heading one
+                
               </a>
               <ul
-                className="none"
+                className="pl12 color-darken75"
               >
                 <li
                   className="mt6"
                 >
                   <a
-                    className="color-blue-on-hover"
-                    href="#subheading-one"
+                    className="color-blue-on-hover txt-bold"
+                    href="#"
                   >
                     Subheading one
+                    
                   </a>
                 </li>
                 <li
@@ -309,6 +309,7 @@ exports[`navigation-accordion Shows third level items renders as expected 1`] = 
                     href="#subheading-two"
                   >
                     Subheading two
+                    
                   </a>
                 </li>
               </ul>
@@ -321,6 +322,7 @@ exports[`navigation-accordion Shows third level items renders as expected 1`] = 
                 href="#heading-two"
               >
                 Heading two
+                
               </a>
               <ul
                 className="none"
@@ -344,11 +346,256 @@ exports[`navigation-accordion Shows third level items renders as expected 1`] = 
             className="pl12 py12 txt-bold txt-m flex-child"
           >
             Title two
-            <div
-              className="inline-block ml12 txt-xs txt-bold txt-uppercase px6 round color-blue bg-blue-faint"
+            
+          </div>
+          <div
+            className="flex-child flex-child--no-shrink"
+          >
+            <svg
+              className="events-none icon"
+              focusable="false"
+              role="presentation"
+              style={
+                Object {
+                  "height": 18,
+                  "width": 18,
+                }
+              }
             >
-              Advanced
-            </div>
+              <use
+                xlinkHref="#icon-chevron-down"
+                xmlnsXlink="http://www.w3.org/1999/xlink"
+              />
+            </svg>
+          </div>
+        </a>
+        
+      </div>
+    </div>
+  </div>
+  <div
+    className="none-mm block bg-gray-faint px24 py24"
+  >
+    <div
+      className="relative "
+    >
+      <div
+        className="select-container "
+      >
+        <select
+          aria-required={true}
+          className="select select--stroke round-full bg-white"
+          data-test="navigate-this-section-select"
+          disabled={false}
+          id="navigate-this-section"
+          onChange={[Function]}
+          value="page-one"
+        >
+          <option
+            value="page-one"
+          >
+            Title one
+          </option>
+          <option
+            value="page-two"
+          >
+            Title two
+          </option>
+        </select>
+        <div
+          className="select-arrow"
+        />
+      </div>
+      <div
+        role="alert"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`navigation-accordion Titles with tags renders as expected 1`] = `
+<div>
+  <div
+    className="block-mm none"
+  >
+    <div
+      className="pl24-mm px0 block-mm none pr12 bg-lighten75"
+    >
+      <div
+        className="py3 "
+      >
+        <a
+          className="color-blue-on-hover color-gray text-decoration-none unprose flex-parent flex-parent--space-between-main flex-parent--center-cross"
+          href="page-one"
+        >
+          <div
+            className="pl12 py12 txt-bold txt-m flex-child color-black"
+          >
+            Title one
+            
+          </div>
+        </a>
+        <div
+          className="ml24 pt0"
+        >
+          <ul
+            className="txt-m pb12 inline-block-mm none unprose"
+          >
+            <li
+              className="mb6"
+            >
+              <a
+                className="color-blue-on-hover"
+                href="#heading-one"
+              >
+                Heading one
+                
+              </a>
+              <ul
+                className="pl12 color-darken75"
+              >
+                <li
+                  className="mt6"
+                >
+                  <a
+                    className="color-blue-on-hover txt-bold"
+                    href="#"
+                  >
+                    Subheading one
+                    <span
+                      className="ml6"
+                    >
+                      <div
+                        className="inline-block"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                      >
+                        <div
+                          aria-describedby="tooltip-1"
+                          className="txt-s txt-bold round px6 py3 inline-block cursor-default bg-orange-faint color-orange-dark "
+                        >
+                          Beta
+                        </div>
+                        <div
+                          className="hide-visually"
+                          id="tooltip-1"
+                          role="tooltip"
+                        >
+                          <div
+                            className="txt-s wmax120"
+                          >
+                            This feature is in public beta and is subject to potential changes.
+                          </div>
+                        </div>
+                      </div>
+                    </span>
+                  </a>
+                </li>
+                <li
+                  className="mt6"
+                >
+                  <a
+                    className="color-blue-on-hover"
+                    href="#subheading-two"
+                  >
+                    Subheading two
+                    
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li
+              className="mb6"
+            >
+              <a
+                className="color-blue-on-hover"
+                href="#heading-two"
+              >
+                Heading two
+                <span
+                  className="ml6"
+                >
+                  <div
+                    className="inline-block"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                  >
+                    <div
+                      aria-describedby="tooltip-2"
+                      className="txt-s txt-bold round px6 py3 inline-block cursor-default bg-orange-faint color-orange-dark "
+                    >
+                      Beta
+                    </div>
+                    <div
+                      className="hide-visually"
+                      id="tooltip-2"
+                      role="tooltip"
+                    >
+                      <div
+                        className="txt-s wmax120"
+                      >
+                        This feature is in public beta and is subject to potential changes.
+                      </div>
+                    </div>
+                  </div>
+                </span>
+              </a>
+              <ul
+                className="none"
+              />
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div
+      className="pl24-mm px0 block-mm none pr12"
+    >
+      <div
+        className="py3  border-t border--gray-light"
+      >
+        <a
+          className="color-blue-on-hover color-gray text-decoration-none unprose flex-parent flex-parent--space-between-main flex-parent--center-cross"
+          href="page-two"
+        >
+          <div
+            className="pl12 py12 txt-bold txt-m flex-child"
+          >
+            Title two
+            <span
+              className="ml6"
+            >
+              <div
+                className="inline-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+              >
+                <div
+                  aria-describedby="tooltip-3"
+                  className="txt-s txt-bold round px6 py3 inline-block cursor-default bg-orange-faint color-orange-dark "
+                >
+                  Beta
+                </div>
+                <div
+                  className="hide-visually"
+                  id="tooltip-3"
+                  role="tooltip"
+                >
+                  <div
+                    className="txt-s wmax120"
+                  >
+                    This feature is in public beta and is subject to potential changes.
+                  </div>
+                </div>
+              </div>
+            </span>
           </div>
           <div
             className="flex-child flex-child--no-shrink"

--- a/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
+++ b/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
@@ -475,7 +475,13 @@ exports[`navigation-accordion Titles with tags renders as expected 1`] = `
                       >
                         <div
                           aria-describedby="tooltip-1"
-                          className="txt-s txt-bold round px6 py3 inline-block cursor-default bg-orange-faint color-orange-dark "
+                          className="txt-s txt-bold round px6 inline-block cursor-default border border--green-light"
+                          style={
+                            Object {
+                              "backgroundColor": "rgb(232, 245, 238)",
+                              "color": "rgb(27, 125, 79)",
+                            }
+                          }
                         >
                           Beta
                         </div>
@@ -487,7 +493,7 @@ exports[`navigation-accordion Titles with tags renders as expected 1`] = `
                           <div
                             className="txt-s wmax120"
                           >
-                            This feature is in public beta and is subject to potential changes.
+                            This feature is in public beta and is subject to changes.
                           </div>
                         </div>
                       </div>
@@ -527,7 +533,13 @@ exports[`navigation-accordion Titles with tags renders as expected 1`] = `
                   >
                     <div
                       aria-describedby="tooltip-2"
-                      className="txt-s txt-bold round px6 py3 inline-block cursor-default bg-orange-faint color-orange-dark "
+                      className="txt-s txt-bold round px6 inline-block cursor-default border border--green-light"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(232, 245, 238)",
+                          "color": "rgb(27, 125, 79)",
+                        }
+                      }
                     >
                       Beta
                     </div>
@@ -539,7 +551,7 @@ exports[`navigation-accordion Titles with tags renders as expected 1`] = `
                       <div
                         className="txt-s wmax120"
                       >
-                        This feature is in public beta and is subject to potential changes.
+                        This feature is in public beta and is subject to changes.
                       </div>
                     </div>
                   </div>
@@ -579,7 +591,13 @@ exports[`navigation-accordion Titles with tags renders as expected 1`] = `
               >
                 <div
                   aria-describedby="tooltip-3"
-                  className="txt-s txt-bold round px6 py3 inline-block cursor-default bg-orange-faint color-orange-dark "
+                  className="txt-s txt-bold round px6 inline-block cursor-default border border--green-light"
+                  style={
+                    Object {
+                      "backgroundColor": "rgb(232, 245, 238)",
+                      "color": "rgb(27, 125, 79)",
+                    }
+                  }
                 >
                   Beta
                 </div>
@@ -591,7 +609,7 @@ exports[`navigation-accordion Titles with tags renders as expected 1`] = `
                   <div
                     className="txt-s wmax120"
                   >
-                    This feature is in public beta and is subject to potential changes.
+                    This feature is in public beta and is subject to changes.
                   </div>
                 </div>
               </div>

--- a/src/components/navigation-accordion/__tests__/navigation-accordion-test-cases.js
+++ b/src/components/navigation-accordion/__tests__/navigation-accordion-test-cases.js
@@ -2,12 +2,6 @@ import React from 'react';
 import NavigationAccordion from '../navigation-accordion';
 import BetaFlag from '../../beta-flag/beta-flag';
 
-const BetaFlagWithMargin = (
-  <span className="ml6">
-    <BetaFlag />
-  </span>
-);
-
 const testCases = {};
 
 testCases.basic = {
@@ -116,7 +110,7 @@ testCases.withTags = {
         },
         {
           title: 'Title two',
-          tag: BetaFlagWithMargin,
+          tag: <BetaFlag />,
           path: 'page-two'
         }
       ],
@@ -127,7 +121,7 @@ testCases.withTags = {
           thirdLevelItems: [
             {
               title: 'Subheading one',
-              tag: BetaFlagWithMargin,
+              tag: <BetaFlag />,
               path: ''
             },
             {
@@ -138,7 +132,7 @@ testCases.withTags = {
         },
         {
           title: 'Heading two',
-          tag: BetaFlagWithMargin,
+          tag: <BetaFlag />,
           path: 'heading-two'
         }
       ]

--- a/src/components/navigation-accordion/__tests__/navigation-accordion-test-cases.js
+++ b/src/components/navigation-accordion/__tests__/navigation-accordion-test-cases.js
@@ -1,5 +1,12 @@
 import React from 'react';
 import NavigationAccordion from '../navigation-accordion';
+import BetaFlag from '../../beta-flag/beta-flag';
+
+const BetaFlagWithMargin = (
+  <span className="ml6">
+    <BetaFlag />
+  </span>
+);
 
 const testCases = {};
 
@@ -64,20 +71,10 @@ testCases.withThirdLevelItems = {
       firstLevelItems: [
         {
           title: 'Title one',
-          tag: (
-            <div className="inline-block ml12 txt-xs txt-bold txt-uppercase px6 round color-pink bg-pink-faint">
-              Fundamentals
-            </div>
-          ),
           path: 'page-one'
         },
         {
           title: 'Title two',
-          tag: (
-            <div className="inline-block ml12 txt-xs txt-bold txt-uppercase px6 round color-blue bg-blue-faint">
-              Advanced
-            </div>
-          ),
           path: 'page-two'
         }
       ],
@@ -88,7 +85,7 @@ testCases.withThirdLevelItems = {
           thirdLevelItems: [
             {
               title: 'Subheading one',
-              path: 'subheading-one'
+              path: ''
             },
             {
               title: 'Subheading two',
@@ -98,6 +95,50 @@ testCases.withThirdLevelItems = {
         },
         {
           title: 'Heading two',
+          path: 'heading-two'
+        }
+      ]
+    },
+    onDropdownChange: () => {}
+  }
+};
+
+testCases.withTags = {
+  description: 'Titles with tags',
+  component: NavigationAccordion,
+  props: {
+    currentPath: 'page-one',
+    contents: {
+      firstLevelItems: [
+        {
+          title: 'Title one',
+          path: 'page-one'
+        },
+        {
+          title: 'Title two',
+          tag: BetaFlagWithMargin,
+          path: 'page-two'
+        }
+      ],
+      secondLevelItems: [
+        {
+          title: 'Heading one',
+          path: 'heading-one',
+          thirdLevelItems: [
+            {
+              title: 'Subheading one',
+              tag: BetaFlagWithMargin,
+              path: ''
+            },
+            {
+              title: 'Subheading two',
+              path: 'subheading-two'
+            }
+          ]
+        },
+        {
+          title: 'Heading two',
+          tag: BetaFlagWithMargin,
           path: 'heading-two'
         }
       ]

--- a/src/components/navigation-accordion/__tests__/navigation-accordion.test.js
+++ b/src/components/navigation-accordion/__tests__/navigation-accordion.test.js
@@ -56,4 +56,22 @@ describe('navigation-accordion', () => {
       expect(tree).toMatchSnapshot();
     });
   });
+
+  describe(testCases.withTags.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.withTags;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
 });

--- a/src/components/navigation-accordion/navigation-accordion.js
+++ b/src/components/navigation-accordion/navigation-accordion.js
@@ -77,6 +77,7 @@ class NavigationAccordion extends React.PureComponent {
               <li key={subItem.path} className="mt6">
                 <a href={`#${subItem.path}`} className={itemClasses(isActive)}>
                   {subItem.title}
+                  {subItem.tag ? subItem.tag : ''}
                 </a>
               </li>
             );
@@ -85,6 +86,7 @@ class NavigationAccordion extends React.PureComponent {
           <li key={item.path} className="mb6">
             <a href={`#${item.path}`} className={itemClasses(isActive)}>
               {item.title}
+              {item.tag ? item.tag : ''}
             </a>
             <ul className={openSubItems ? 'pl12 color-darken75' : 'none'}>
               {subItems}
@@ -174,10 +176,12 @@ NavigationAccordion.propTypes = {
     secondLevelItems: PropTypes.arrayOf(
       PropTypes.shape({
         title: PropTypes.string.isRequired,
+        tag: PropTypes.node,
         path: PropTypes.string.isRequired,
         thirdLevelItems: PropTypes.arrayOf(
           PropTypes.shape({
             title: PropTypes.string.isRequired,
+            tag: PropTypes.node,
             path: PropTypes.string.isRequired
           })
         )

--- a/src/components/navigation-accordion/navigation-accordion.js
+++ b/src/components/navigation-accordion/navigation-accordion.js
@@ -77,7 +77,11 @@ class NavigationAccordion extends React.PureComponent {
               <li key={subItem.path} className="mt6">
                 <a href={`#${subItem.path}`} className={itemClasses(isActive)}>
                   {subItem.title}
-                  {subItem.tag ? subItem.tag : ''}
+                  {subItem.tag ? (
+                    <span className="ml6">{subItem.tag}</span>
+                  ) : (
+                    ''
+                  )}
                 </a>
               </li>
             );
@@ -86,7 +90,7 @@ class NavigationAccordion extends React.PureComponent {
           <li key={item.path} className="mb6">
             <a href={`#${item.path}`} className={itemClasses(isActive)}>
               {item.title}
-              {item.tag ? item.tag : ''}
+              {item.tag ? <span className="ml6">{item.tag}</span> : ''}
             </a>
             <ul className={openSubItems ? 'pl12 color-darken75' : 'none'}>
               {subItems}
@@ -138,7 +142,7 @@ class NavigationAccordion extends React.PureComponent {
               >
                 <div className={textClasses}>
                   {title}
-                  {page.tag ? page.tag : ''}
+                  {page.tag ? <span className="ml6">{page.tag}</span> : ''}
                 </div>
                 {icon}
               </a>

--- a/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
+++ b/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
@@ -549,7 +549,7 @@ exports[`overview-header Beta product renders as expected 1`] = `
       >
         <div
           aria-describedby="tooltip-1"
-          className="txt-s txt-bold round px6 ml6 inline-block cursor-default border border--green-light"
+          className="txt-s txt-bold round px6 inline-block cursor-default border border--green-light"
           style={
             Object {
               "backgroundColor": "rgb(232, 245, 238)",

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -186,6 +186,7 @@ exports[`page-layout Common use case renders as expected 1`] = `
                           href="#heading-one"
                         >
                           Heading one
+                          
                         </a>
                         <ul
                           className="none"
@@ -199,6 +200,7 @@ exports[`page-layout Common use case renders as expected 1`] = `
                           href="#heading-two"
                         >
                           Heading two
+                          
                         </a>
                         <ul
                           className="none"
@@ -535,6 +537,7 @@ exports[`page-layout Many first level items renders as expected 1`] = `
                           href="#heading-one"
                         >
                           Heading one
+                          
                         </a>
                         <ul
                           className="none"
@@ -548,6 +551,7 @@ exports[`page-layout Many first level items renders as expected 1`] = `
                           href="#heading-two"
                         >
                           Heading two
+                          
                         </a>
                         <ul
                           className="none"

--- a/src/components/product-menu/__tests__/__snapshots__/product-menu.test.js.snap
+++ b/src/components/product-menu/__tests__/__snapshots__/product-menu.test.js.snap
@@ -23,7 +23,7 @@ exports[`product-menu Beta product renders as expected 1`] = `
     >
       <div
         aria-describedby="tooltip-1"
-        className="txt-s txt-bold round px6 ml6 inline-block cursor-default border border--green-light"
+        className="txt-s txt-bold round px6 inline-block cursor-default border border--green-light"
         style={
           Object {
             "backgroundColor": "rgb(232, 245, 238)",

--- a/src/components/search/__tests__/__snapshots__/search.test.js.snap
+++ b/src/components/search/__tests__/__snapshots__/search.test.js.snap
@@ -384,6 +384,7 @@ exports[`search Search with \`narrow\` option set renders as expected 2`] = `
                               href="#heading-one"
                             >
                               Heading one
+                              
                             </a>
                             <ul
                               className="none"
@@ -397,6 +398,7 @@ exports[`search Search with \`narrow\` option set renders as expected 2`] = `
                               href="#heading-two"
                             >
                               Heading two
+                              
                             </a>
                             <ul
                               className="none"


### PR DESCRIPTION
Adds an optional `tag` prop to `secondLevelHeadings` and `thirdLevelHeadings` in `NavigationAccordion`.

<img width="379" alt="Screen Shot 2019-12-19 at 8 22 57 AM" src="https://user-images.githubusercontent.com/10479155/71191237-e1cd5800-223a-11ea-9728-fdf5e9c02143.png">
