### PR TITLE
remove code formatting from Edit component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Master
+
+* Remove code formatter (Indent.js) from `Edit` component. [#228](https://github.com/mapbox/dr-ui/pull/228)
+
 ## 0.25.3
 
 * Replace Prettier (in browser) for Indent.js to fix IE 11 compatibility issue. [#226](https://github.com/mapbox/dr-ui/pull/226)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6848,11 +6848,6 @@
       "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
       "dev": true
     },
-    "indent.js": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/indent.js/-/indent.js-0.3.5.tgz",
-      "integrity": "sha512-wiTA5fEz0kc8tHzY6CSujl/k62WVNvTxAZzmPe5V7MYxRCeGGibPCIYWYBzPp/bcJh3CXUO/8qrTrO/x9s1i2Q=="
-    },
     "individual": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/individual/-/individual-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "debounce": "^1.2.0",
     "downshift": "^3.2.7",
     "hastscript": "^5.0.0",
-    "indent.js": "^0.3.5",
     "prismjs": "^1.18.0",
     "react-app-polyfill": "^1.0.5",
     "react-aria-modal": "^4.0.0",

--- a/src/components/code-snippet/__tests__/__snapshots__/code-snippet.test.js.snap
+++ b/src/components/code-snippet/__tests__/__snapshots__/code-snippet.test.js.snap
@@ -92,7 +92,7 @@ See the example: https://docs.mapbox.com//site"
         <input
           name="data"
           type="hidden"
-          value="{\\"title\\":\\"My Code\\",\\"html\\":\\"<h1>gurd murn!</h1>\\",\\"description\\":\\"cool code by mapbox\\\\n\\\\nSee the example: [https://docs.mapbox.com//site](https://docs.mapbox.com//site)\\",\\"tags\\":[\\"mapbox\\",\\"maps\\"],\\"css\\":\\"h1 {color: red}\\",\\"js\\":\\"console.log('hurn')\\",\\"css_external\\":\\"\\",\\"js_external\\":\\"\\"}"
+          value="{\\"title\\":\\"My Code\\",\\"html\\":\\"<h1>gurd murn!</h1>\\",\\"html_pre_processor\\":\\"none\\",\\"description\\":\\"cool code by mapbox\\\\n\\\\nSee the example: [https://docs.mapbox.com//site](https://docs.mapbox.com//site)\\",\\"tags\\":[\\"mapbox\\",\\"maps\\"],\\"css\\":\\"h1 {color: red}\\",\\"css_pre_processor\\":\\"none\\",\\"js\\":\\"console.log('hurn')\\",\\"js_pre_processor\\":\\"none\\",\\"css_external\\":\\"\\",\\"js_external\\":\\"\\"}"
         />
         <input
           className="btn btn--s cursor-pointer round"
@@ -264,7 +264,7 @@ See the example: https://docs.mapbox.com//mapbox-gl-js/example/simple-map/"
         <input
           name="data"
           type="hidden"
-          value="{\\"title\\":\\"Display a map\\",\\"html\\":\\"\\\\n<div id='map'></div>\\\\n\\\\n\\\\n\\",\\"description\\":\\"Initialize a map in an HTML element with Mapbox GL JS.\\\\n\\\\nSee the example: [https://docs.mapbox.com//mapbox-gl-js/example/simple-map/](https://docs.mapbox.com//mapbox-gl-js/example/simple-map/)\\",\\"tags\\":[\\"mapbox\\",\\"maps\\"],\\"css\\":\\"\\\\n    body { margin: 0; padding: 0; }\\\\n        #map { position: absolute; top: 0; bottom: 0; width: 100%; };\\\\n\\",\\"js\\":\\"\\\\nmapboxgl.accessToken = '<your access token here>';\\\\nvar map = new mapboxgl.Map({\\\\n    container: 'map', // container id\\\\n    style: 'mapbox://styles/mapbox/streets-v11', // stylesheet location\\\\n    center: [-74.50, 40], // starting position [lng, lat]\\\\n    zoom: 9 // starting zoom\\\\n});\\\\n\\",\\"css_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css\\",\\"js_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.js\\"}"
+          value="{\\"title\\":\\"Display a map\\",\\"html\\":\\"\\\\n<div id='map'></div>\\\\n\\\\n\\\\n\\",\\"html_pre_processor\\":\\"none\\",\\"description\\":\\"Initialize a map in an HTML element with Mapbox GL JS.\\\\n\\\\nSee the example: [https://docs.mapbox.com//mapbox-gl-js/example/simple-map/](https://docs.mapbox.com//mapbox-gl-js/example/simple-map/)\\",\\"tags\\":[\\"mapbox\\",\\"maps\\"],\\"css\\":\\"\\\\n    body { margin: 0; padding: 0; }\\\\n        #map { position: absolute; top: 0; bottom: 0; width: 100%; };\\\\n\\",\\"css_pre_processor\\":\\"none\\",\\"js\\":\\"\\\\nmapboxgl.accessToken = '<your access token here>';\\\\nvar map = new mapboxgl.Map({\\\\n    container: 'map', // container id\\\\n    style: 'mapbox://styles/mapbox/streets-v11', // stylesheet location\\\\n    center: [-74.50, 40], // starting position [lng, lat]\\\\n    zoom: 9 // starting zoom\\\\n});\\\\n\\",\\"js_pre_processor\\":\\"none\\",\\"css_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css\\",\\"js_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.js\\"}"
         />
         <input
           className="btn btn--s cursor-pointer round"

--- a/src/components/code-snippet/__tests__/__snapshots__/code-snippet.test.js.snap
+++ b/src/components/code-snippet/__tests__/__snapshots__/code-snippet.test.js.snap
@@ -206,8 +206,8 @@ exports[`CodeSnippet CodeSnippet with edit buttons and extractor renders as expe
           name="css"
           type="hidden"
           value="
-body { margin: 0; padding: 0; }
-#map { position: absolute; top: 0; bottom: 0; width: 100%; };
+    body { margin: 0; padding: 0; }
+        #map { position: absolute; top: 0; bottom: 0; width: 100%; };
 "
         />
         <input
@@ -225,10 +225,10 @@ body { margin: 0; padding: 0; }
           value="
 mapboxgl.accessToken = '<your access token here>';
 var map = new mapboxgl.Map({
-	container: 'map', // container id
-	style: 'mapbox://styles/mapbox/streets-v11', // stylesheet location
-	center: [-74.50, 40], // starting position [lng, lat]
-	zoom: 9 // starting zoom
+    container: 'map', // container id
+    style: 'mapbox://styles/mapbox/streets-v11', // stylesheet location
+    center: [-74.50, 40], // starting position [lng, lat]
+    zoom: 9 // starting zoom
 });
 "
         />
@@ -264,7 +264,7 @@ See the example: https://docs.mapbox.com//mapbox-gl-js/example/simple-map/"
         <input
           name="data"
           type="hidden"
-          value="{\\"title\\":\\"Display a map\\",\\"html\\":\\"\\\\r\\\\n<div id='map'></div>\\\\r\\\\n\\\\r\\\\n\\\\r\\\\n\\",\\"description\\":\\"Initialize a map in an HTML element with Mapbox GL JS.\\\\n\\\\nSee the example: [https://docs.mapbox.com//mapbox-gl-js/example/simple-map/](https://docs.mapbox.com//mapbox-gl-js/example/simple-map/)\\",\\"tags\\":[\\"mapbox\\",\\"maps\\"],\\"css\\":\\"\\\\r\\\\nbody { margin: 0; padding: 0; }\\\\r\\\\n#map { position: absolute; top: 0; bottom: 0; width: 100%; };\\\\r\\\\n\\",\\"js\\":\\"\\\\r\\\\nmapboxgl.accessToken = '<your access token here>';\\\\r\\\\nvar map = new mapboxgl.Map({\\\\r\\\\n\\\\tcontainer: 'map', // container id\\\\r\\\\n\\\\tstyle: 'mapbox://styles/mapbox/streets-v11', // stylesheet location\\\\r\\\\n\\\\tcenter: [-74.50, 40], // starting position [lng, lat]\\\\r\\\\n\\\\tzoom: 9 // starting zoom\\\\r\\\\n});\\\\r\\\\n\\",\\"css_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css\\",\\"js_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.js\\"}"
+          value="{\\"title\\":\\"Display a map\\",\\"html\\":\\"\\\\n<div id='map'></div>\\\\n\\\\n\\\\n\\",\\"description\\":\\"Initialize a map in an HTML element with Mapbox GL JS.\\\\n\\\\nSee the example: [https://docs.mapbox.com//mapbox-gl-js/example/simple-map/](https://docs.mapbox.com//mapbox-gl-js/example/simple-map/)\\",\\"tags\\":[\\"mapbox\\",\\"maps\\"],\\"css\\":\\"\\\\n    body { margin: 0; padding: 0; }\\\\n        #map { position: absolute; top: 0; bottom: 0; width: 100%; };\\\\n\\",\\"js\\":\\"\\\\nmapboxgl.accessToken = '<your access token here>';\\\\nvar map = new mapboxgl.Map({\\\\n    container: 'map', // container id\\\\n    style: 'mapbox://styles/mapbox/streets-v11', // stylesheet location\\\\n    center: [-74.50, 40], // starting position [lng, lat]\\\\n    zoom: 9 // starting zoom\\\\n});\\\\n\\",\\"css_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css\\",\\"js_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.js\\"}"
         />
         <input
           className="btn btn--s cursor-pointer round"

--- a/src/components/edit/__tests__/__snapshots__/edit.test.js.snap
+++ b/src/components/edit/__tests__/__snapshots__/edit.test.js.snap
@@ -27,13 +27,13 @@ Array [
     <input
       name="css"
       type="hidden"
-      value="body { margin: 0; padding: 0; }
+      value="body { margin: 0; padding: 0; background: yellow; }
         #map { position: absolute; top: 0; bottom: 0; width: 100%; };"
     />
     <input
       name="html"
       type="hidden"
-      value="<div id='map'></div>"
+      value="<h1>hello world!</h1><div id='map'></div>"
     />
     <input
       name="js"
@@ -77,7 +77,7 @@ See the example: https://docs.mapbox.com//mapbox-gl-js/example/simple-map/"
     <input
       name="data"
       type="hidden"
-      value="{\\"title\\":\\"Display a map\\",\\"html\\":\\"<div id='map'></div>\\",\\"description\\":\\"Initialize a map in an HTML element with Mapbox GL JS.\\\\n\\\\nSee the example: [https://docs.mapbox.com//mapbox-gl-js/example/simple-map/](https://docs.mapbox.com//mapbox-gl-js/example/simple-map/)\\",\\"tags\\":[\\"mapbox\\",\\"maps\\"],\\"css\\":\\"body { margin: 0; padding: 0; }\\\\n        #map { position: absolute; top: 0; bottom: 0; width: 100%; };\\",\\"js\\":\\"var map = new mapboxgl.Map({\\\\n    container: 'map', // container id\\\\n    style: 'mapbox://styles/mapbox/streets-v11', // stylesheet location\\\\n    center: [-74.50, 40], // starting position [lng, lat]\\\\n    zoom: 9 // starting zoom\\\\n});\\",\\"css_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css\\",\\"js_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.js\\",\\"head\\":\\"<meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />\\"}"
+      value="{\\"title\\":\\"Display a map\\",\\"html\\":\\"<h1>hello world!</h1><div id='map'></div>\\",\\"html_pre_processor\\":\\"none\\",\\"description\\":\\"Initialize a map in an HTML element with Mapbox GL JS.\\\\n\\\\nSee the example: [https://docs.mapbox.com//mapbox-gl-js/example/simple-map/](https://docs.mapbox.com//mapbox-gl-js/example/simple-map/)\\",\\"tags\\":[\\"mapbox\\",\\"maps\\"],\\"css\\":\\"body { margin: 0; padding: 0; background: yellow; }\\\\n        #map { position: absolute; top: 0; bottom: 0; width: 100%; };\\",\\"css_pre_processor\\":\\"none\\",\\"js\\":\\"var map = new mapboxgl.Map({\\\\n    container: 'map', // container id\\\\n    style: 'mapbox://styles/mapbox/streets-v11', // stylesheet location\\\\n    center: [-74.50, 40], // starting position [lng, lat]\\\\n    zoom: 9 // starting zoom\\\\n});\\",\\"js_pre_processor\\":\\"none\\",\\"css_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css\\",\\"js_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.js\\",\\"head\\":\\"<meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />\\"}"
     />
     <input
       className="btn btn--s cursor-pointer round"

--- a/src/components/edit/__tests__/__snapshots__/edit.test.js.snap
+++ b/src/components/edit/__tests__/__snapshots__/edit.test.js.snap
@@ -28,7 +28,7 @@ Array [
       name="css"
       type="hidden"
       value="body { margin: 0; padding: 0; }
-#map { position: absolute; top: 0; bottom: 0; width: 100%; };"
+        #map { position: absolute; top: 0; bottom: 0; width: 100%; };"
     />
     <input
       name="html"
@@ -39,10 +39,10 @@ Array [
       name="js"
       type="hidden"
       value="var map = new mapboxgl.Map({
-	container: 'map', // container id
-	style: 'mapbox://styles/mapbox/streets-v11', // stylesheet location
-	center: [-74.50, 40], // starting position [lng, lat]
-	zoom: 9 // starting zoom
+    container: 'map', // container id
+    style: 'mapbox://styles/mapbox/streets-v11', // stylesheet location
+    center: [-74.50, 40], // starting position [lng, lat]
+    zoom: 9 // starting zoom
 });"
     />
     <input
@@ -77,7 +77,7 @@ See the example: https://docs.mapbox.com//mapbox-gl-js/example/simple-map/"
     <input
       name="data"
       type="hidden"
-      value="{\\"title\\":\\"Display a map\\",\\"html\\":\\"<div id='map'></div>\\",\\"description\\":\\"Initialize a map in an HTML element with Mapbox GL JS.\\\\n\\\\nSee the example: [https://docs.mapbox.com//mapbox-gl-js/example/simple-map/](https://docs.mapbox.com//mapbox-gl-js/example/simple-map/)\\",\\"tags\\":[\\"mapbox\\",\\"maps\\"],\\"css\\":\\"body { margin: 0; padding: 0; }\\\\r\\\\n#map { position: absolute; top: 0; bottom: 0; width: 100%; };\\",\\"js\\":\\"var map = new mapboxgl.Map({\\\\r\\\\n\\\\tcontainer: 'map', // container id\\\\r\\\\n\\\\tstyle: 'mapbox://styles/mapbox/streets-v11', // stylesheet location\\\\r\\\\n\\\\tcenter: [-74.50, 40], // starting position [lng, lat]\\\\r\\\\n\\\\tzoom: 9 // starting zoom\\\\r\\\\n});\\",\\"css_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css\\",\\"js_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.js\\",\\"head\\":\\"<meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />\\"}"
+      value="{\\"title\\":\\"Display a map\\",\\"html\\":\\"<div id='map'></div>\\",\\"description\\":\\"Initialize a map in an HTML element with Mapbox GL JS.\\\\n\\\\nSee the example: [https://docs.mapbox.com//mapbox-gl-js/example/simple-map/](https://docs.mapbox.com//mapbox-gl-js/example/simple-map/)\\",\\"tags\\":[\\"mapbox\\",\\"maps\\"],\\"css\\":\\"body { margin: 0; padding: 0; }\\\\n        #map { position: absolute; top: 0; bottom: 0; width: 100%; };\\",\\"js\\":\\"var map = new mapboxgl.Map({\\\\n    container: 'map', // container id\\\\n    style: 'mapbox://styles/mapbox/streets-v11', // stylesheet location\\\\n    center: [-74.50, 40], // starting position [lng, lat]\\\\n    zoom: 9 // starting zoom\\\\n});\\",\\"css_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css\\",\\"js_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.js\\",\\"head\\":\\"<meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />\\"}"
     />
     <input
       className="btn btn--s cursor-pointer round"

--- a/src/components/edit/__tests__/edit-test-cases.js
+++ b/src/components/edit/__tests__/edit-test-cases.js
@@ -10,9 +10,9 @@ testCases.basic = {
   component: Edit,
   description: 'Basic example',
   props: {
-    html: "<div id='map'></div>",
+    html: "<h1>hello world!</h1><div id='map'></div>",
     css:
-      'body { margin: 0; padding: 0; }\n        #map { position: absolute; top: 0; bottom: 0; width: 100%; };',
+      'body { margin: 0; padding: 0; background: yellow; }\n        #map { position: absolute; top: 0; bottom: 0; width: 100%; };',
     frontMatter: {
       description: 'Initialize a map in an HTML element with Mapbox GL JS.',
       pathname: '/mapbox-gl-js/example/simple-map/',
@@ -29,7 +29,7 @@ testCases.basic = {
 };
 
 const code = helpers.extractor(
-  "<!DOCTYPE html>\n<html>\n<head>\n<meta charset='utf-8' />\n<title>Display a map</title>\n<meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />\n<script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.js'></script>\n<link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css' rel='stylesheet' />\n<style>\n    body { margin: 0; padding: 0; }\n        #map { position: absolute; top: 0; bottom: 0; width: 100%; };\n</style><style>body {background: red;}</style>\n</head>\n<body>\n<div id='map'></div>\n<script>\nmapboxgl.accessToken = '<your access token here>';\nvar map = new mapboxgl.Map({\n    container: 'map', // container id\n    style: 'mapbox://styles/mapbox/streets-v11', // stylesheet location\n    center: [-74.50, 40], // starting position [lng, lat]\n    zoom: 9 // starting zoom\n});\n</script>\n\n</body>\n</html>"
+  "<!DOCTYPE html>\n<html>\n<head>\n<meta charset='utf-8' />\n<title>Display a map</title>\n<meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />\n<script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.js'></script>\n<link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css' rel='stylesheet' />\n<style>\n    body { margin: 0; padding: 0; }\n        #map { position: absolute; top: 0; bottom: 0; width: 100%; }\n</style><style>h1 {color: red;}</style>\n</head>\n<body>\n<h1>Hello world!</h1><div id='map'></div>\n<script>\nconsole.log('hi')</script>\n\n</body>\n</html>"
 );
 
 testCases.basicWithHelpers = {

--- a/src/components/edit/edit.js
+++ b/src/components/edit/edit.js
@@ -87,10 +87,13 @@ export default class Edit extends React.Component {
             value={JSON.stringify({
               title: projectMeta.title,
               html: html,
+              html_pre_processor: 'none',
               description: projectMeta.description,
               tags: projectMeta.tags,
               css: css,
+              css_pre_processor: 'none',
               js: js,
+              js_pre_processor: 'none',
               css_external:
                 resources && resources.css ? resources.css.join(';') : '',
               js_external:

--- a/src/components/edit/edit.js
+++ b/src/components/edit/edit.js
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import indent from 'indent.js';
 import stripMd from 'remove-markdown';
 
 // formats the metadata
@@ -60,9 +59,6 @@ export default class Edit extends React.Component {
   render() {
     let { css, js, html, head, resources, frontMatter } = this.props;
     const projectMeta = meta(frontMatter);
-    css = indent.css(css);
-    js = indent.js(js);
-    html = indent.html(html);
     return (
       <>
         <Form action="https://jsfiddle.net/api/post/library/pure/">


### PR DESCRIPTION
#226 was a bust. Once dr-ui is compiled, indent.js didn't have default exports for each function and broke on production. Since code formatting the exported code is purely cosmetic, I feel ok with removing it completely.

## QA Checklist

<!-- complete this checklist when adding a new component or package -->

- [x] No errors logged to console.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] IE11, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.
