### PR TITLE
Send basic user metadata along with Feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   - 🚨Check the `sidebarTitle` value of `PageLayout`, you should not need additional margin or padding classes. The sidebar text should line up with the `PageLayout` title text.
 * Add `icon` option for third level items in `NavigationAccordion`. [#252](https://github.com/mapbox/dr-ui/pull/252)
 * Add Sentry to `Feedback` to catch failed forward-event events. [#256](https://github.com/mapbox/dr-ui/pull/256)
+* Send basic user metadata to Sentry through the `Feedback` component. [#255](https://github.com/mapbox/dr-ui/pull/255)
+  - 🚨 The `userName` prop has been replaced by `user` object.
 
 ## 0.26.0
 

--- a/src/components/feedback/__tests__/__snapshots__/feedback.test.js.snap
+++ b/src/components/feedback/__tests__/__snapshots__/feedback.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`feedback Basic (sends user information as \`decorah\`) renders as expected 1`] = `
+exports[`feedback Basic (sends user information as \`crocsfan19\`) renders as expected 1`] = `
 <div
   className="bg-gray-faint py12 px18 round color-gray"
 >

--- a/src/components/feedback/__tests__/__snapshots__/feedback.test.js.snap
+++ b/src/components/feedback/__tests__/__snapshots__/feedback.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`feedback Basic renders as expected 1`] = `
+exports[`feedback Basic (sends user information as \`decorah\`) renders as expected 1`] = `
 <div
   className="bg-gray-faint py12 px18 round color-gray"
 >
@@ -32,7 +32,7 @@ exports[`feedback Basic renders as expected 1`] = `
 </div>
 `;
 
-exports[`feedback Change type renders as expected 1`] = `
+exports[`feedback Change type (sends anonymous user information) renders as expected 1`] = `
 <div
   className="bg-gray-faint py12 px18 round color-gray"
 >
@@ -64,7 +64,7 @@ exports[`feedback Change type renders as expected 1`] = `
 </div>
 `;
 
-exports[`feedback Feedback placement renders as expected 1`] = `
+exports[`feedback Feedback placement (sends anonymous user information) renders as expected 1`] = `
 <div>
   <div
     className="sticky-outer-wrapper"

--- a/src/components/feedback/__tests__/feedback-sent-rating.test.js
+++ b/src/components/feedback/__tests__/feedback-sent-rating.test.js
@@ -46,7 +46,7 @@ describe('Sent helpful rating - yes', () => {
             search: ''
           },
           page: { hash: '#lnglat', pathname: '/mapbox-gl-js/api/' },
-          planId: 'staff',
+          plan: 'staff',
           section: undefined,
           site: 'dr-ui',
           userId: 'decorah'
@@ -99,7 +99,7 @@ describe('Sent helpful rating - no', () => {
             search: ''
           },
           page: { hash: '#lnglat', pathname: '/mapbox-gl-js/api/' },
-          planId: 'staff',
+          plan: 'staff',
           section: undefined,
           site: 'dr-ui',
           userId: 'decorah'

--- a/src/components/feedback/__tests__/feedback-sent-rating.test.js
+++ b/src/components/feedback/__tests__/feedback-sent-rating.test.js
@@ -15,10 +15,10 @@ describe('Sent helpful rating - yes', () => {
         hash: '#lnglat'
       }}
       user={{
-        id: 'decorah',
-        email: 'decorah@mapbox.com',
+        id: 'crocsfan19',
+        email: 'crocsfan19@mapbox.com',
         plan: {
-          id: 'staff'
+          id: 'starter'
         }
       }}
       webhook={{
@@ -32,7 +32,7 @@ describe('Sent helpful rating - yes', () => {
     expect(feedback.state()).toEqual({
       event: {
         event: 'Sent docs feedback',
-        userId: 'decorah',
+        userId: 'crocsfan19',
         properties: {
           environment: 'staging',
           helpful: true,
@@ -46,10 +46,10 @@ describe('Sent helpful rating - yes', () => {
             search: ''
           },
           page: { hash: '#lnglat', pathname: '/mapbox-gl-js/api/' },
-          plan: 'staff',
+          plan: 'starter',
           section: undefined,
           site: 'dr-ui',
-          userId: 'decorah'
+          userId: 'crocsfan19'
         }
       },
       feedback: undefined,
@@ -68,10 +68,10 @@ describe('Sent helpful rating - no', () => {
         hash: '#lnglat'
       }}
       user={{
-        id: 'decorah',
-        email: 'decorah@mapbox.com',
+        id: 'crocsfan19',
+        email: 'crocsfan19@mapbox.com',
         plan: {
-          id: 'staff'
+          id: 'starter'
         }
       }}
       webhook={{
@@ -85,7 +85,7 @@ describe('Sent helpful rating - no', () => {
     expect(feedback.state()).toEqual({
       event: {
         event: 'Sent docs feedback',
-        userId: 'decorah',
+        userId: 'crocsfan19',
         properties: {
           environment: 'staging',
           helpful: false,
@@ -99,10 +99,10 @@ describe('Sent helpful rating - no', () => {
             search: ''
           },
           page: { hash: '#lnglat', pathname: '/mapbox-gl-js/api/' },
-          plan: 'staff',
+          plan: 'starter',
           section: undefined,
           site: 'dr-ui',
-          userId: 'decorah'
+          userId: 'crocsfan19'
         }
       },
       feedback: undefined,

--- a/src/components/feedback/__tests__/feedback-sent-rating.test.js
+++ b/src/components/feedback/__tests__/feedback-sent-rating.test.js
@@ -14,7 +14,13 @@ describe('Sent helpful rating - yes', () => {
         pathname: '/mapbox-gl-js/api/',
         hash: '#lnglat'
       }}
-      userName="decorah"
+      user={{
+        id: 'decorah',
+        email: 'decorah@mapbox.com',
+        plan: {
+          id: 'staff'
+        }
+      }}
       webhook={{
         production: '',
         staging: ''
@@ -40,6 +46,7 @@ describe('Sent helpful rating - yes', () => {
             search: ''
           },
           page: { hash: '#lnglat', pathname: '/mapbox-gl-js/api/' },
+          planId: 'staff',
           section: undefined,
           site: 'dr-ui',
           userId: 'decorah'
@@ -60,7 +67,13 @@ describe('Sent helpful rating - no', () => {
         pathname: '/mapbox-gl-js/api/',
         hash: '#lnglat'
       }}
-      userName="decorah"
+      user={{
+        id: 'decorah',
+        email: 'decorah@mapbox.com',
+        plan: {
+          id: 'staff'
+        }
+      }}
       webhook={{
         production: '',
         staging: ''
@@ -86,6 +99,7 @@ describe('Sent helpful rating - no', () => {
             search: ''
           },
           page: { hash: '#lnglat', pathname: '/mapbox-gl-js/api/' },
+          planId: 'staff',
           section: undefined,
           site: 'dr-ui',
           userId: 'decorah'

--- a/src/components/feedback/__tests__/feedback-sent-text.test.js
+++ b/src/components/feedback/__tests__/feedback-sent-text.test.js
@@ -15,10 +15,10 @@ describe('Sent text feedback', () => {
         hash: '#lnglat'
       }}
       user={{
-        id: 'decorah',
-        email: 'decorah@mapbox.com',
+        id: 'crocsfan19',
+        email: 'crocsfan19@mapbox.com',
         plan: {
-          id: 'staff'
+          id: 'starter'
         }
       }}
       webhook={{
@@ -48,7 +48,7 @@ describe('Sent text feedback', () => {
     expect(feedback.state()).toEqual({
       event: {
         event: 'Sent docs feedback',
-        userId: 'decorah',
+        userId: 'crocsfan19',
         properties: {
           environment: 'staging',
           feedback: 'cool beans!',
@@ -66,10 +66,10 @@ describe('Sent text feedback', () => {
             hash: '#lnglat',
             pathname: '/mapbox-gl-js/api/'
           },
-          plan: 'staff',
+          plan: 'starter',
           section: undefined,
           site: 'dr-ui',
-          userId: 'decorah'
+          userId: 'crocsfan19'
         }
       },
       feedback: 'cool beans!',

--- a/src/components/feedback/__tests__/feedback-sent-text.test.js
+++ b/src/components/feedback/__tests__/feedback-sent-text.test.js
@@ -14,7 +14,13 @@ describe('Sent text feedback', () => {
         pathname: '/mapbox-gl-js/api/',
         hash: '#lnglat'
       }}
-      userName="decorah"
+      user={{
+        id: 'decorah',
+        email: 'decorah@mapbox.com',
+        plan: {
+          id: 'staff'
+        }
+      }}
       webhook={{
         production: '',
         staging: ''
@@ -60,6 +66,7 @@ describe('Sent text feedback', () => {
             hash: '#lnglat',
             pathname: '/mapbox-gl-js/api/'
           },
+          planId: 'staff',
           section: undefined,
           site: 'dr-ui',
           userId: 'decorah'

--- a/src/components/feedback/__tests__/feedback-sent-text.test.js
+++ b/src/components/feedback/__tests__/feedback-sent-text.test.js
@@ -66,7 +66,7 @@ describe('Sent text feedback', () => {
             hash: '#lnglat',
             pathname: '/mapbox-gl-js/api/'
           },
-          planId: 'staff',
+          plan: 'staff',
           section: undefined,
           site: 'dr-ui',
           userId: 'decorah'

--- a/src/components/feedback/__tests__/feedback-test-cases.js
+++ b/src/components/feedback/__tests__/feedback-test-cases.js
@@ -10,7 +10,7 @@ const testCases = {};
 
 testCases.basic = {
   component: Feedback,
-  description: 'Basic (sends user information as `decorah`)',
+  description: 'Basic (sends user information as `crocsfan19`)',
   props: {
     site: 'dr-ui',
     webhook: {
@@ -21,10 +21,10 @@ testCases.basic = {
     },
     preferredLanguage: 'Swift',
     user: {
-      id: 'decorah',
-      email: 'decorah@mapbox.com',
+      id: 'crocsfan19',
+      email: 'crocsfan19@mapbox.com',
       plan: {
-        id: 'staff'
+        id: 'starter'
       }
     },
     section: 'LngLat',

--- a/src/components/feedback/__tests__/feedback-test-cases.js
+++ b/src/components/feedback/__tests__/feedback-test-cases.js
@@ -12,7 +12,7 @@ testCases.basic = {
   component: Feedback,
   description: 'Basic',
   props: {
-    site: 'Mapbox GL JS',
+    site: 'dr-ui',
     webhook: {
       staging:
         'https://evj5gwoa8j.execute-api.us-east-1.amazonaws.com/hookshot/webhook',
@@ -20,9 +20,16 @@ testCases.basic = {
         'https://2n40g6lyc9.execute-api.us-east-1.amazonaws.com/hookshot/webhook'
     },
     preferredLanguage: 'Swift',
+    user: {
+      id: 'decorah',
+      email: 'decorah@mapbox.com',
+      plan: {
+        id: 'staff'
+      }
+    },
     section: 'LngLat',
     location: {
-      pathname: '/mapbox-gl-js/api/',
+      pathname: '/dr-ui/feedback/',
       hash: '#lnglat'
     }
   }
@@ -33,7 +40,7 @@ testCases.type = {
   description: 'Change type',
   props: {
     type: 'section',
-    site: 'Help',
+    site: 'dr-ui',
     webhook: {
       staging:
         'https://evj5gwoa8j.execute-api.us-east-1.amazonaws.com/hookshot/webhook',
@@ -48,7 +55,7 @@ testCases.noSentry = {
   component: Feedback,
   description: 'Does not send text feedback to Sentry',
   props: {
-    site: 'Mapbox GL JS',
+    site: 'dr-ui',
     webhook: {
       staging:
         'https://evj5gwoa8j.execute-api.us-east-1.amazonaws.com/hookshot/webhook',
@@ -59,7 +66,7 @@ testCases.noSentry = {
     preferredLanguage: 'Swift',
     section: 'LngLat',
     location: {
-      pathname: '/mapbox-gl-js/api/',
+      pathname: '/dr-ui/api/',
       hash: '#lnglat'
     }
   }
@@ -137,7 +144,7 @@ testCases.common = {
             </p>
 
             <Feedback
-              site="Help"
+              site="dr-ui"
               location={{}}
               webhook={{
                 staging:

--- a/src/components/feedback/__tests__/feedback-test-cases.js
+++ b/src/components/feedback/__tests__/feedback-test-cases.js
@@ -10,7 +10,7 @@ const testCases = {};
 
 testCases.basic = {
   component: Feedback,
-  description: 'Basic',
+  description: 'Basic (sends user information as `decorah`)',
   props: {
     site: 'dr-ui',
     webhook: {
@@ -37,7 +37,7 @@ testCases.basic = {
 
 testCases.type = {
   component: Feedback,
-  description: 'Change type',
+  description: 'Change type (sends anonymous user information)',
   props: {
     type: 'section',
     site: 'dr-ui',
@@ -53,7 +53,8 @@ testCases.type = {
 
 testCases.noSentry = {
   component: Feedback,
-  description: 'Does not send text feedback to Sentry',
+  description:
+    'Does not send text feedback to Sentry (sends anonymous user information)',
   props: {
     site: 'dr-ui',
     webhook: {
@@ -73,7 +74,7 @@ testCases.noSentry = {
 };
 
 testCases.common = {
-  description: 'Feedback placement',
+  description: 'Feedback placement (sends anonymous user information)',
   element: (
     <div>
       <TopbarSticker>

--- a/src/components/feedback/feedback.js
+++ b/src/components/feedback/feedback.js
@@ -75,8 +75,7 @@ class Feedback extends React.Component {
       event: 'Sent docs feedback',
       // set user if available (needed for forward-event request)
       ...(this.props.user && this.props.user && { userId: this.props.user.id }),
-      ...(!this.props.user &&
-        !this.props.user.id && { anonymousId: anonymousId }),
+      ...(!this.props.user && { anonymousId: anonymousId }),
       properties: {
         // true, false
         helpful: this.state.helpful,
@@ -92,8 +91,7 @@ class Feedback extends React.Component {
         ...(this.props.user &&
           this.props.user && { userId: this.props.user.id }),
         // set anonymousId, if userId is unavailable
-        ...(!this.props.user &&
-          !this.props.user.id && { anonymousId: anonymousId }),
+        ...(!this.props.user && { anonymousId: anonymousId }),
         // set plan, if available
         ...(this.props.user &&
           this.props.user.plan && { planId: this.props.user.plan.id }),

--- a/src/components/feedback/feedback.js
+++ b/src/components/feedback/feedback.js
@@ -74,25 +74,30 @@ class Feedback extends React.Component {
     return {
       event: 'Sent docs feedback',
       // set user if available (needed for forward-event request)
-      userId: this.props.userName || undefined,
-      ...(!this.props.userName && { anonymousId: anonymousId }),
+      userId: this.props.user.id || undefined,
+      ...(!this.props.user.id && { anonymousId: anonymousId }),
       properties: {
-        // true, false,
+        // true, false
         helpful: this.state.helpful,
-        // text feedback
+        // text feedback, if available
         ...(this.state.feedback && { feedback: this.state.feedback }),
-        // name of current site, helpful for filtering in Mode
+        // name of current site, important for filtering in Mode
         site: this.props.site,
         // (optional) name of section for longer pagers, helpful for fitering in Mode and identifying section areas
         section: this.props.section || undefined,
         // get page context
         page: this.props.location || undefined,
-        // set user if available (needed for mode reports)
-        userId: this.props.userName || undefined,
-        ...(!this.props.userName && { anonymousId: anonymousId }),
-        // staging or production
-        environment,
-        // pull window.location
+        // set user, if available (needed for mode reports)
+        ...(this.props.user &&
+          this.props.user && { userId: this.props.user.id }),
+        // set anonymousId, if userId is unavailable
+        ...(!this.props.user && { anonymousId: anonymousId }),
+        // set plan, if available
+        ...(this.props.user &&
+          this.props.user.plan && { planId: this.props.user.plan.id }),
+        // get environment: staging or production
+        environment: environment,
+        // get full window location
         location: {
           hash: location.hash,
           host: location.host,
@@ -116,20 +121,38 @@ class Feedback extends React.Component {
 
   // sends text feedback to Sentry
   sendToSentry = (level, error) => {
+    // initialize Sentry project to send the feedback
     Sentry.init({
       dsn: this.props.feedbackSentryDsn,
       environment
     });
+    // configure data to send with feeedback
     Sentry.configureScope(scope => {
-      scope.setTag('site', this.props.site); // site name
-      scope.setTag('helpful', this.state.helpful); // the user's boolean rating
-      if (this.props.section) scope.setTag('section', this.props.section); // section of the page (if available)
+      // set tag for site name
+      scope.setTag('site', this.props.site);
+      // set tag for the user's boolean rating
+      scope.setTag('helpful', this.state.helpful);
+      // set tag for the section of the page (if available)
+      if (this.props.section) scope.setTag('section', this.props.section);
+      // set tags for the user's preferred language (if available)
       if (this.props.preferredLanguage)
-        scope.setTag('preferredLanguage', this.props.preferredLanguage); // user's preferred language (if available)
-      scope.setLevel(level || 'info'); // sets the message as "info" by default
-      if (error) Sentry.setExtra('error', error); // send error message (if available)
+        scope.setTag('preferredLanguage', this.props.preferredLanguage);
+      // set user attributes (if available)
+      if (this.props.user) {
+        Sentry.setUser({
+          ...(this.props.user.id && { username: this.props.user.id }),
+          ...(this.props.user.email && { email: this.props.user.email }),
+          ...(this.props.user.plan &&
+            this.props.user.plan.id && { plan: this.props.user.plan.id })
+        });
+      }
+      // send error message (if available)
+      if (error) Sentry.setExtra('error', error);
+      // set the message as "info" (rather than warning)
+      scope.setLevel(level || 'info');
     });
-    Sentry.captureMessage(this.state.feedback); // capture the feedback as a message
+    // capture the feedback as a message
+    Sentry.captureMessage(this.state.feedback);
   };
 
   render() {
@@ -221,7 +244,12 @@ Feedback.propTypes = {
     staging: PropTypes.string.isRequired,
     production: PropTypes.string.isRequired
   }), // staging and production webhook URLs to send forward event data to
-  userName: PropTypes.string, // userid if available
+  user: PropTypes.shape({
+    // user object if available
+    id: PropTypes.string,
+    email: PropTypes.string,
+    plan: PropTypes.shape({ id: PropTypes.string })
+  }),
   preferredLanguage: PropTypes.string, // preferred code language if available
   feedbackSentryDsn: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]) // Sentry DSN (URL) to send text feedback to for issue management or "false" to not send feedback to Sentry
 };

--- a/src/components/feedback/feedback.js
+++ b/src/components/feedback/feedback.js
@@ -73,24 +73,25 @@ class Feedback extends React.Component {
   createSegmentEvent = () => {
     return {
       event: 'Sent docs feedback',
-      // set user if available (needed for forward-event request)
-      ...(this.props.user && this.props.user && { userId: this.props.user.id }),
-      ...(!this.props.user && { anonymousId: anonymousId }),
+      // set user if available else set anonymousId (needed for forward-event request)
+      ...(this.props.user && this.props.user.id
+        ? { userId: this.props.user.id }
+        : { anonymousId: anonymousId }),
       properties: {
         // true, false
         helpful: this.state.helpful,
         // text feedback, if available
         ...(this.state.feedback && { feedback: this.state.feedback }),
-        // name of current site, important for filtering in Mode
+        // name of current site (important for filtering in Mode)
         site: this.props.site,
         // (optional) name of section for longer pagers, helpful for fitering in Mode and identifying section areas
         section: this.props.section || undefined,
         // get page context
         page: this.props.location || undefined,
-        // set user, if available (needed for mode reports)
-        ...(this.props.user &&
-          this.props.user && { userId: this.props.user.id }),
-        // set anonymousId, if userId is unavailable
+        // set user if available else set anonymousId (needed for Mode)
+        ...(this.props.user && this.props.user.id
+          ? { userId: this.props.user.id }
+          : { anonymousId: anonymousId }),
         ...(!this.props.user && { anonymousId: anonymousId }),
         // set plan, if available
         ...(this.props.user &&
@@ -138,7 +139,7 @@ class Feedback extends React.Component {
       if (this.props.preferredLanguage)
         scope.setTag('preferredLanguage', this.props.preferredLanguage);
       // set tags for the user's plan (if available)
-      if (this.props.user.plan && this.props.user.plan.id)
+      if (this.props.user && this.props.user.plan && this.props.user.plan.id)
         scope.setTag('plan', this.props.user.plan.id);
       // set user attributes (if available)
       if (this.props.user) {

--- a/src/components/feedback/feedback.js
+++ b/src/components/feedback/feedback.js
@@ -94,7 +94,7 @@ class Feedback extends React.Component {
         ...(!this.props.user && { anonymousId: anonymousId }),
         // set plan, if available
         ...(this.props.user &&
-          this.props.user.plan && { planId: this.props.user.plan.id }),
+          this.props.user.plan && { plan: this.props.user.plan.id }),
         // get environment: staging or production
         environment: environment,
         // get full window location
@@ -143,7 +143,9 @@ class Feedback extends React.Component {
           ...(this.props.user.id && { username: this.props.user.id }),
           ...(this.props.user.email && { email: this.props.user.email }),
           ...(this.props.user.plan &&
-            this.props.user.plan.id && { plan: this.props.user.plan.id })
+            this.props.user.plan.id && {
+              data: { plan: this.props.user.plan.id }
+            })
         });
       }
       // send error message (if available)

--- a/src/components/feedback/feedback.js
+++ b/src/components/feedback/feedback.js
@@ -137,6 +137,9 @@ class Feedback extends React.Component {
       // set tags for the user's preferred language (if available)
       if (this.props.preferredLanguage)
         scope.setTag('preferredLanguage', this.props.preferredLanguage);
+      // set tags for the user's plan (if available)
+      if (this.props.user.plan && this.props.user.plan.id)
+        scope.setTag('plan', this.props.user.plan.id);
       // set user attributes (if available)
       if (this.props.user) {
         Sentry.setUser({

--- a/src/components/feedback/feedback.js
+++ b/src/components/feedback/feedback.js
@@ -74,8 +74,9 @@ class Feedback extends React.Component {
     return {
       event: 'Sent docs feedback',
       // set user if available (needed for forward-event request)
-      userId: this.props.user.id || undefined,
-      ...(!this.props.user.id && { anonymousId: anonymousId }),
+      ...(this.props.user && this.props.user && { userId: this.props.user.id }),
+      ...(!this.props.user &&
+        !this.props.user.id && { anonymousId: anonymousId }),
       properties: {
         // true, false
         helpful: this.state.helpful,
@@ -91,7 +92,8 @@ class Feedback extends React.Component {
         ...(this.props.user &&
           this.props.user && { userId: this.props.user.id }),
         // set anonymousId, if userId is unavailable
-        ...(!this.props.user && { anonymousId: anonymousId }),
+        ...(!this.props.user &&
+          !this.props.user.id && { anonymousId: anonymousId }),
         // set plan, if available
         ...(this.props.user &&
           this.props.user.plan && { planId: this.props.user.plan.id }),


### PR DESCRIPTION
This PR:
- Replaces the Feedback component's `userName` prop with the `user` object (which we will populate using a docs-page-shell function)
- Sends `plan` information to Segment 
- Sends user data (username, plan, email) to Sentry
- Adds line comments

To do:

* [x] Decide if `plan` should be a tag or part of the user object.

## How to test

1. `npm start` and open /Feedback test case app OR test the /api-documentation branch `dr-ui-0.27.0` locally
2. You should check the response in two places:
   - #bots (Segment) 
   - [docs-feedback Sentry project](https://sentry.io/organizations/mapboxcom/issues/?environment=staging&project=1848287&referrer=slack)

On the /api-documentation branch, try sending feedback signed in and signed out. Look for:
- signed in - Your userId and plan are found in the #bots event object. Your userId and email are found in the "User" section of the Sentry issue and your plan is set as a tag.
- signed out - No user information is passed, only an anonymousId.


## QA Checklist

<!-- complete this checklist when adding a new component or package -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `5.7.0`.
    - Score should be 89, due to #257 #248 and the `#docs-content` id that's baked into the test-cases app
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.
- [x] If applicable, create a PR in a site repo, copy the component, and test it. Push to staging and instruct the reviewer to test the component in-page.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] IE11, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.
