### PR TITLE
replace prettier (browser) with indent.js in Edit component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Master
+
+* Replace Prettier (in browser) for Indent.js to fix IE 11 compatibility issue. [#226](https://github.com/mapbox/dr-ui/pull/226)
+
 ## 0.25.2
 
 * Darken text color for `Note` and `Tag` themes. [#223](https://github.com/mapbox/dr-ui/pull/223)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6848,6 +6848,11 @@
       "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
       "dev": true
     },
+    "indent.js": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/indent.js/-/indent.js-0.3.5.tgz",
+      "integrity": "sha512-wiTA5fEz0kc8tHzY6CSujl/k62WVNvTxAZzmPe5V7MYxRCeGGibPCIYWYBzPp/bcJh3CXUO/8qrTrO/x9s1i2Q=="
+    },
     "individual": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/individual/-/individual-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "debounce": "^1.2.0",
     "downshift": "^3.2.7",
     "hastscript": "^5.0.0",
+    "indent.js": "^0.3.5",
     "prismjs": "^1.18.0",
     "react-app-polyfill": "^1.0.5",
     "react-aria-modal": "^4.0.0",

--- a/src/components/code-snippet/__tests__/__snapshots__/code-snippet.test.js.snap
+++ b/src/components/code-snippet/__tests__/__snapshots__/code-snippet.test.js.snap
@@ -53,22 +53,17 @@ exports[`CodeSnippet A CodeSnippet with every feature (edit buttons, title) rend
         <input
           name="css"
           type="hidden"
-          value="h1 {
-  color: red;
-}
-"
+          value="h1 {color: red}"
         />
         <input
           name="html"
           type="hidden"
-          value="<h1>gurd murn!</h1>
-"
+          value="<h1>gurd murn!</h1>"
         />
         <input
           name="js"
           type="hidden"
-          value="console.log(\\"hurn\\");
-"
+          value="console.log('hurn')"
         />
         <input
           name="title"
@@ -97,7 +92,7 @@ See the example: https://docs.mapbox.com//site"
         <input
           name="data"
           type="hidden"
-          value="{\\"title\\":\\"My Code\\",\\"html\\":\\"<h1>gurd murn!</h1>\\\\n\\",\\"description\\":\\"cool code by mapbox\\\\n\\\\nSee the example: [https://docs.mapbox.com//site](https://docs.mapbox.com//site)\\",\\"tags\\":[\\"mapbox\\",\\"maps\\"],\\"css\\":\\"h1 {\\\\n  color: red;\\\\n}\\\\n\\",\\"js\\":\\"console.log(\\\\\\"hurn\\\\\\");\\\\n\\",\\"css_external\\":\\"\\",\\"js_external\\":\\"\\"}"
+          value="{\\"title\\":\\"My Code\\",\\"html\\":\\"<h1>gurd murn!</h1>\\",\\"description\\":\\"cool code by mapbox\\\\n\\\\nSee the example: [https://docs.mapbox.com//site](https://docs.mapbox.com//site)\\",\\"tags\\":[\\"mapbox\\",\\"maps\\"],\\"css\\":\\"h1 {color: red}\\",\\"js\\":\\"console.log('hurn')\\",\\"css_external\\":\\"\\",\\"js_external\\":\\"\\"}"
         />
         <input
           className="btn btn--s cursor-pointer round"
@@ -210,33 +205,30 @@ exports[`CodeSnippet CodeSnippet with edit buttons and extractor renders as expe
         <input
           name="css"
           type="hidden"
-          value="body {
-  margin: 0;
-  padding: 0;
-}
-#map {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 100%;
-}
+          value="
+body { margin: 0; padding: 0; }
+#map { position: absolute; top: 0; bottom: 0; width: 100%; };
 "
         />
         <input
           name="html"
           type="hidden"
-          value="<div id=\\"map\\"></div>
+          value="
+<div id='map'></div>
+
+
 "
         />
         <input
           name="js"
           type="hidden"
-          value="mapboxgl.accessToken = \\"<your access token here>\\";
+          value="
+mapboxgl.accessToken = '<your access token here>';
 var map = new mapboxgl.Map({
-  container: \\"map\\", // container id
-  style: \\"mapbox://styles/mapbox/streets-v11\\", // stylesheet location
-  center: [-74.5, 40], // starting position [lng, lat]
-  zoom: 9 // starting zoom
+	container: 'map', // container id
+	style: 'mapbox://styles/mapbox/streets-v11', // stylesheet location
+	center: [-74.50, 40], // starting position [lng, lat]
+	zoom: 9 // starting zoom
 });
 "
         />
@@ -272,7 +264,7 @@ See the example: https://docs.mapbox.com//mapbox-gl-js/example/simple-map/"
         <input
           name="data"
           type="hidden"
-          value="{\\"title\\":\\"Display a map\\",\\"html\\":\\"<div id=\\\\\\"map\\\\\\"></div>\\\\n\\",\\"description\\":\\"Initialize a map in an HTML element with Mapbox GL JS.\\\\n\\\\nSee the example: [https://docs.mapbox.com//mapbox-gl-js/example/simple-map/](https://docs.mapbox.com//mapbox-gl-js/example/simple-map/)\\",\\"tags\\":[\\"mapbox\\",\\"maps\\"],\\"css\\":\\"body {\\\\n  margin: 0;\\\\n  padding: 0;\\\\n}\\\\n#map {\\\\n  position: absolute;\\\\n  top: 0;\\\\n  bottom: 0;\\\\n  width: 100%;\\\\n}\\\\n\\",\\"js\\":\\"mapboxgl.accessToken = \\\\\\"<your access token here>\\\\\\";\\\\nvar map = new mapboxgl.Map({\\\\n  container: \\\\\\"map\\\\\\", // container id\\\\n  style: \\\\\\"mapbox://styles/mapbox/streets-v11\\\\\\", // stylesheet location\\\\n  center: [-74.5, 40], // starting position [lng, lat]\\\\n  zoom: 9 // starting zoom\\\\n});\\\\n\\",\\"css_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css\\",\\"js_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.js\\"}"
+          value="{\\"title\\":\\"Display a map\\",\\"html\\":\\"\\\\r\\\\n<div id='map'></div>\\\\r\\\\n\\\\r\\\\n\\\\r\\\\n\\",\\"description\\":\\"Initialize a map in an HTML element with Mapbox GL JS.\\\\n\\\\nSee the example: [https://docs.mapbox.com//mapbox-gl-js/example/simple-map/](https://docs.mapbox.com//mapbox-gl-js/example/simple-map/)\\",\\"tags\\":[\\"mapbox\\",\\"maps\\"],\\"css\\":\\"\\\\r\\\\nbody { margin: 0; padding: 0; }\\\\r\\\\n#map { position: absolute; top: 0; bottom: 0; width: 100%; };\\\\r\\\\n\\",\\"js\\":\\"\\\\r\\\\nmapboxgl.accessToken = '<your access token here>';\\\\r\\\\nvar map = new mapboxgl.Map({\\\\r\\\\n\\\\tcontainer: 'map', // container id\\\\r\\\\n\\\\tstyle: 'mapbox://styles/mapbox/streets-v11', // stylesheet location\\\\r\\\\n\\\\tcenter: [-74.50, 40], // starting position [lng, lat]\\\\r\\\\n\\\\tzoom: 9 // starting zoom\\\\r\\\\n});\\\\r\\\\n\\",\\"css_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css\\",\\"js_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.js\\"}"
         />
         <input
           className="btn btn--s cursor-pointer round"

--- a/src/components/edit/__tests__/__snapshots__/edit.test.js.snap
+++ b/src/components/edit/__tests__/__snapshots__/edit.test.js.snap
@@ -27,34 +27,23 @@ Array [
     <input
       name="css"
       type="hidden"
-      value="body {
-  margin: 0;
-  padding: 0;
-}
-#map {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 100%;
-}
-"
+      value="body { margin: 0; padding: 0; }
+#map { position: absolute; top: 0; bottom: 0; width: 100%; };"
     />
     <input
       name="html"
       type="hidden"
-      value="<div id=\\"map\\"></div>
-"
+      value="<div id='map'></div>"
     />
     <input
       name="js"
       type="hidden"
       value="var map = new mapboxgl.Map({
-  container: \\"map\\", // container id
-  style: \\"mapbox://styles/mapbox/streets-v11\\", // stylesheet location
-  center: [-74.5, 40], // starting position [lng, lat]
-  zoom: 9 // starting zoom
-});
-"
+	container: 'map', // container id
+	style: 'mapbox://styles/mapbox/streets-v11', // stylesheet location
+	center: [-74.50, 40], // starting position [lng, lat]
+	zoom: 9 // starting zoom
+});"
     />
     <input
       name="title"
@@ -88,7 +77,7 @@ See the example: https://docs.mapbox.com//mapbox-gl-js/example/simple-map/"
     <input
       name="data"
       type="hidden"
-      value="{\\"title\\":\\"Display a map\\",\\"html\\":\\"<div id=\\\\\\"map\\\\\\"></div>\\\\n\\",\\"description\\":\\"Initialize a map in an HTML element with Mapbox GL JS.\\\\n\\\\nSee the example: [https://docs.mapbox.com//mapbox-gl-js/example/simple-map/](https://docs.mapbox.com//mapbox-gl-js/example/simple-map/)\\",\\"tags\\":[\\"mapbox\\",\\"maps\\"],\\"css\\":\\"body {\\\\n  margin: 0;\\\\n  padding: 0;\\\\n}\\\\n#map {\\\\n  position: absolute;\\\\n  top: 0;\\\\n  bottom: 0;\\\\n  width: 100%;\\\\n}\\\\n\\",\\"js\\":\\"var map = new mapboxgl.Map({\\\\n  container: \\\\\\"map\\\\\\", // container id\\\\n  style: \\\\\\"mapbox://styles/mapbox/streets-v11\\\\\\", // stylesheet location\\\\n  center: [-74.5, 40], // starting position [lng, lat]\\\\n  zoom: 9 // starting zoom\\\\n});\\\\n\\",\\"css_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css\\",\\"js_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.js\\",\\"head\\":\\"<meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />\\"}"
+      value="{\\"title\\":\\"Display a map\\",\\"html\\":\\"<div id='map'></div>\\",\\"description\\":\\"Initialize a map in an HTML element with Mapbox GL JS.\\\\n\\\\nSee the example: [https://docs.mapbox.com//mapbox-gl-js/example/simple-map/](https://docs.mapbox.com//mapbox-gl-js/example/simple-map/)\\",\\"tags\\":[\\"mapbox\\",\\"maps\\"],\\"css\\":\\"body { margin: 0; padding: 0; }\\\\r\\\\n#map { position: absolute; top: 0; bottom: 0; width: 100%; };\\",\\"js\\":\\"var map = new mapboxgl.Map({\\\\r\\\\n\\\\tcontainer: 'map', // container id\\\\r\\\\n\\\\tstyle: 'mapbox://styles/mapbox/streets-v11', // stylesheet location\\\\r\\\\n\\\\tcenter: [-74.50, 40], // starting position [lng, lat]\\\\r\\\\n\\\\tzoom: 9 // starting zoom\\\\r\\\\n});\\",\\"css_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css\\",\\"js_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.js\\",\\"head\\":\\"<meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />\\"}"
     />
     <input
       className="btn btn--s cursor-pointer round"

--- a/src/components/edit/edit.js
+++ b/src/components/edit/edit.js
@@ -2,12 +2,8 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import prettier from 'prettier/standalone';
-import parserCss from 'prettier/parser-postcss';
-import parserJs from 'prettier/parser-babylon';
-import parserHtml from 'prettier/parser-html';
+import indent from 'indent.js';
 import stripMd from 'remove-markdown';
-import * as Sentry from '@sentry/browser';
 
 // formats the metadata
 function meta(frontMatter) {
@@ -19,19 +15,6 @@ function meta(frontMatter) {
     description,
     tags: ['mapbox', 'maps']
   };
-}
-
-// formats the code with prettier
-function format(code, parser, plugin) {
-  try {
-    return prettier.format(code, { parser: parser, plugins: [plugin] });
-  } catch (err) {
-    Sentry.configureScope(scope => {
-      scope.setTag('type', 'edit buttons');
-    });
-    Sentry.captureException(new Error(err));
-    return code;
-  }
 }
 
 // creates a form wrapper for each platform
@@ -77,9 +60,9 @@ export default class Edit extends React.Component {
   render() {
     let { css, js, html, head, resources, frontMatter } = this.props;
     const projectMeta = meta(frontMatter);
-    css = format(css, 'css', parserCss);
-    js = format(js, 'babel', parserJs);
-    html = format(html, 'html', parserHtml);
+    css = indent.css(css);
+    js = indent.js(js);
+    html = indent.html(html);
     return (
       <>
         <Form action="https://jsfiddle.net/api/post/library/pure/">


### PR DESCRIPTION
We're using prettier in the browser to format the code for the Edit buttons. Unfortunately Prettier uses `startsWith` which is not compatible with IE11. This PR replaces Prettier with Indent.js which doesn't exactly what we need and works on IE 11.

Note: this code indentation/beautifying feature is purely cosmetic to make the code look nice when you export it. If we have any more problems with it (I don't think we will) we can scrap indenting the code.