### PR TITLE
use number for icon `size` to prevent small icons in firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Master
+
+* Fix icons in `Note` by setting `size` as a number to correct their size in Firefox. [#233](https://github.com/mapbox/dr-ui/pull/233)
+
 ## 0.25.4
 
 * Remove code formatter (Indent.js) from `Edit` component. [#228](https://github.com/mapbox/dr-ui/pull/228)

--- a/src/components/demo-iframe/__tests__/__snapshots__/demo-iframe.test.js.snap
+++ b/src/components/demo-iframe/__tests__/__snapshots__/demo-iframe.test.js.snap
@@ -68,8 +68,8 @@ exports[`demo-iframe Basic renders as expected 1`] = `
         role="presentation"
         style={
           Object {
-            "height": "40",
-            "width": "40",
+            "height": 40,
+            "width": 40,
           }
         }
       >
@@ -139,8 +139,8 @@ exports[`demo-iframe With token renders as expected 1`] = `
         role="presentation"
         style={
           Object {
-            "height": "40",
-            "width": "40",
+            "height": 40,
+            "width": 40,
           }
         }
       >

--- a/src/components/gl-wrapper/__tests__/__snapshots__/gl-wrapper.test.js.snap
+++ b/src/components/gl-wrapper/__tests__/__snapshots__/gl-wrapper.test.js.snap
@@ -28,8 +28,8 @@ exports[`gl-wrapper Basic renders as expected 1`] = `
         role="presentation"
         style={
           Object {
-            "height": "40",
-            "width": "40",
+            "height": 40,
+            "width": 40,
           }
         }
       >

--- a/src/components/note/__tests__/__snapshots__/note.test.js.snap
+++ b/src/components/note/__tests__/__snapshots__/note.test.js.snap
@@ -28,8 +28,8 @@ exports[`note A legacy note, has same styling as warning renders as expected 1`]
         role="presentation"
         style={
           Object {
-            "height": "40",
-            "width": "40",
+            "height": 40,
+            "width": 40,
           }
         }
       >
@@ -83,8 +83,8 @@ exports[`note A note to display an error with steps or links on how to troublesh
         role="presentation"
         style={
           Object {
-            "height": "40",
-            "width": "40",
+            "height": 40,
+            "width": 40,
           }
         }
       >
@@ -145,8 +145,8 @@ exports[`note A note to display with a message about new products or features. r
         role="presentation"
         style={
           Object {
-            "height": "40",
-            "width": "40",
+            "height": 40,
+            "width": 40,
           }
         }
       >
@@ -200,8 +200,8 @@ exports[`note A note to flag information about a beta release/product renders as
         role="presentation"
         style={
           Object {
-            "height": "40",
-            "width": "40",
+            "height": 40,
+            "width": 40,
           }
         }
       >
@@ -255,8 +255,8 @@ exports[`note A warning note to let the user know something has changed or will 
         role="presentation"
         style={
           Object {
-            "height": "40",
-            "width": "40",
+            "height": 40,
+            "width": 40,
           }
         }
       >
@@ -310,8 +310,8 @@ exports[`note Default note renders as expected 1`] = `
         role="presentation"
         style={
           Object {
-            "height": "40",
-            "width": "40",
+            "height": 40,
+            "width": 40,
           }
         }
       >
@@ -390,8 +390,8 @@ exports[`note Note with custom title. renders as expected 1`] = `
         role="presentation"
         style={
           Object {
-            "height": "40",
-            "width": "40",
+            "height": 40,
+            "width": 40,
           }
         }
       >
@@ -453,8 +453,8 @@ exports[`note download renders as expected 1`] = `
         role="presentation"
         style={
           Object {
-            "height": "40",
-            "width": "40",
+            "height": 40,
+            "width": 40,
           }
         }
       >

--- a/src/components/themes/__tests__/__snapshots__/themes.test.js.snap
+++ b/src/components/themes/__tests__/__snapshots__/themes.test.js.snap
@@ -30,8 +30,8 @@ exports[`themes Default renders as expected 1`] = `
         role="presentation"
         style={
           Object {
-            "height": "40",
-            "width": "40",
+            "height": 40,
+            "width": 40,
           }
         }
       >
@@ -84,8 +84,8 @@ exports[`themes beta renders as expected 1`] = `
           role="presentation"
           style={
             Object {
-              "height": "40",
-              "width": "40",
+              "height": 40,
+              "width": 40,
             }
           }
         >
@@ -173,8 +173,8 @@ exports[`themes download renders as expected 1`] = `
           role="presentation"
           style={
             Object {
-              "height": "40",
-              "width": "40",
+              "height": 40,
+              "width": 40,
             }
           }
         >
@@ -229,8 +229,8 @@ exports[`themes error renders as expected 1`] = `
           role="presentation"
           style={
             Object {
-              "height": "40",
-              "width": "40",
+              "height": 40,
+              "width": 40,
             }
           }
         >
@@ -323,8 +323,8 @@ exports[`themes legacy or warning renders as expected 1`] = `
           role="presentation"
           style={
             Object {
-              "height": "40",
-              "width": "40",
+              "height": 40,
+              "width": 40,
             }
           }
         >

--- a/src/components/themes/themes.js
+++ b/src/components/themes/themes.js
@@ -10,7 +10,7 @@ class Image extends React.Component {
         className={`bg-${color}-light round-full color-${color} flex-parent flex-parent--center-main flex-parent--center-cross`}
         style={{ width: 50, height: 50 }}
       >
-        <Icon name={icon} size="40" />
+        <Icon name={icon} size={40} />
       </div>
     );
   }


### PR DESCRIPTION
Fixes #232 

## QA Checklist

<!-- complete this checklist when adding a new component or package -->

- [x] No errors logged to console.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] IE11, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.
