### PR TITLE
Darken text color on default, warning, beta, new, and download themes to improve readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Master
+
+* Darken text color for `Note` and `Tag` themes. [#223](https://github.com/mapbox/dr-ui/pull/223)
+
 ## 0.25.1
 
 * Add IE11 compatibility for the `Search` component. [#203](https://github.com/mapbox/dr-ui/pull/203)

--- a/src/components/demo-iframe/__tests__/__snapshots__/demo-iframe.test.js.snap
+++ b/src/components/demo-iframe/__tests__/__snapshots__/demo-iframe.test.js.snap
@@ -46,7 +46,7 @@ exports[`demo-iframe Basic renders as expected 1`] = `
   style={
     Object {
       "background": "#feefe2",
-      "color": "#945823",
+      "color": "#78471c",
     }
   }
 >
@@ -117,7 +117,7 @@ exports[`demo-iframe With token renders as expected 1`] = `
   style={
     Object {
       "background": "#feefe2",
-      "color": "#945823",
+      "color": "#78471c",
     }
   }
 >

--- a/src/components/gl-wrapper/__tests__/__snapshots__/gl-wrapper.test.js.snap
+++ b/src/components/gl-wrapper/__tests__/__snapshots__/gl-wrapper.test.js.snap
@@ -6,7 +6,7 @@ exports[`gl-wrapper Basic renders as expected 1`] = `
   style={
     Object {
       "background": "#feefe2",
-      "color": "#945823",
+      "color": "#78471c",
     }
   }
 >

--- a/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
+++ b/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
@@ -479,8 +479,8 @@ exports[`navigation-accordion Titles with tags renders as expected 1`] = `
                           style={
                             Object {
                               "background": "#feefe2",
-                              "borderColor": "#dea573",
-                              "color": "#945823",
+                              "borderColor": "#ba6e2c",
+                              "color": "#78471c",
                             }
                           }
                         >
@@ -596,9 +596,9 @@ exports[`navigation-accordion Titles with tags renders as expected 1`] = `
                   className="txt-s txt-bold round px6 inline-block cursor-default border"
                   style={
                     Object {
-                      "background": "#edf0fd",
-                      "borderColor": "#4264fb",
-                      "color": "#3658ee",
+                      "background": "#f1f3fd",
+                      "borderColor": "#0428c8",
+                      "color": "#0c248d",
                     }
                   }
                 >

--- a/src/components/note/__tests__/__snapshots__/note.test.js.snap
+++ b/src/components/note/__tests__/__snapshots__/note.test.js.snap
@@ -6,7 +6,7 @@ exports[`note A legacy note, has same styling as warning renders as expected 1`]
   style={
     Object {
       "background": "#feefe2",
-      "color": "#945823",
+      "color": "#78471c",
     }
   }
 >
@@ -123,7 +123,7 @@ exports[`note A note to display with a message about new products or features. r
   style={
     Object {
       "background": "#e8f5ee",
-      "color": "#1b7d4f",
+      "color": "#15603d",
     }
   }
 >
@@ -177,8 +177,8 @@ exports[`note A note to flag information about a beta release/product renders as
   className="dr-ui--note py18 px18 round flex-parent flex-parent--row mb18"
   style={
     Object {
-      "background": "#edf0fd",
-      "color": "#3658ee",
+      "background": "#f1f3fd",
+      "color": "#0c248d",
     }
   }
 >
@@ -233,7 +233,7 @@ exports[`note A warning note to let the user know something has changed or will 
   style={
     Object {
       "background": "#feefe2",
-      "color": "#945823",
+      "color": "#78471c",
     }
   }
 >
@@ -288,7 +288,7 @@ exports[`note Default note renders as expected 1`] = `
   style={
     Object {
       "background": "#f4f7fb",
-      "color": "#547190",
+      "color": "#425870",
     }
   }
 >
@@ -343,7 +343,7 @@ exports[`note Default note with no image renders as expected 1`] = `
   style={
     Object {
       "background": "#f4f7fb",
-      "color": "#547190",
+      "color": "#425870",
     }
   }
 >
@@ -368,7 +368,7 @@ exports[`note Note with custom title. renders as expected 1`] = `
   style={
     Object {
       "background": "#f4f7fb",
-      "color": "#547190",
+      "color": "#425870",
     }
   }
 >
@@ -431,7 +431,7 @@ exports[`note download renders as expected 1`] = `
   style={
     Object {
       "background": "#f2effa",
-      "color": "#5a3fc0",
+      "color": "#452f92",
     }
   }
 >

--- a/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
+++ b/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
@@ -549,9 +549,9 @@ exports[`overview-header Beta product renders as expected 1`] = `
           className="txt-s txt-bold round px6 inline-block cursor-default border"
           style={
             Object {
-              "background": "#edf0fd",
-              "borderColor": "#4264fb",
-              "color": "#3658ee",
+              "background": "#f1f3fd",
+              "borderColor": "#0428c8",
+              "color": "#0c248d",
             }
           }
         >

--- a/src/components/product-menu/__tests__/__snapshots__/product-menu.test.js.snap
+++ b/src/components/product-menu/__tests__/__snapshots__/product-menu.test.js.snap
@@ -26,9 +26,9 @@ exports[`product-menu Beta product renders as expected 1`] = `
         className="txt-s txt-bold round px6 inline-block cursor-default border"
         style={
           Object {
-            "background": "#edf0fd",
-            "borderColor": "#4264fb",
-            "color": "#3658ee",
+            "background": "#f1f3fd",
+            "borderColor": "#0428c8",
+            "color": "#0c248d",
           }
         }
       >

--- a/src/components/tag/__tests__/__snapshots__/tag.test.js.snap
+++ b/src/components/tag/__tests__/__snapshots__/tag.test.js.snap
@@ -13,9 +13,9 @@ exports[`back-top-top-button Beta tag renders as expected 1`] = `
     className="txt-s txt-bold round px6 inline-block cursor-default border"
     style={
       Object {
-        "background": "#edf0fd",
-        "borderColor": "#4264fb",
-        "color": "#3658ee",
+        "background": "#f1f3fd",
+        "borderColor": "#0428c8",
+        "color": "#0c248d",
       }
     }
   >

--- a/src/components/themes/__tests__/__snapshots__/themes.test.js.snap
+++ b/src/components/themes/__tests__/__snapshots__/themes.test.js.snap
@@ -8,7 +8,7 @@ exports[`themes Default renders as expected 1`] = `
   style={
     Object {
       "background": "#f4f7fb",
-      "color": "#547190",
+      "color": "#425870",
     }
   }
 >
@@ -61,8 +61,8 @@ exports[`themes beta renders as expected 1`] = `
     className="dr-ui--note py18 px18 round flex-parent flex-parent--row mb18"
     style={
       Object {
-        "background": "#edf0fd",
-        "color": "#3658ee",
+        "background": "#f1f3fd",
+        "color": "#0c248d",
       }
     }
   >
@@ -120,9 +120,9 @@ exports[`themes beta renders as expected 1`] = `
       className="txt-s txt-bold round px6 inline-block cursor-default border"
       style={
         Object {
-          "background": "#edf0fd",
-          "borderColor": "#4264fb",
-          "color": "#3658ee",
+          "background": "#f1f3fd",
+          "borderColor": "#0428c8",
+          "color": "#0c248d",
         }
       }
     >
@@ -151,7 +151,7 @@ exports[`themes download renders as expected 1`] = `
     style={
       Object {
         "background": "#f2effa",
-        "color": "#5a3fc0",
+        "color": "#452f92",
       }
     }
   >
@@ -301,7 +301,7 @@ exports[`themes legacy or warning renders as expected 1`] = `
     style={
       Object {
         "background": "#feefe2",
-        "color": "#945823",
+        "color": "#78471c",
       }
     }
   >
@@ -359,8 +359,8 @@ exports[`themes legacy or warning renders as expected 1`] = `
       style={
         Object {
           "background": "#feefe2",
-          "borderColor": "#dea573",
-          "color": "#945823",
+          "borderColor": "#ba6e2c",
+          "color": "#78471c",
         }
       }
     >

--- a/src/components/themes/themes.js
+++ b/src/components/themes/themes.js
@@ -36,7 +36,7 @@ const themes = {
     label: 'Note',
     styles: {
       background: '#f4f7fb',
-      color: '#547190'
+      color: '#425870'
     }
   },
   warning: {
@@ -44,8 +44,8 @@ const themes = {
     label: 'Warning',
     styles: {
       background: '#feefe2',
-      color: '#945823',
-      borderColor: '#dea573'
+      color: '#78471c',
+      borderColor: '#ba6e2c'
     }
   },
   error: {
@@ -61,9 +61,9 @@ const themes = {
     label: 'Beta',
     tooltipText: 'This feature is in public beta and is subject to changes.',
     styles: {
-      background: '#edf0fd',
-      color: '#3658ee',
-      borderColor: '#4264fb'
+      background: '#f1f3fd',
+      color: '#0c248d',
+      borderColor: '#0428c8'
     }
   },
   new: {
@@ -72,8 +72,8 @@ const themes = {
     tooltipText: 'This feature was released recently.',
     styles: {
       background: '#e8f5ee',
-      color: '#1b7d4f',
-      borderColor: '#75c684'
+      color: '#15603d',
+      borderColor: '#378645'
     }
   },
   download: {
@@ -81,7 +81,7 @@ const themes = {
     label: 'Download',
     styles: {
       background: '#f2effa',
-      color: '#5a3fc0'
+      color: '#452f92'
     }
   },
   fundamentals: {


### PR DESCRIPTION
@colleenmcginnis While testing the latest dr-ui release on /api, one beta note is particularly large and I think that the bright blue text color was a little jarring and not as easy to read as the surrounding text (despite being AA compliant!). This PR darkens the text color on the default, warning, beta, new, and download themes.

Current | Proposed
---|---
![image](https://user-images.githubusercontent.com/2180540/72118570-7fd6ae80-331f-11ea-8c5b-22e81292a2f4.png) | ![image](https://user-images.githubusercontent.com/2180540/72118576-82d19f00-331f-11ea-8ddd-2a43223604e3.png)
![screencapture-192-168-7-223-9966-Themes-2020-01-09-20_37_24](https://user-images.githubusercontent.com/2180540/72118674-e2c84580-331f-11ea-89ea-a48cdb837197.png) | ![screencapture-192-168-7-223-9966-Themes-2020-01-09-20_36_46](https://user-images.githubusercontent.com/2180540/72118675-e2c84580-331f-11ea-9965-810633974a99.png)


