### PR TITLE
Make NavigationAccordion, SectionedAccordion, and PageLayout>sidebarTitle line up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Add feature to scroll to active item in `SectionedNavigation` onload. [#249](https://github.com/mapbox/dr-ui/pull/249)
 * Add feature to scroll to active item in `NavigationAccordion` onload. [#247](https://github.com/mapbox/dr-ui/pull/247)
+* Improve text alignment of sidebar including `NavigationAccordion`, `SectionedNavigation`, and `PageLayout` `sidebarTitle`. [#254](https://github.com/mapbox/dr-ui/pull/254)
+  - 🚨Check the `sidebarTitle` value of `PageLayout`, you should not need additional margin or padding classes. The sidebar text should line up with the `PageLayout` title text.
 
 ## 0.26.0
 

--- a/src/components/feedback/__tests__/__snapshots__/feedback.test.js.snap
+++ b/src/components/feedback/__tests__/__snapshots__/feedback.test.js.snap
@@ -135,7 +135,7 @@ exports[`feedback Feedback placement renders as expected 1`] = `
             }
           >
             <div
-              className="pt24-mm pt0 viewport-almost-mm scroll-auto-mm scroll-styled block"
+              className="pt12-mm pt0 viewport-almost-mm scroll-auto-mm scroll-styled block"
               id="dr-ui--page-layout-sidebar"
             >
               <div

--- a/src/components/feedback/__tests__/__snapshots__/feedback.test.js.snap
+++ b/src/components/feedback/__tests__/__snapshots__/feedback.test.js.snap
@@ -139,20 +139,16 @@ exports[`feedback Feedback placement renders as expected 1`] = `
               id="dr-ui--page-layout-sidebar"
             >
               <div
-                className="txt-l color-blue txt-fancy mb12 block-mm none"
+                className="txt-l color-blue txt-fancy mb12 block-mm none mx24"
               >
-                <div
-                  className="ml36"
-                >
-                  Section title
-                </div>
+                Section title
               </div>
               <div>
                 <div
                   className="block-mm none"
                 >
                   <div
-                    className="pl24-mm px0 block-mm none pr12 bg-lighten75"
+                    className="px12 block-mm none bg-lighten75"
                   >
                     <div
                       className="py3 "
@@ -207,7 +203,7 @@ exports[`feedback Feedback placement renders as expected 1`] = `
                     </div>
                   </div>
                   <div
-                    className="pl24-mm px0 block-mm none pr12"
+                    className="px12 block-mm none"
                   >
                     <div
                       className="py3  border-t border--gray-light"

--- a/src/components/feedback/__tests__/feedback-test-cases.js
+++ b/src/components/feedback/__tests__/feedback-test-cases.js
@@ -85,7 +85,7 @@ testCases.common = {
       </TopbarSticker>
       <div className="limiter">
         <PageLayout
-          sidebarTitle={<div className="ml36">Section title</div>}
+          sidebarTitle="Section title"
           sidebarContent={
             <NavigationAccordion
               currentPath="page-one"

--- a/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
+++ b/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
@@ -6,7 +6,7 @@ exports[`navigation-accordion Basic renders as expected 1`] = `
     className="block-mm none"
   >
     <div
-      className="pl24-mm px0 block-mm none pr12 bg-lighten75"
+      className="px12 block-mm none bg-lighten75"
     >
       <div
         className="py3 "
@@ -61,7 +61,7 @@ exports[`navigation-accordion Basic renders as expected 1`] = `
       </div>
     </div>
     <div
-      className="pl24-mm px0 block-mm none pr12"
+      className="px12 block-mm none"
     >
       <div
         className="py3  border-t border--gray-light"
@@ -148,7 +148,7 @@ exports[`navigation-accordion No second level items renders as expected 1`] = `
     className="block-mm none"
   >
     <div
-      className="pl24-mm px0 block-mm none pr12 bg-lighten75"
+      className="px12 block-mm none bg-lighten75"
     >
       <div
         className="py3 "
@@ -168,7 +168,7 @@ exports[`navigation-accordion No second level items renders as expected 1`] = `
       </div>
     </div>
     <div
-      className="pl24-mm px0 block-mm none pr12"
+      className="px12 block-mm none"
     >
       <div
         className="py3  border-t border--gray-light"
@@ -255,7 +255,7 @@ exports[`navigation-accordion Shows third level items renders as expected 1`] = 
     className="block-mm none"
   >
     <div
-      className="pl24-mm px0 block-mm none pr12 bg-lighten75"
+      className="px12 block-mm none bg-lighten75"
     >
       <div
         className="py3 "
@@ -333,7 +333,7 @@ exports[`navigation-accordion Shows third level items renders as expected 1`] = 
       </div>
     </div>
     <div
-      className="pl24-mm px0 block-mm none pr12"
+      className="px12 block-mm none"
     >
       <div
         className="py3  border-t border--gray-light"
@@ -420,7 +420,7 @@ exports[`navigation-accordion Titles with tags renders as expected 1`] = `
     className="block-mm none"
   >
     <div
-      className="pl24-mm px0 block-mm none pr12 bg-lighten75"
+      className="px12 block-mm none bg-lighten75"
     >
       <div
         className="py3 "
@@ -568,7 +568,7 @@ exports[`navigation-accordion Titles with tags renders as expected 1`] = `
       </div>
     </div>
     <div
-      className="pl24-mm px0 block-mm none pr12"
+      className="px12 block-mm none"
     >
       <div
         className="py3  border-t border--gray-light"

--- a/src/components/navigation-accordion/navigation-accordion.js
+++ b/src/components/navigation-accordion/navigation-accordion.js
@@ -126,12 +126,9 @@ class NavigationAccordion extends React.PureComponent {
         const textClasses = classnames('pl12 py12 txt-bold txt-m flex-child', {
           'color-black': isActive
         });
-        const activeSectionClasses = classnames(
-          'pl24-mm px0 block-mm none pr12',
-          {
-            'bg-lighten75': isActive
-          }
-        );
+        const activeSectionClasses = classnames('px12 block-mm none', {
+          'bg-lighten75': isActive
+        });
         if (!isActive) {
           icon = (
             <div className="flex-child flex-child--no-shrink">

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -23,7 +23,7 @@ exports[`page-layout Basic renders as expected 1`] = `
         }
       >
         <div
-          className="pt24-mm pt0 viewport-almost-mm scroll-auto-mm scroll-styled none block-mm"
+          className="pt12-mm pt0 viewport-almost-mm scroll-auto-mm scroll-styled none block-mm"
           id="dr-ui--page-layout-sidebar"
         >
           <div
@@ -72,7 +72,7 @@ exports[`page-layout Code highlighting test renders as expected 1`] = `
         }
       >
         <div
-          className="pt24-mm pt0 viewport-almost-mm scroll-auto-mm scroll-styled none block-mm"
+          className="pt12-mm pt0 viewport-almost-mm scroll-auto-mm scroll-styled none block-mm"
           id="dr-ui--page-layout-sidebar"
         >
           <div
@@ -142,7 +142,7 @@ exports[`page-layout Common use case renders as expected 1`] = `
         }
       >
         <div
-          className="pt24-mm pt0 viewport-almost-mm scroll-auto-mm scroll-styled block"
+          className="pt12-mm pt0 viewport-almost-mm scroll-auto-mm scroll-styled block"
           id="dr-ui--page-layout-sidebar"
         >
           <div
@@ -346,7 +346,7 @@ exports[`page-layout Custom sidebar column size renders as expected 1`] = `
         }
       >
         <div
-          className="pt24-mm pt0 viewport-almost-mm scroll-auto-mm scroll-styled none block-mm"
+          className="pt12-mm pt0 viewport-almost-mm scroll-auto-mm scroll-styled none block-mm"
           id="dr-ui--page-layout-sidebar"
         >
           <div
@@ -395,7 +395,7 @@ exports[`page-layout Custom sidebar column size, too large - default to original
         }
       >
         <div
-          className="pt24-mm pt0 viewport-almost-mm scroll-auto-mm scroll-styled none block-mm"
+          className="pt12-mm pt0 viewport-almost-mm scroll-auto-mm scroll-styled none block-mm"
           id="dr-ui--page-layout-sidebar"
         >
           <div
@@ -444,7 +444,7 @@ exports[`page-layout Custom sidebar column size, too small - default to original
         }
       >
         <div
-          className="pt24-mm pt0 viewport-almost-mm scroll-auto-mm scroll-styled none block-mm"
+          className="pt12-mm pt0 viewport-almost-mm scroll-auto-mm scroll-styled none block-mm"
           id="dr-ui--page-layout-sidebar"
         >
           <div
@@ -493,7 +493,7 @@ exports[`page-layout Many first level items renders as expected 1`] = `
         }
       >
         <div
-          className="pt24-mm pt0 viewport-almost-mm scroll-auto-mm scroll-styled block"
+          className="pt12-mm pt0 viewport-almost-mm scroll-auto-mm scroll-styled block"
           id="dr-ui--page-layout-sidebar"
         >
           <div

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -27,7 +27,7 @@ exports[`page-layout Basic renders as expected 1`] = `
           id="dr-ui--page-layout-sidebar"
         >
           <div
-            className="txt-l color-blue txt-fancy mb12 block-mm none"
+            className="txt-l color-blue txt-fancy mb12 block-mm none mx24"
           >
             Some title
           </div>
@@ -76,7 +76,7 @@ exports[`page-layout Code highlighting test renders as expected 1`] = `
           id="dr-ui--page-layout-sidebar"
         >
           <div
-            className="txt-l color-blue txt-fancy mb12 block-mm none"
+            className="txt-l color-blue txt-fancy mb12 block-mm none mx24"
           >
             Some title
           </div>
@@ -146,20 +146,16 @@ exports[`page-layout Common use case renders as expected 1`] = `
           id="dr-ui--page-layout-sidebar"
         >
           <div
-            className="txt-l color-blue txt-fancy mb12 block-mm none"
+            className="txt-l color-blue txt-fancy mb12 block-mm none mx24"
           >
-            <div
-              className="ml36"
-            >
-              Section title
-            </div>
+            Section title
           </div>
           <div>
             <div
               className="block-mm none"
             >
               <div
-                className="pl24-mm px0 block-mm none pr12 bg-lighten75"
+                className="px12 block-mm none bg-lighten75"
               >
                 <div
                   className="py3 "
@@ -214,7 +210,7 @@ exports[`page-layout Common use case renders as expected 1`] = `
                 </div>
               </div>
               <div
-                className="pl24-mm px0 block-mm none pr12"
+                className="px12 block-mm none"
               >
                 <div
                   className="py3  border-t border--gray-light"
@@ -354,7 +350,7 @@ exports[`page-layout Custom sidebar column size renders as expected 1`] = `
           id="dr-ui--page-layout-sidebar"
         >
           <div
-            className="txt-l color-blue txt-fancy mb12 block-mm none"
+            className="txt-l color-blue txt-fancy mb12 block-mm none mx24"
           >
             Some title
           </div>
@@ -403,7 +399,7 @@ exports[`page-layout Custom sidebar column size, too large - default to original
           id="dr-ui--page-layout-sidebar"
         >
           <div
-            className="txt-l color-blue txt-fancy mb12 block-mm none"
+            className="txt-l color-blue txt-fancy mb12 block-mm none mx24"
           >
             Some title
           </div>
@@ -452,7 +448,7 @@ exports[`page-layout Custom sidebar column size, too small - default to original
           id="dr-ui--page-layout-sidebar"
         >
           <div
-            className="txt-l color-blue txt-fancy mb12 block-mm none"
+            className="txt-l color-blue txt-fancy mb12 block-mm none mx24"
           >
             Some title
           </div>
@@ -501,20 +497,16 @@ exports[`page-layout Many first level items renders as expected 1`] = `
           id="dr-ui--page-layout-sidebar"
         >
           <div
-            className="txt-l color-blue txt-fancy mb12 block-mm none"
+            className="txt-l color-blue txt-fancy mb12 block-mm none mx24"
           >
-            <div
-              className="ml36"
-            >
-              Section title
-            </div>
+            Section title
           </div>
           <div>
             <div
               className="block-mm none"
             >
               <div
-                className="pl24-mm px0 block-mm none pr12 bg-lighten75"
+                className="px12 block-mm none bg-lighten75"
               >
                 <div
                   className="py3 "
@@ -569,7 +561,7 @@ exports[`page-layout Many first level items renders as expected 1`] = `
                 </div>
               </div>
               <div
-                className="pl24-mm px0 block-mm none pr12"
+                className="px12 block-mm none"
               >
                 <div
                   className="py3  border-t border--gray-light"
@@ -609,7 +601,7 @@ exports[`page-layout Many first level items renders as expected 1`] = `
                 </div>
               </div>
               <div
-                className="pl24-mm px0 block-mm none pr12"
+                className="px12 block-mm none"
               >
                 <div
                   className="py3  border-t border--gray-light"
@@ -649,7 +641,7 @@ exports[`page-layout Many first level items renders as expected 1`] = `
                 </div>
               </div>
               <div
-                className="pl24-mm px0 block-mm none pr12"
+                className="px12 block-mm none"
               >
                 <div
                   className="py3  border-t border--gray-light"
@@ -689,7 +681,7 @@ exports[`page-layout Many first level items renders as expected 1`] = `
                 </div>
               </div>
               <div
-                className="pl24-mm px0 block-mm none pr12"
+                className="px12 block-mm none"
               >
                 <div
                   className="py3  border-t border--gray-light"
@@ -729,7 +721,7 @@ exports[`page-layout Many first level items renders as expected 1`] = `
                 </div>
               </div>
               <div
-                className="pl24-mm px0 block-mm none pr12"
+                className="px12 block-mm none"
               >
                 <div
                   className="py3  border-t border--gray-light"
@@ -769,7 +761,7 @@ exports[`page-layout Many first level items renders as expected 1`] = `
                 </div>
               </div>
               <div
-                className="pl24-mm px0 block-mm none pr12"
+                className="px12 block-mm none"
               >
                 <div
                   className="py3  border-t border--gray-light"
@@ -809,7 +801,7 @@ exports[`page-layout Many first level items renders as expected 1`] = `
                 </div>
               </div>
               <div
-                className="pl24-mm px0 block-mm none pr12"
+                className="px12 block-mm none"
               >
                 <div
                   className="py3  border-t border--gray-light"
@@ -849,7 +841,7 @@ exports[`page-layout Many first level items renders as expected 1`] = `
                 </div>
               </div>
               <div
-                className="pl24-mm px0 block-mm none pr12"
+                className="px12 block-mm none"
               >
                 <div
                   className="py3  border-t border--gray-light"
@@ -889,7 +881,7 @@ exports[`page-layout Many first level items renders as expected 1`] = `
                 </div>
               </div>
               <div
-                className="pl24-mm px0 block-mm none pr12"
+                className="px12 block-mm none"
               >
                 <div
                   className="py3  border-t border--gray-light"

--- a/src/components/page-layout/__tests__/page-layout-test-cases.js
+++ b/src/components/page-layout/__tests__/page-layout-test-cases.js
@@ -61,7 +61,7 @@ testCases.common = {
   description: 'Common use case',
   component: PageLayout,
   props: {
-    sidebarTitle: <div className="ml36">Section title</div>,
+    sidebarTitle: 'Section title',
     sidebarContent: (
       <NavigationAccordion
         currentPath="page-one"
@@ -134,7 +134,7 @@ testCases.many = {
   description: 'Many first level items',
   component: PageLayout,
   props: {
-    sidebarTitle: <div className="ml36">Section title</div>,
+    sidebarTitle: 'Section title',
     sidebarContent: (
       <NavigationAccordion
         currentPath="page-one"

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -104,7 +104,7 @@ class PageLayout extends React.Component {
             top={state.topValue}
           >
             <div
-              className={`pt24-mm pt0 viewport-almost-mm scroll-auto-mm scroll-styled ${sidebarNarrowClasses}`}
+              className={`pt12-mm pt0 viewport-almost-mm scroll-auto-mm scroll-styled ${sidebarNarrowClasses}`}
               id="dr-ui--page-layout-sidebar"
             >
               {title}

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -69,7 +69,7 @@ class PageLayout extends React.Component {
     let title = '';
     if (props.sidebarTitle) {
       title = (
-        <div className="txt-l color-blue txt-fancy mb12 block-mm none">
+        <div className="txt-l color-blue txt-fancy mb12 block-mm none mx24">
           {props.sidebarTitle}
         </div>
       );

--- a/src/components/search/__tests__/__snapshots__/search.test.js.snap
+++ b/src/components/search/__tests__/__snapshots__/search.test.js.snap
@@ -337,7 +337,7 @@ exports[`search Search with \`narrow\` option set renders as expected 2`] = `
             }
           >
             <div
-              className="pt24-mm pt0 viewport-almost-mm scroll-auto-mm scroll-styled block"
+              className="pt12-mm pt0 viewport-almost-mm scroll-auto-mm scroll-styled block"
               id="dr-ui--page-layout-sidebar"
             >
               <div

--- a/src/components/search/__tests__/__snapshots__/search.test.js.snap
+++ b/src/components/search/__tests__/__snapshots__/search.test.js.snap
@@ -343,11 +343,7 @@ exports[`search Search with \`narrow\` option set renders as expected 2`] = `
               <div
                 className="txt-l color-blue txt-fancy mb12 block-mm none mx24"
               >
-                <div
-                  className="ml36"
-                >
-                  Section title
-                </div>
+                Section title
               </div>
               <div>
                 <div

--- a/src/components/search/__tests__/__snapshots__/search.test.js.snap
+++ b/src/components/search/__tests__/__snapshots__/search.test.js.snap
@@ -341,7 +341,7 @@ exports[`search Search with \`narrow\` option set renders as expected 2`] = `
               id="dr-ui--page-layout-sidebar"
             >
               <div
-                className="txt-l color-blue txt-fancy mb12 block-mm none"
+                className="txt-l color-blue txt-fancy mb12 block-mm none mx24"
               >
                 <div
                   className="ml36"
@@ -354,7 +354,7 @@ exports[`search Search with \`narrow\` option set renders as expected 2`] = `
                   className="block-mm none"
                 >
                   <div
-                    className="pl24-mm px0 block-mm none pr12 bg-lighten75"
+                    className="px12 block-mm none bg-lighten75"
                   >
                     <div
                       className="py3 "
@@ -409,7 +409,7 @@ exports[`search Search with \`narrow\` option set renders as expected 2`] = `
                     </div>
                   </div>
                   <div
-                    className="pl24-mm px0 block-mm none pr12"
+                    className="px12 block-mm none"
                   >
                     <div
                       className="py3  border-t border--gray-light"

--- a/src/components/search/__tests__/search-test-cases.js
+++ b/src/components/search/__tests__/search-test-cases.js
@@ -88,7 +88,7 @@ testCases.withLayout = {
       </TopbarSticker>
       <div className="limiter">
         <PageLayout
-          sidebarTitle={<div className="ml36">Section title</div>}
+          sidebarTitle="Section title"
           sidebarContent={
             <NavigationAccordion
               currentPath="page-one"

--- a/src/components/sectioned-navigation/__tests__/__snapshots__/sectioned-navigation.test.js.snap
+++ b/src/components/sectioned-navigation/__tests__/__snapshots__/sectioned-navigation.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`sectioned-navigation With a title, linked section headings, and counts renders as expected 1`] = `
 <div
+  className="mx24"
   data-swiftype-index="false"
 >
   <div
@@ -71,6 +72,7 @@ exports[`sectioned-navigation With a title, linked section headings, and counts 
 
 exports[`sectioned-navigation With a title, linked section headings, counts, and filter renders as expected 1`] = `
 <div
+  className="mx24"
   data-swiftype-index="false"
 >
   <div
@@ -79,7 +81,7 @@ exports[`sectioned-navigation With a title, linked section headings, counts, and
     Examples
   </div>
   <div
-    className="mb18"
+    className="mb3"
   >
     <div
       className="relative bg-white"
@@ -162,6 +164,7 @@ exports[`sectioned-navigation With a title, linked section headings, counts, and
 
 exports[`sectioned-navigation Without title, without linked section headings, without counts renders as expected 1`] = `
 <div
+  className="mx24"
   data-swiftype-index="false"
 >
   <div
@@ -222,6 +225,7 @@ exports[`sectioned-navigation Without title, without linked section headings, wi
 
 exports[`sectioned-navigation Without title, without sub items renders as expected 1`] = `
 <div
+  className="mx24"
   data-swiftype-index="false"
 >
   <a

--- a/src/components/sectioned-navigation/sectioned-navigation.js
+++ b/src/components/sectioned-navigation/sectioned-navigation.js
@@ -30,7 +30,7 @@ class SectionedNavigation extends React.Component {
       return null;
     }
     return (
-      <div className="mb18">
+      <div className="mb3">
         <ControlText
           onChange={e => this.setState({ filter: e }, this.filterResults)}
           value={this.state.filter}
@@ -73,7 +73,7 @@ class SectionedNavigation extends React.Component {
         };
       });
     return (
-      <div data-swiftype-index="false">
+      <div className="mx24" data-swiftype-index="false">
         {this.renderTitle()}
         {this.renderFilterBar()}
         {visibleSections.map((section, i) => (


### PR DESCRIPTION
This PR makes sure all sidebar items are lined up:

* Fixes uneven side spacing on NavigationAccordion, fixes #253 
* Adds the same padding to sidebarTitle in PageLayout
* Give SectionedAccordion same spacing

Current | Proposed
---|---
![image](https://user-images.githubusercontent.com/2180540/74968938-b822df80-53e9-11ea-9425-6b79de8a94ef.png)  | ![image](https://user-images.githubusercontent.com/2180540/74969280-45663400-53ea-11ea-91dc-99539f0f569b.png)
![image](https://user-images.githubusercontent.com/2180540/74970349-397b7180-53ec-11ea-8d9a-3dac44a2f8c2.png) | ![image](https://user-images.githubusercontent.com/2180540/74970367-426c4300-53ec-11ea-93e8-86928214cbf6.png)


## How to review

1. `npm start`
2. Navigate to /NavigationAccordion, /SectionedNavigation; /Feedback as a nice PageLayout example that you can preview

I also copied this component as a test in /mapbox-gl-js-docs:

1. Open /mapbox-gl-js-docs locally, pull down the `nav-accordion-test` branch.
2. `yarn install`
3. `yarn start`
4.  Visit every /overview, /api, /examples to make sure all sidebar items are lined up.


## QA Checklist

<!-- complete this checklist when adding a new component or package -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `7.5.0`. Tested a few pages and didn't get 100% due to #248 and test-cases app having the docs Id baked in:
  - SectionedNavigation - 90
  - PageLayout - 90
  - NavigationAccordion - 91
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.
- [x] If applicable, create a PR in a site repo, copy the component, and test it. Push to staging and instruct the reviewer to test the component in-page.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] IE11, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.
