### PR TITLE
Add `icon` option for third level items in NavigationAccordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add feature to scroll to active item in `NavigationAccordion` onload. [#247](https://github.com/mapbox/dr-ui/pull/247)
 * Improve text alignment of sidebar including `NavigationAccordion`, `SectionedNavigation`, and `PageLayout` `sidebarTitle`. [#254](https://github.com/mapbox/dr-ui/pull/254)
   - 🚨Check the `sidebarTitle` value of `PageLayout`, you should not need additional margin or padding classes. The sidebar text should line up with the `PageLayout` title text.
+* Add `icon` option for third level items in `NavigationAccordion`. [#252](https://github.com/mapbox/dr-ui/pull/252)
 
 ## 0.26.0
 

--- a/src/components/feedback/__tests__/__snapshots__/feedback.test.js.snap
+++ b/src/components/feedback/__tests__/__snapshots__/feedback.test.js.snap
@@ -147,7 +147,9 @@ exports[`feedback Feedback placement renders as expected 1`] = `
                   Section title
                 </div>
               </div>
-              <div>
+              <div
+                className="dr-ui--navigation-accordion"
+              >
                 <div
                   className="block-mm none"
                 >

--- a/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
+++ b/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
@@ -414,6 +414,211 @@ exports[`navigation-accordion Shows third level items renders as expected 1`] = 
 </div>
 `;
 
+exports[`navigation-accordion Shows third level items with icons renders as expected 1`] = `
+<div>
+  <div
+    className="block-mm none"
+  >
+    <div
+      className="pl24-mm px0 block-mm none pr12 bg-lighten75"
+    >
+      <div
+        className="py3 "
+      >
+        <a
+          className="color-blue-on-hover color-gray text-decoration-none unprose flex-parent flex-parent--space-between-main flex-parent--center-cross"
+          href="page-one"
+        >
+          <div
+            className="pl12 py12 txt-bold txt-m flex-child color-black"
+          >
+            Title one
+            
+          </div>
+        </a>
+        <div
+          className="ml24 pt0"
+        >
+          <ul
+            className="txt-m pb12 inline-block-mm none unprose"
+          >
+            <li
+              className="mb6"
+            >
+              <a
+                className="color-blue-on-hover"
+                href="#heading-one"
+              >
+                Heading one
+                
+              </a>
+              <ul
+                className="pl12 color-darken75"
+              >
+                <li
+                  className="mt6"
+                >
+                  <a
+                    className="color-blue-on-hover txt-bold"
+                    href="#"
+                  >
+                    <span
+                      className="mr6 ml-neg12 w18 h18 align-middle inline-block bg-gray-faint round-full"
+                    >
+                      <svg
+                        className="events-none icon"
+                        focusable="false"
+                        role="presentation"
+                        style={
+                          Object {
+                            "height": 16,
+                            "width": 16,
+                          }
+                        }
+                      >
+                        <use
+                          xlinkHref="#icon-paint"
+                          xmlnsXlink="http://www.w3.org/1999/xlink"
+                        />
+                      </svg>
+                    </span>
+                    Subheading one
+                    
+                  </a>
+                </li>
+                <li
+                  className="mt6"
+                >
+                  <a
+                    className="color-blue-on-hover"
+                    href="#subheading-two"
+                  >
+                    <span
+                      className="mr6 ml-neg12 w18 h18 align-middle inline-block bg-gray-faint round-full"
+                    >
+                      <svg
+                        className="events-none icon"
+                        focusable="false"
+                        role="presentation"
+                        style={
+                          Object {
+                            "height": 16,
+                            "width": 16,
+                          }
+                        }
+                      >
+                        <use
+                          xlinkHref="#icon-paint"
+                          xmlnsXlink="http://www.w3.org/1999/xlink"
+                        />
+                      </svg>
+                    </span>
+                    Subheading two
+                    
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li
+              className="mb6"
+            >
+              <a
+                className="color-blue-on-hover"
+                href="#heading-two"
+              >
+                Heading two
+                
+              </a>
+              <ul
+                className="none"
+              />
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div
+      className="pl24-mm px0 block-mm none pr12"
+    >
+      <div
+        className="py3  border-t border--gray-light"
+      >
+        <a
+          className="color-blue-on-hover color-gray text-decoration-none unprose flex-parent flex-parent--space-between-main flex-parent--center-cross"
+          href="page-two"
+        >
+          <div
+            className="pl12 py12 txt-bold txt-m flex-child"
+          >
+            Title two
+            
+          </div>
+          <div
+            className="flex-child flex-child--no-shrink"
+          >
+            <svg
+              className="events-none icon"
+              focusable="false"
+              role="presentation"
+              style={
+                Object {
+                  "height": 18,
+                  "width": 18,
+                }
+              }
+            >
+              <use
+                xlinkHref="#icon-chevron-down"
+                xmlnsXlink="http://www.w3.org/1999/xlink"
+              />
+            </svg>
+          </div>
+        </a>
+        
+      </div>
+    </div>
+  </div>
+  <div
+    className="none-mm block bg-gray-faint px24 py24"
+  >
+    <div
+      className="relative "
+    >
+      <div
+        className="select-container "
+      >
+        <select
+          aria-required={true}
+          className="select select--stroke round-full bg-white"
+          data-test="navigate-this-section-select"
+          disabled={false}
+          id="navigate-this-section"
+          onChange={[Function]}
+          value="page-one"
+        >
+          <option
+            value="page-one"
+          >
+            Title one
+          </option>
+          <option
+            value="page-two"
+          >
+            Title two
+          </option>
+        </select>
+        <div
+          className="select-arrow"
+        />
+      </div>
+      <div
+        role="alert"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`navigation-accordion Titles with tags renders as expected 1`] = `
 <div>
   <div

--- a/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
+++ b/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
@@ -434,7 +434,7 @@ exports[`navigation-accordion Shows third level items with icons renders as expe
     className="block-mm none"
   >
     <div
-      className="pl24-mm px0 block-mm none pr12 bg-lighten75"
+      className="px12 block-mm none bg-lighten75"
     >
       <div
         className="py3 "
@@ -606,7 +606,7 @@ exports[`navigation-accordion Shows third level items with icons renders as expe
       </div>
     </div>
     <div
-      className="pl24-mm px0 block-mm none pr12"
+      className="px12 block-mm none"
     >
       <div
         className="py3  border-t border--gray-light"

--- a/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
+++ b/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
@@ -462,6 +462,7 @@ exports[`navigation-accordion Shows third level items with icons renders as expe
               <a
                 className="color-blue-on-hover"
                 href="#heading-one"
+                id="#heading-one-sidebar"
               >
                 Heading one
                 
@@ -481,6 +482,7 @@ exports[`navigation-accordion Shows third level items with icons renders as expe
                   <a
                     className="color-blue-on-hover txt-bold"
                     href="#"
+                    id="#-sidebar"
                   >
                     <span
                       className="mr6 w18 h18 align-middle inline-block bg-gray-faint round-full"
@@ -518,6 +520,7 @@ exports[`navigation-accordion Shows third level items with icons renders as expe
                   <a
                     className="color-blue-on-hover"
                     href="#subheading-two"
+                    id="#subheading-two-sidebar"
                   >
                     <span
                       className="mr6 w18 h18 align-middle inline-block bg-gray-faint round-full"
@@ -555,6 +558,7 @@ exports[`navigation-accordion Shows third level items with icons renders as expe
                   <a
                     className="color-blue-on-hover"
                     href="#subheading-three"
+                    id="#subheading-three-sidebar"
                   >
                     <span
                       className="mr6 w18 h18 align-middle inline-block bg-gray-faint round-full"
@@ -588,6 +592,7 @@ exports[`navigation-accordion Shows third level items with icons renders as expe
               <a
                 className="color-blue-on-hover"
                 href="#heading-two"
+                id="#heading-two-sidebar"
               >
                 Heading two
                 

--- a/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
+++ b/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`navigation-accordion Basic renders as expected 1`] = `
-<div>
+<div
+  className="dr-ui--navigation-accordion"
+>
   <div
     className="block-mm none"
   >
@@ -143,7 +145,9 @@ exports[`navigation-accordion Basic renders as expected 1`] = `
 `;
 
 exports[`navigation-accordion No second level items renders as expected 1`] = `
-<div>
+<div
+  className="dr-ui--navigation-accordion"
+>
   <div
     className="block-mm none"
   >
@@ -250,7 +254,9 @@ exports[`navigation-accordion No second level items renders as expected 1`] = `
 `;
 
 exports[`navigation-accordion Shows third level items renders as expected 1`] = `
-<div>
+<div
+  className="dr-ui--navigation-accordion"
+>
   <div
     className="block-mm none"
   >
@@ -415,7 +421,9 @@ exports[`navigation-accordion Shows third level items renders as expected 1`] = 
 `;
 
 exports[`navigation-accordion Shows third level items with icons renders as expected 1`] = `
-<div>
+<div
+  className="dr-ui--navigation-accordion"
+>
   <div
     className="block-mm none"
   >
@@ -457,13 +465,19 @@ exports[`navigation-accordion Shows third level items with icons renders as expe
               >
                 <li
                   className="mt6"
+                  style={
+                    Object {
+                      "marginLeft": "11px",
+                      "textIndent": "-24px",
+                    }
+                  }
                 >
                   <a
                     className="color-blue-on-hover txt-bold"
                     href="#"
                   >
                     <span
-                      className="mr6 ml-neg12 w18 h18 align-middle inline-block bg-gray-faint round-full"
+                      className="mr6 w18 h18 align-middle inline-block bg-gray-faint round-full"
                     >
                       <svg
                         className="events-none icon"
@@ -488,13 +502,19 @@ exports[`navigation-accordion Shows third level items with icons renders as expe
                 </li>
                 <li
                   className="mt6"
+                  style={
+                    Object {
+                      "marginLeft": "11px",
+                      "textIndent": "-24px",
+                    }
+                  }
                 >
                   <a
                     className="color-blue-on-hover"
                     href="#subheading-two"
                   >
                     <span
-                      className="mr6 ml-neg12 w18 h18 align-middle inline-block bg-gray-faint round-full"
+                      className="mr6 w18 h18 align-middle inline-block bg-gray-faint round-full"
                     >
                       <svg
                         className="events-none icon"
@@ -514,6 +534,43 @@ exports[`navigation-accordion Shows third level items with icons renders as expe
                       </svg>
                     </span>
                     Subheading two
+                    
+                  </a>
+                </li>
+                <li
+                  className="mt6"
+                  style={
+                    Object {
+                      "marginLeft": "11px",
+                      "textIndent": "-24px",
+                    }
+                  }
+                >
+                  <a
+                    className="color-blue-on-hover"
+                    href="#subheading-three"
+                  >
+                    <span
+                      className="mr6 w18 h18 align-middle inline-block bg-gray-faint round-full"
+                    >
+                      <svg
+                        className="events-none icon"
+                        focusable="false"
+                        role="presentation"
+                        style={
+                          Object {
+                            "height": 16,
+                            "width": 16,
+                          }
+                        }
+                      >
+                        <use
+                          xlinkHref="#icon-star"
+                          xmlnsXlink="http://www.w3.org/1999/xlink"
+                        />
+                      </svg>
+                    </span>
+                    Subheading three is long so we should wrap it nicely
                     
                   </a>
                 </li>
@@ -620,7 +677,9 @@ exports[`navigation-accordion Shows third level items with icons renders as expe
 `;
 
 exports[`navigation-accordion Titles with tags renders as expected 1`] = `
-<div>
+<div
+  className="dr-ui--navigation-accordion"
+>
   <div
     className="block-mm none"
   >

--- a/src/components/navigation-accordion/__tests__/navigation-accordion-test-cases.js
+++ b/src/components/navigation-accordion/__tests__/navigation-accordion-test-cases.js
@@ -95,6 +95,49 @@ testCases.withThirdLevelItems = {
   }
 };
 
+testCases.withThirdLevelItemsWithIcons = {
+  description: 'Shows third level items with icons',
+  component: NavigationAccordion,
+  props: {
+    currentPath: 'page-one',
+    contents: {
+      firstLevelItems: [
+        {
+          title: 'Title one',
+          path: 'page-one'
+        },
+        {
+          title: 'Title two',
+          path: 'page-two'
+        }
+      ],
+      secondLevelItems: [
+        {
+          title: 'Heading one',
+          path: 'heading-one',
+          thirdLevelItems: [
+            {
+              title: 'Subheading one',
+              path: '',
+              icon: 'paint'
+            },
+            {
+              title: 'Subheading two',
+              path: 'subheading-two',
+              icon: 'paint'
+            }
+          ]
+        },
+        {
+          title: 'Heading two',
+          path: 'heading-two'
+        }
+      ]
+    },
+    onDropdownChange: () => {}
+  }
+};
+
 testCases.withTags = {
   description: 'Titles with tags',
   component: NavigationAccordion,

--- a/src/components/navigation-accordion/__tests__/navigation-accordion-test-cases.js
+++ b/src/components/navigation-accordion/__tests__/navigation-accordion-test-cases.js
@@ -125,6 +125,11 @@ testCases.withThirdLevelItemsWithIcons = {
               title: 'Subheading two',
               path: 'subheading-two',
               icon: 'paint'
+            },
+            {
+              title: 'Subheading three is long so we should wrap it nicely',
+              path: 'subheading-three',
+              icon: 'star'
             }
           ]
         },

--- a/src/components/navigation-accordion/__tests__/navigation-accordion.test.js
+++ b/src/components/navigation-accordion/__tests__/navigation-accordion.test.js
@@ -57,6 +57,24 @@ describe('navigation-accordion', () => {
     });
   });
 
+  describe(testCases.withThirdLevelItemsWithIcons.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.withThirdLevelItemsWithIcons;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
   describe(testCases.withTags.description, () => {
     let testCase;
     let wrapper;

--- a/src/components/navigation-accordion/navigation-accordion.js
+++ b/src/components/navigation-accordion/navigation-accordion.js
@@ -97,6 +97,12 @@ class NavigationAccordion extends React.PureComponent {
             return (
               <li key={subItem.path} className="mt6">
                 <a href={`#${subItem.path}`} className={itemClasses(isActive)}>
+                  {subItem.icon && (
+                    <span className="mr6 ml-neg12 w18 h18 align-middle inline-block bg-gray-faint round-full">
+                      <Icon size={16} name={subItem.icon} />
+                    </span>
+                  )}
+
                   {subItem.title}
                   {subItem.tag ? this.buildTag(subItem) : ''}
                 </a>
@@ -234,6 +240,7 @@ NavigationAccordion.propTypes = {
         thirdLevelItems: PropTypes.arrayOf(
           PropTypes.shape({
             title: PropTypes.string.isRequired,
+            icon: PropTypes.string,
             tag: PropTypes.oneOf([
               'legacy',
               'beta',

--- a/src/components/navigation-accordion/navigation-accordion.js
+++ b/src/components/navigation-accordion/navigation-accordion.js
@@ -95,10 +95,16 @@ class NavigationAccordion extends React.PureComponent {
             const isActive = state.activeh3 === subItem.path;
             if (isActive) openSubItems = true;
             return (
-              <li key={subItem.path} className="mt6">
+              <li
+                key={subItem.path}
+                className="mt6"
+                style={
+                  subItem.icon && { textIndent: '-24px', marginLeft: '11px' }
+                }
+              >
                 <a href={`#${subItem.path}`} className={itemClasses(isActive)}>
                   {subItem.icon && (
-                    <span className="mr6 ml-neg12 w18 h18 align-middle inline-block bg-gray-faint round-full">
+                    <span className="mr6 w18 h18 align-middle inline-block bg-gray-faint round-full">
                       <Icon size={16} name={subItem.icon} />
                     </span>
                   )}
@@ -176,7 +182,7 @@ class NavigationAccordion extends React.PureComponent {
       }
     );
     return (
-      <div>
+      <div className="dr-ui--navigation-accordion">
         <div className="block-mm none">{firstLevelContent}</div>
         <div className="none-mm block bg-gray-faint px24 py24">
           <NavigationDropdown

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -154,7 +154,9 @@ exports[`page-layout Common use case renders as expected 1`] = `
               Section title
             </div>
           </div>
-          <div>
+          <div
+            className="dr-ui--navigation-accordion"
+          >
             <div
               className="block-mm none"
             >
@@ -509,7 +511,9 @@ exports[`page-layout Many first level items renders as expected 1`] = `
               Section title
             </div>
           </div>
-          <div>
+          <div
+            className="dr-ui--navigation-accordion"
+          >
             <div
               className="block-mm none"
             >

--- a/src/components/search/__tests__/__snapshots__/search.test.js.snap
+++ b/src/components/search/__tests__/__snapshots__/search.test.js.snap
@@ -349,7 +349,9 @@ exports[`search Search with \`narrow\` option set renders as expected 2`] = `
                   Section title
                 </div>
               </div>
-              <div>
+              <div
+                className="dr-ui--navigation-accordion"
+              >
                 <div
                   className="block-mm none"
                 >

--- a/src/test-cases-app/index.html
+++ b/src/test-cases-app/index.html
@@ -8,6 +8,11 @@
   <link href="dist/docs-prose.css" rel="stylesheet">
   <link href="dist/prism.css" rel="stylesheet">
   <script id="assembly-js" src="dist/assembly.js"></script>
+  <style>
+  .dr-ui--navigation-accordion {
+    max-width: 400px;
+  }
+  </style>
 </head>
 <body id="docs-content">
   <script src="test-cases-app.js"></script>


### PR DESCRIPTION
This PR:

* adds an `icon` option for third level items. This option accepts a maki icon value.
* added test-case only css to set the max-width of NavigationAccordion to 400px (which is the max-width the component usually sees on the page) - this will help catch layout issues a little better.



Fixes #235

> ![image](https://user-images.githubusercontent.com/2180540/74482288-3a5b5300-4e82-11ea-8c5d-0ffeb8ec287b.png)


## How to review

1. `npm start`
2. Navigate to /NavigationAccordion
3. Test `Shows third level items with icons` test case.

I also copied this component as a test in /mapbox-gl-js-docs:

1. Open /mapbox-gl-js-docs locally, pull down the `nav-accordion-test` branch.
2. `yarn install`
3. `yarn start`
4.  Visit /mapbox-gl-js/style-spec/layers/#fill-extrusion to check the icons on the layer's page.


## QA Checklist

<!-- complete this checklist when adding a new component or package -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `5.7.0`.
  - Score should be 91% due to #248 
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.
- [x] If applicable, create a PR in a site repo, copy the component, and test it. Push to staging and instruct the reviewer to test the component in-page.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] IE11, no errors logged to console.
~~- [ ] Mobile Safari, no errors logged to console.~~ not applicable
~~- [ ] Android Chrome, no errors logged to console.~~ not applicable
