### PR TITLE
Add tests to assert Segment event in Feedback component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Improve text alignment of sidebar including `NavigationAccordion`, `SectionedNavigation`, and `PageLayout` `sidebarTitle`. [#254](https://github.com/mapbox/dr-ui/pull/254)
   - 🚨Check the `sidebarTitle` value of `PageLayout`, you should not need additional margin or padding classes. The sidebar text should line up with the `PageLayout` title text.
 * Add `icon` option for third level items in `NavigationAccordion`. [#252](https://github.com/mapbox/dr-ui/pull/252)
+* Add Sentry to `Feedback` to catch failed forward-event events. [#256](https://github.com/mapbox/dr-ui/pull/256)
 
 ## 0.26.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12540,6 +12540,11 @@
         }
       }
     },
+    "slugify": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.6.tgz",
+      "integrity": "sha512-wA9XS475ZmGNlEnYYLPReSfuz/c3VQsEMoU43mi6OnKMCdbnFXd4/Yg7J0lBv8jkPolacMpOrWEaoYxuE1+hoQ=="
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1821,59 +1821,59 @@
       }
     },
     "@sentry/browser": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.11.0.tgz",
-      "integrity": "sha512-+POFe768M6de+y6IK1jB+zXXpSPSekQ47retE5YLuGwdI5vBgB7V7/Zcv++Vrr5TR+TOwBxNQEuq7Z/bySeksw==",
+      "version": "5.12.4",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.12.4.tgz",
+      "integrity": "sha512-D74LtB9sevPpYgczYsbKTcx7IdCxHPuv5JxD9YQfzNmpCzBiwlUGqr3u03SdVOwmdVrzfRLjxO+vYPe071zjbA==",
       "requires": {
-        "@sentry/core": "5.11.0",
-        "@sentry/types": "5.11.0",
-        "@sentry/utils": "5.11.0",
+        "@sentry/core": "5.12.4",
+        "@sentry/types": "5.12.4",
+        "@sentry/utils": "5.12.4",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.11.0.tgz",
-      "integrity": "sha512-bofpzY5Sgcrq69eg1iA13kGJqWia4s/jVOB3DCU3rPUKGHVL8hh9CjrIho1C0XygQxjuPAJznOj0cCaRxD1vJQ==",
+      "version": "5.12.4",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.12.4.tgz",
+      "integrity": "sha512-n4ZQxqq78GhYMeY2hiP0pn9Z+/2/yNfXwxnh4o59qagD/NfUe5wj4l8cwMvzFn5I7gy0xmUp3BkJrwsZlAYfUw==",
       "requires": {
-        "@sentry/hub": "5.11.0",
-        "@sentry/minimal": "5.11.0",
-        "@sentry/types": "5.11.0",
-        "@sentry/utils": "5.11.0",
+        "@sentry/hub": "5.12.4",
+        "@sentry/minimal": "5.12.4",
+        "@sentry/types": "5.12.4",
+        "@sentry/utils": "5.12.4",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.11.0.tgz",
-      "integrity": "sha512-ZtCcbq3BLkQo/y07amvP21ZjmL7up/fD1032XrA+44U7M1d2w+CDCVRWcCJGK/otzPz7cw8yc5oS4Cn68wLVxw==",
+      "version": "5.12.4",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.12.4.tgz",
+      "integrity": "sha512-x0IGqTXgjRQrrLbjkjYa2qbwSa6dFejM3F29cpwjD7yp87MVkmDy/S7LwFFsjThOzsHXsjQxmPlQB8nu4sIOXw==",
       "requires": {
-        "@sentry/types": "5.11.0",
-        "@sentry/utils": "5.11.0",
+        "@sentry/types": "5.12.4",
+        "@sentry/utils": "5.12.4",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.11.0.tgz",
-      "integrity": "sha512-fplz8sCmYE9Hdm+qnoATls5FPKjVyXcCuav9UKFLV6L+MAPjWVINbHFPBcYAmR5bjK4/Otfi1SPCBe1MQT/FtA==",
+      "version": "5.12.4",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.12.4.tgz",
+      "integrity": "sha512-/cDkibXPIXYjboMZ4nSytJmpR/QIT1d0i9qxqlZh4vwsb2mrGdU9KxNvR6G3AXTQNybehm6TGewPo8rGz1GJQQ==",
       "requires": {
-        "@sentry/hub": "5.11.0",
-        "@sentry/types": "5.11.0",
+        "@sentry/hub": "5.12.4",
+        "@sentry/types": "5.12.4",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.11.0.tgz",
-      "integrity": "sha512-1Uhycpmeo1ZK2GLvrtwZhTwIodJHcyIS6bn+t4IMkN9MFoo6ktbAfhvexBDW/IDtdLlCGJbfm8nIZerxy0QUpg=="
+      "version": "5.12.4",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.12.4.tgz",
+      "integrity": "sha512-JoN3YIp7Z+uxUZArj2B6NcEoXFQDhd0kqO0QpfiHZyg4Dhx2/E2aHuVx0H6Fndk+60iEZSECaCBXe2MOPo4fqA=="
     },
     "@sentry/utils": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.11.0.tgz",
-      "integrity": "sha512-84MNM08ANmda/tWMBCCb9tga0b4ZD7tSo0i20RJalkdLk9zJmmepKw+sA5PyztO/YxkqAt9KijSmtIafd0LlOQ==",
+      "version": "5.12.4",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.12.4.tgz",
+      "integrity": "sha512-7ISjK+AH676NXtW5n2/MHxEPS0Y2cpIXqJppg7ReVvCFNKHGovKmK4d5yXcP+AoEJt84in3A8D5Y3BONdpjWHQ==",
       "requires": {
-        "@sentry/types": "5.11.0",
+        "@sentry/types": "5.12.4",
         "tslib": "^1.9.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@elastic/search-ui-site-search-connector": "^1.3.2",
     "@mapbox/mapbox-gl-supported": "^1.4.1",
     "@mapbox/mr-ui": "^0.7.4",
-    "@sentry/browser": "^5.11.0",
+    "@sentry/browser": "^5.12.4",
     "classnames": "^2.2.6",
     "compare-versions": "^3.4.0",
     "debounce": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "react-stickynode": "^2.1.1",
     "rehype-sectionize-headings": "^1.0.0-rc.1",
     "remove-markdown": "^0.3.0",
+    "slugify": "^1.3.6",
     "uuid": "^3.3.2"
   },
   "jest": {

--- a/src/components/feedback/__tests__/__snapshots__/feedback-sent-rating.test.js.snap
+++ b/src/components/feedback/__tests__/__snapshots__/feedback-sent-rating.test.js.snap
@@ -29,7 +29,7 @@ exports[`Sent helpful rating snapshot snapshot 1`] = `
         , you can provide it below (optional):
       </div>
       <ControlTextarea
-        id="docs-feedback"
+        id="dr-ui--feedback-page-text"
         noAuto={false}
         onChange={[Function]}
         optional={false}
@@ -40,6 +40,7 @@ exports[`Sent helpful rating snapshot snapshot 1`] = `
       <button
         className="btn btn--s mb18"
         disabled={true}
+        id="dr-ui--feedback-page-submit"
         onClick={[Function]}
       >
         Send feedback

--- a/src/components/feedback/__tests__/__snapshots__/feedback-sent-rating.test.js.snap
+++ b/src/components/feedback/__tests__/__snapshots__/feedback-sent-rating.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Sent helpful rating basic 1`] = `
+exports[`Sent helpful rating snapshot snapshot 1`] = `
 <div
   className="bg-gray-faint py12 px18 round color-gray"
 >

--- a/src/components/feedback/__tests__/__snapshots__/feedback-sent-text.test.js.snap
+++ b/src/components/feedback/__tests__/__snapshots__/feedback-sent-text.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Sent text feedback basic 1`] = `
+exports[`Sent text feedback snapshot 1`] = `
 <div
   className="bg-gray-faint py12 px18 round color-gray"
 >

--- a/src/components/feedback/__tests__/__snapshots__/feedback.test.js.snap
+++ b/src/components/feedback/__tests__/__snapshots__/feedback.test.js.snap
@@ -15,14 +15,14 @@ exports[`feedback Basic renders as expected 1`] = `
       </div>
       <button
         className="btn btn--s"
-        id="dr-ui--feedback-LngLat-yes"
+        id="dr-ui--feedback-lnglat-yes"
         onClick={[Function]}
       >
         Yes
       </button>
       <button
         className="btn btn--s ml6"
-        id="dr-ui--feedback-LngLat-no"
+        id="dr-ui--feedback-lnglat-no"
         onClick={[Function]}
       >
         No

--- a/src/components/feedback/__tests__/__snapshots__/feedback.test.js.snap
+++ b/src/components/feedback/__tests__/__snapshots__/feedback.test.js.snap
@@ -15,12 +15,14 @@ exports[`feedback Basic renders as expected 1`] = `
       </div>
       <button
         className="btn btn--s"
+        id="dr-ui--feedback-LngLat-yes"
         onClick={[Function]}
       >
         Yes
       </button>
       <button
         className="btn btn--s ml6"
+        id="dr-ui--feedback-LngLat-no"
         onClick={[Function]}
       >
         No
@@ -45,12 +47,14 @@ exports[`feedback Change type renders as expected 1`] = `
       </div>
       <button
         className="btn btn--s"
+        id="dr-ui--feedback-page-yes"
         onClick={[Function]}
       >
         Yes
       </button>
       <button
         className="btn btn--s ml6"
+        id="dr-ui--feedback-page-no"
         onClick={[Function]}
       >
         No
@@ -322,12 +326,14 @@ exports[`feedback Feedback placement renders as expected 1`] = `
                 </div>
                 <button
                   className="btn btn--s"
+                  id="dr-ui--feedback-page-yes"
                   onClick={[Function]}
                 >
                   Yes
                 </button>
                 <button
                   className="btn btn--s ml6"
+                  id="dr-ui--feedback-page-no"
                   onClick={[Function]}
                 >
                   No

--- a/src/components/feedback/__tests__/feedback-sent-rating.test.js
+++ b/src/components/feedback/__tests__/feedback-sent-rating.test.js
@@ -22,10 +22,11 @@ describe('Sent helpful rating - yes', () => {
     />
   );
   test('clicked yes', () => {
-    feedback.find('#dr-ui--feedback-yes').simulate('click');
+    feedback.find('#dr-ui--feedback-page-yes').simulate('click');
     expect(feedback.state()).toEqual({
       event: {
         event: 'Sent docs feedback',
+        userId: 'decorah',
         properties: {
           environment: 'staging',
           helpful: true,
@@ -67,10 +68,11 @@ describe('Sent helpful rating - no', () => {
     />
   );
   test('clicked no', () => {
-    feedback.find('#dr-ui--feedback-no').simulate('click');
+    feedback.find('#dr-ui--feedback-page-no').simulate('click');
     expect(feedback.state()).toEqual({
       event: {
         event: 'Sent docs feedback',
+        userId: 'decorah',
         properties: {
           environment: 'staging',
           helpful: false,

--- a/src/components/feedback/__tests__/feedback-sent-rating.test.js
+++ b/src/components/feedback/__tests__/feedback-sent-rating.test.js
@@ -1,12 +1,102 @@
 import React from 'react';
 import Feedback from '..';
 import toJson from 'enzyme-to-json';
-import { configure, shallow } from 'enzyme';
+import { configure, shallow, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 configure({ adapter: new Adapter() });
 
-describe('Sent helpful rating', () => {
+describe('Sent helpful rating - yes', () => {
+  const feedback = mount(
+    <Feedback
+      site="dr-ui"
+      location={{
+        pathname: '/mapbox-gl-js/api/',
+        hash: '#lnglat'
+      }}
+      userName="decorah"
+      webhook={{
+        production: '',
+        staging: ''
+      }}
+    />
+  );
+  test('clicked yes', () => {
+    feedback.find('#dr-ui--feedback-yes').simulate('click');
+    expect(feedback.state()).toEqual({
+      event: {
+        event: 'Sent docs feedback',
+        properties: {
+          environment: 'staging',
+          helpful: true,
+          location: {
+            hash: '',
+            host: 'localhost',
+            hostname: 'localhost',
+            href: 'http://localhost/',
+            origin: 'http://localhost',
+            pathname: '/',
+            search: ''
+          },
+          page: { hash: '#lnglat', pathname: '/mapbox-gl-js/api/' },
+          section: undefined,
+          site: 'dr-ui',
+          userId: 'decorah'
+        }
+      },
+      feedback: undefined,
+      feedbackSent: undefined,
+      helpful: true
+    });
+  });
+});
+
+describe('Sent helpful rating - no', () => {
+  const feedback = mount(
+    <Feedback
+      site="dr-ui"
+      location={{
+        pathname: '/mapbox-gl-js/api/',
+        hash: '#lnglat'
+      }}
+      userName="decorah"
+      webhook={{
+        production: '',
+        staging: ''
+      }}
+    />
+  );
+  test('clicked no', () => {
+    feedback.find('#dr-ui--feedback-no').simulate('click');
+    expect(feedback.state()).toEqual({
+      event: {
+        event: 'Sent docs feedback',
+        properties: {
+          environment: 'staging',
+          helpful: false,
+          location: {
+            hash: '',
+            host: 'localhost',
+            hostname: 'localhost',
+            href: 'http://localhost/',
+            origin: 'http://localhost',
+            pathname: '/',
+            search: ''
+          },
+          page: { hash: '#lnglat', pathname: '/mapbox-gl-js/api/' },
+          section: undefined,
+          site: 'dr-ui',
+          userId: 'decorah'
+        }
+      },
+      feedback: undefined,
+      feedbackSent: undefined,
+      helpful: false
+    });
+  });
+});
+
+describe('Sent helpful rating snapshot', () => {
   const feedback = shallow(
     <Feedback
       site="dr-ui"
@@ -20,7 +110,7 @@ describe('Sent helpful rating', () => {
     helpful: true
   });
 
-  test('basic', () => {
+  test('snapshot', () => {
     expect(toJson(feedback)).toMatchSnapshot();
   });
 });

--- a/src/components/feedback/__tests__/feedback-sent-text.test.js
+++ b/src/components/feedback/__tests__/feedback-sent-text.test.js
@@ -1,10 +1,75 @@
 import React from 'react';
 import Feedback from '..';
 import toJson from 'enzyme-to-json';
-import { configure, shallow } from 'enzyme';
+import { configure, shallow, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 configure({ adapter: new Adapter() });
+
+describe('Sent text feedback', () => {
+  const feedback = mount(
+    <Feedback
+      site="dr-ui"
+      location={{
+        pathname: '/mapbox-gl-js/api/',
+        hash: '#lnglat'
+      }}
+      userName="decorah"
+      webhook={{
+        production: '',
+        staging: ''
+      }}
+    />
+  );
+
+  test('clicked yes and sent feedback', () => {
+    // click yes
+    feedback.setState({
+      helpful: true
+    });
+    // simulate typing feedback
+    feedback
+      .find('#docs-feedback')
+      .at(0)
+      .props()
+      .onChange('cool beans!');
+    // simulate submit button click
+    feedback
+      .find('#docs-submit-feedback')
+      .at(0)
+      .simulate('click');
+
+    expect(feedback.state()).toEqual({
+      event: {
+        event: 'Sent docs feedback',
+        properties: {
+          environment: 'staging',
+          feedback: 'cool beans!',
+          helpful: true,
+          location: {
+            hash: '',
+            host: 'localhost',
+            hostname: 'localhost',
+            href: 'http://localhost/',
+            origin: 'http://localhost',
+            pathname: '/',
+            search: ''
+          },
+          page: {
+            hash: '#lnglat',
+            pathname: '/mapbox-gl-js/api/'
+          },
+          section: undefined,
+          site: 'dr-ui',
+          userId: 'decorah'
+        }
+      },
+      feedback: 'cool beans!',
+      feedbackSent: true,
+      helpful: true
+    });
+  });
+});
 
 describe('Sent text feedback', () => {
   const feedback = shallow(

--- a/src/components/feedback/__tests__/feedback-sent-text.test.js
+++ b/src/components/feedback/__tests__/feedback-sent-text.test.js
@@ -29,19 +29,20 @@ describe('Sent text feedback', () => {
     });
     // simulate typing feedback
     feedback
-      .find('#docs-feedback')
+      .find('#dr-ui--feedback-page-text')
       .at(0)
       .props()
       .onChange('cool beans!');
     // simulate submit button click
     feedback
-      .find('#docs-submit-feedback')
+      .find('#dr-ui--feedback-page-submit')
       .at(0)
       .simulate('click');
 
     expect(feedback.state()).toEqual({
       event: {
         event: 'Sent docs feedback',
+        userId: 'decorah',
         properties: {
           environment: 'staging',
           feedback: 'cool beans!',
@@ -87,7 +88,7 @@ describe('Sent text feedback', () => {
     feedbackSent: true
   });
 
-  test('basic', () => {
+  test('snapshot', () => {
     expect(toJson(feedback)).toMatchSnapshot();
   });
 });

--- a/src/components/feedback/feedback.js
+++ b/src/components/feedback/feedback.js
@@ -5,6 +5,7 @@ import forwardEvent from './forward-event';
 import uuidv4 from 'uuid/v4';
 import Icon from '@mapbox/mr-ui/icon';
 import * as Sentry from '@sentry/browser';
+import slugify from 'slugify';
 
 const anonymousId = uuidv4(); // creates an anonymousId fallback if user is not logged or we cant get their info
 const environment =
@@ -30,8 +31,13 @@ class Feedback extends React.Component {
     this.sendToSegment = this.sendToSegment.bind(this);
   }
 
+  // creates a unique id for an element
   createId = el => {
-    return `dr-ui--feedback-${this.props.section || 'page'}-${el}`;
+    const section = slugify(this.props.section || 'page', {
+      replacement: '-',
+      lower: true
+    });
+    return `dr-ui--feedback-${section}-${el}`;
   };
 
   // pushes the text feedback to the state as the user types

--- a/src/components/feedback/feedback.js
+++ b/src/components/feedback/feedback.js
@@ -110,14 +110,12 @@ class Feedback extends React.Component {
   sendToSegment = () => {
     // sends event to Segment via forward event webhook
     forwardEvent(this.state.event, this.props.webhook, err => {
-      if (err) {
-        console.log(err); // eslint-disable-line
-      }
+      if (err) this.sendToSentry('error', err);
     });
   };
 
   // sends text feedback to Sentry
-  sendToSentry = () => {
+  sendToSentry = (level, error) => {
     Sentry.init({
       dsn: this.props.feedbackSentryDsn,
       environment
@@ -128,7 +126,8 @@ class Feedback extends React.Component {
       if (this.props.section) scope.setTag('section', this.props.section); // section of the page (if available)
       if (this.props.preferredLanguage)
         scope.setTag('preferredLanguage', this.props.preferredLanguage); // user's preferred language (if available)
-      scope.setLevel('info'); // sets the message as "info" (rather than warning)
+      scope.setLevel(level || 'info'); // sets the message as "info" by default
+      if (error) Sentry.setExtra('error', error); // send error message (if available)
     });
     Sentry.captureMessage(this.state.feedback); // capture the feedback as a message
   };

--- a/src/components/feedback/feedback.js
+++ b/src/components/feedback/feedback.js
@@ -13,6 +13,7 @@ const environment =
       ? 'production'
       : 'staging'
     : undefined;
+const location = typeof window !== 'undefined' ? window.location : undefined;
 
 class Feedback extends React.Component {
   constructor(props) {
@@ -20,7 +21,8 @@ class Feedback extends React.Component {
     this.state = {
       helpful: undefined,
       feedback: undefined,
-      feedbackSent: undefined
+      feedbackSent: undefined,
+      event: undefined
     };
     this.handleText = this.handleText.bind(this);
     this.handleYesNo = this.handleYesNo.bind(this);
@@ -34,11 +36,47 @@ class Feedback extends React.Component {
   }
   // when user clicks YES or NO, the value is pushed to the state and then sent to segment
   handleYesNo(helpful) {
-    this.setState({ helpful }, () => {
+    const event = this.createSegmentEvent(helpful);
+    this.setState({ helpful, event }, () => {
       // track helpful rating
       this.sendToSegment();
     });
   }
+
+  // create event object to sent to Segment
+  createSegmentEvent(helpful, feedback) {
+    return {
+      event: 'Sent docs feedback',
+      properties: {
+        // true, false,
+        helpful: helpful,
+        // text feedback
+        ...(feedback && { feedback: feedback }),
+        // name of current site, helpful for filtering in Mode
+        site: this.props.site,
+        // (optional) name of section for longer pagers, helpful for fitering in Mode and identifying section areas
+        section: this.props.section || undefined,
+        // get page context
+        page: this.props.location || undefined,
+        // set user if available
+        userId: this.props.userName || undefined,
+        ...(!this.props.userName && { anonymousId: anonymousId }),
+        // staging or production
+        environment,
+        // pull full window.location
+        location: {
+          hash: location.hash,
+          host: location.host,
+          hostname: location.hostname,
+          href: location.href,
+          origin: location.origin,
+          pathname: location.pathname,
+          search: location.search
+        }
+      }
+    };
+  }
+
   // when user click submit feedback button, the value is pushed to the state and then sent to segment
   submitFeedback() {
     // initialize docs-feedback sentry project if enabled
@@ -57,7 +95,11 @@ class Feedback extends React.Component {
       });
       Sentry.captureMessage(this.state.feedback); // capture the feedback as a message
     }
-    this.setState({ feedbackSent: true }, () => {
+    const event = this.createSegmentEvent(
+      this.state.helpful,
+      this.state.feedback
+    );
+    this.setState({ feedbackSent: true, event }, () => {
       // Track response to Segement
       this.sendToSegment();
     });
@@ -65,27 +107,8 @@ class Feedback extends React.Component {
 
   // sends all available data to segment
   sendToSegment() {
-    const location =
-      typeof window !== 'undefined' ? window.location : undefined;
-    const event = {
-      event: 'Sent docs feedback',
-      properties: {
-        helpful: this.state.helpful, // true, false
-        site: this.props.site, // name of current site, helpful for filtering in Mode
-        section: this.props.section || undefined, // (optional) name of section for longer pagers, helpful for fitering in Mode and identifying section areas
-        feedback: this.state.feedback, // (optional) textarea feedback
-        page: this.props.location || undefined, // get page context
-        userId: this.props.userName || undefined, // set user if available
-        environment, // staging or production
-        location // pull full window.location
-      }
-    };
-    // if user is logged in then associate feedback with them
-    // otherwise use the a random/anonymousId
-    if (this.props.userName) event.userId = this.props.userName;
-    else event.anonymousId = anonymousId;
     // sends event to segment via forward event webhook
-    forwardEvent(event, this.props.webhook, err => {
+    forwardEvent(this.state.event, this.props.webhook, err => {
       if (err) {
         console.log(err); // eslint-disable-line
       }
@@ -100,12 +123,14 @@ class Feedback extends React.Component {
             <div>
               <div className="mb6">Was this {this.props.type} helpful?</div>
               <button
+                id="dr-ui--feedback-yes"
                 onClick={() => this.handleYesNo(true)}
                 className="btn btn--s"
               >
                 Yes
               </button>
               <button
+                id="dr-ui--feedback-no"
                 onClick={() => this.handleYesNo(false)}
                 className="btn btn--s ml6"
               >
@@ -144,6 +169,7 @@ class Feedback extends React.Component {
                     this.state.feedback === undefined ||
                     this.state.feedback.length < 3 // disable button unless more than 3 characters are typed
                   }
+                  id={`${this.props.section || 'docs'}-submit-feedback`}
                   className="btn btn--s mb18"
                   onClick={this.submitFeedback}
                 >

--- a/src/components/feedback/feedback.js
+++ b/src/components/feedback/feedback.js
@@ -30,6 +30,10 @@ class Feedback extends React.Component {
     this.sendToSegment = this.sendToSegment.bind(this);
   }
 
+  createId = el => {
+    return `dr-ui--feedback-${this.props.section || 'page'}-${el}`;
+  };
+
   // pushes the text feedback to the state as the user types
   handleText(feedback) {
     this.setState({ feedback });
@@ -47,6 +51,9 @@ class Feedback extends React.Component {
   createSegmentEvent(helpful, feedback) {
     return {
       event: 'Sent docs feedback',
+      // set user if available (needed for forward-event request)
+      userId: this.props.userName || undefined,
+      ...(!this.props.userName && { anonymousId: anonymousId }),
       properties: {
         // true, false,
         helpful: helpful,
@@ -58,7 +65,7 @@ class Feedback extends React.Component {
         section: this.props.section || undefined,
         // get page context
         page: this.props.location || undefined,
-        // set user if available
+        // set user if available (needed for mode reports)
         userId: this.props.userName || undefined,
         ...(!this.props.userName && { anonymousId: anonymousId }),
         // staging or production
@@ -123,14 +130,14 @@ class Feedback extends React.Component {
             <div>
               <div className="mb6">Was this {this.props.type} helpful?</div>
               <button
-                id="dr-ui--feedback-yes"
+                id={this.createId('yes')}
                 onClick={() => this.handleYesNo(true)}
                 className="btn btn--s"
               >
                 Yes
               </button>
               <button
-                id="dr-ui--feedback-no"
+                id={this.createId('no')}
                 onClick={() => this.handleYesNo(false)}
                 className="btn btn--s ml6"
               >
@@ -158,7 +165,7 @@ class Feedback extends React.Component {
                   , you can provide it below (optional):
                 </div>
                 <ControlTextarea
-                  id={`${this.props.section || 'docs'}-feedback`}
+                  id={this.createId('text')}
                   themeControlWrapper="bg-white mb6"
                   onChange={this.handleText}
                   value={this.state.feedback}
@@ -169,7 +176,7 @@ class Feedback extends React.Component {
                     this.state.feedback === undefined ||
                     this.state.feedback.length < 3 // disable button unless more than 3 characters are typed
                   }
-                  id={`${this.props.section || 'docs'}-submit-feedback`}
+                  id={this.createId('submit')}
                   className="btn btn--s mb18"
                   onClick={this.submitFeedback}
                 >

--- a/src/components/feedback/feedback.js
+++ b/src/components/feedback/feedback.js
@@ -25,10 +25,6 @@ class Feedback extends React.Component {
       feedbackSent: undefined,
       event: undefined
     };
-    this.handleText = this.handleText.bind(this);
-    this.handleYesNo = this.handleYesNo.bind(this);
-    this.handleSubmitFeedback = this.handleSubmitFeedback.bind(this);
-    this.sendToSegment = this.sendToSegment.bind(this);
   }
 
   // creates a unique id for an element
@@ -41,12 +37,12 @@ class Feedback extends React.Component {
   };
 
   // pushes the text feedback to the state as the user types
-  handleText(feedback) {
+  handleText = feedback => {
     this.setState({ feedback });
-  }
+  };
 
   // handles when user clicks YES or NO button
-  handleYesNo(helpful) {
+  handleYesNo = helpful => {
     // sets user rating to the state
     this.setState({ helpful }, () => {
       // creates event to send to Segment and sets it to the state
@@ -55,10 +51,10 @@ class Feedback extends React.Component {
         this.sendToSegment();
       });
     });
-  }
+  };
 
   // handles sending feedback to Sentry (and Segment) when the user clicks SUBMIT FEEDBACK button
-  handleSubmitFeedback() {
+  handleSubmitFeedback = () => {
     // sets event to the state and marks feedbackSent as true
     this.setState(
       { feedbackSent: true, event: this.createSegmentEvent() },
@@ -71,10 +67,10 @@ class Feedback extends React.Component {
         }
       }
     );
-  }
+  };
 
   // create event object to sent to Segment
-  createSegmentEvent() {
+  createSegmentEvent = () => {
     return {
       event: 'Sent docs feedback',
       // set user if available (needed for forward-event request)
@@ -108,20 +104,20 @@ class Feedback extends React.Component {
         }
       }
     };
-  }
+  };
 
   // sends event to Segment
-  sendToSegment() {
+  sendToSegment = () => {
     // sends event to Segment via forward event webhook
     forwardEvent(this.state.event, this.props.webhook, err => {
       if (err) {
         console.log(err); // eslint-disable-line
       }
     });
-  }
+  };
 
   // sends text feedback to Sentry
-  sendToSentry() {
+  sendToSentry = () => {
     Sentry.init({
       dsn: this.props.feedbackSentryDsn,
       environment
@@ -135,7 +131,7 @@ class Feedback extends React.Component {
       scope.setLevel('info'); // sets the message as "info" (rather than warning)
     });
     Sentry.captureMessage(this.state.feedback); // capture the feedback as a message
-  }
+  };
 
   render() {
     return (

--- a/src/components/feedback/forward-event.js
+++ b/src/components/feedback/forward-event.js
@@ -23,12 +23,16 @@ export default function forwardEvent(event, webhook, callback) {
 
   // builds the xhr request to post the Segment event to the webhook
   const xhr = new XMLHttpRequest();
-  xhr.open('POST', url);
-  xhr.setRequestHeader('Accept', 'application/json');
-  xhr.setRequestHeader('Content-Type', 'application/json');
-  xhr.onerror = handleError;
-  xhr.onload = handleLoad;
-  xhr.send(JSON.stringify(event));
+  if (url) {
+    xhr.open('POST', url);
+    xhr.setRequestHeader('Accept', 'application/jsn');
+    xhr.setRequestHeader('Content-Type', 'application/jon');
+    xhr.onerror = handleError;
+    xhr.onload = handleLoad;
+    xhr.send(JSON.stringify(event));
+  } else {
+    handleError('forward-event missing POST url');
+  }
 
   // handles posting the Segment event to the webhook URL
   function handleLoad() {


### PR DESCRIPTION
This PR:
- adds tests to assert the object shape for events sent to Segment.
- pushes the Segment event to the state for easier testing/tracking.
- adds createId function to generated a unique id for each interactive element.
- reorganizes functions and adds comments to help make all the actions clear.

I think this PR will help us better track additions to metadata (like in #255).

## How to test

1. `npm start`
2. Open /Feedback
3. Try any test case, you can see the Segment event posted in #bots and the Sentry feedback posted in #docs-feedback.


## QA Checklist

<!-- complete this checklist when adding a new component or package -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `7.5.0`.
  - Score is 89 due to: 
    - #257 color contrast 
    - [id] attributes on the page are not unique (#docs-content is baked into test cases)
    - #248 form elements missing label
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.
- [x] If applicable, create a PR in a site repo, copy the component, and test it. Push to staging and instruct the reviewer to test the component in-page.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] IE11, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.
