### PR TITLE
[draft/proposal] create passiveSection option for NavigationAccordion

### DIFF
--- a/src/components/feedback/__tests__/__snapshots__/feedback.test.js.snap
+++ b/src/components/feedback/__tests__/__snapshots__/feedback.test.js.snap
@@ -171,13 +171,13 @@ exports[`feedback Feedback placement (sends anonymous user information) renders 
                         </div>
                       </a>
                       <div
-                        className="ml24 pt0"
+                        className="ml12 pt0"
                       >
                         <ul
                           className="txt-m pb12 inline-block-mm none unprose"
                         >
                           <li
-                            className="mb6"
+                            className="mb3"
                           >
                             <a
                               className="color-blue-on-hover"
@@ -192,7 +192,7 @@ exports[`feedback Feedback placement (sends anonymous user information) renders 
                             />
                           </li>
                           <li
-                            className="mb6"
+                            className="mb3"
                           >
                             <a
                               className="color-blue-on-hover"

--- a/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
+++ b/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
@@ -25,13 +25,13 @@ exports[`navigation-accordion Basic renders as expected 1`] = `
           </div>
         </a>
         <div
-          className="ml24 pt0"
+          className="ml12 pt0"
         >
           <ul
             className="txt-m pb12 inline-block-mm none unprose"
           >
             <li
-              className="mb6"
+              className="mb3"
             >
               <a
                 className="color-blue-on-hover"
@@ -46,7 +46,7 @@ exports[`navigation-accordion Basic renders as expected 1`] = `
               />
             </li>
             <li
-              className="mb6"
+              className="mb3"
             >
               <a
                 className="color-blue-on-hover"
@@ -280,13 +280,13 @@ exports[`navigation-accordion Shows third level items renders as expected 1`] = 
           </div>
         </a>
         <div
-          className="ml24 pt0"
+          className="ml12 pt0"
         >
           <ul
             className="txt-m pb12 inline-block-mm none unprose"
           >
             <li
-              className="mb6"
+              className="mb3"
             >
               <a
                 className="color-blue-on-hover"
@@ -303,7 +303,7 @@ exports[`navigation-accordion Shows third level items renders as expected 1`] = 
                   className="mt6"
                 >
                   <a
-                    className="color-blue-on-hover txt-bold"
+                    className="color-blue-on-hover txt-bold color-gray"
                     href="#"
                     id="#-sidebar"
                   >
@@ -326,7 +326,7 @@ exports[`navigation-accordion Shows third level items renders as expected 1`] = 
               </ul>
             </li>
             <li
-              className="mb6"
+              className="mb3"
             >
               <a
                 className="color-blue-on-hover"
@@ -451,13 +451,13 @@ exports[`navigation-accordion Shows third level items with icons renders as expe
           </div>
         </a>
         <div
-          className="ml24 pt0"
+          className="ml12 pt0"
         >
           <ul
             className="txt-m pb12 inline-block-mm none unprose"
           >
             <li
-              className="mb6"
+              className="mb3"
             >
               <a
                 className="color-blue-on-hover"
@@ -480,7 +480,7 @@ exports[`navigation-accordion Shows third level items with icons renders as expe
                   }
                 >
                   <a
-                    className="color-blue-on-hover txt-bold"
+                    className="color-blue-on-hover txt-bold color-gray"
                     href="#"
                     id="#-sidebar"
                   >
@@ -587,7 +587,7 @@ exports[`navigation-accordion Shows third level items with icons renders as expe
               </ul>
             </li>
             <li
-              className="mb6"
+              className="mb3"
             >
               <a
                 className="color-blue-on-hover"
@@ -712,13 +712,13 @@ exports[`navigation-accordion Titles with tags renders as expected 1`] = `
           </div>
         </a>
         <div
-          className="ml24 pt0"
+          className="ml12 pt0"
         >
           <ul
             className="txt-m pb12 inline-block-mm none unprose"
           >
             <li
-              className="mb6"
+              className="mb3"
             >
               <a
                 className="color-blue-on-hover"
@@ -735,7 +735,7 @@ exports[`navigation-accordion Titles with tags renders as expected 1`] = `
                   className="mt6"
                 >
                   <a
-                    className="color-blue-on-hover txt-bold"
+                    className="color-blue-on-hover txt-bold color-gray"
                     href="#"
                     id="#-sidebar"
                   >
@@ -793,7 +793,7 @@ exports[`navigation-accordion Titles with tags renders as expected 1`] = `
               </ul>
             </li>
             <li
-              className="mb6"
+              className="mb3"
             >
               <a
                 className="color-blue-on-hover"

--- a/src/components/navigation-accordion/__tests__/navigation-accordion-test-cases.js
+++ b/src/components/navigation-accordion/__tests__/navigation-accordion-test-cases.js
@@ -35,6 +35,38 @@ testCases.basic = {
   }
 };
 
+testCases.passiveSections = {
+  description: 'With passive sections',
+  component: NavigationAccordion,
+  props: {
+    currentPath: 'page-one',
+    contents: {
+      firstLevelItems: [
+        {
+          title: 'Title one',
+          path: 'page-one'
+        },
+        {
+          title: 'Title two',
+          path: 'page-two'
+        }
+      ],
+      secondLevelItems: [
+        { title: 'Methods and events', passiveSection: true },
+        { title: 'Get map state', path: '#' },
+        { title: 'Modify map state', path: '#' },
+        { title: 'Layers, styles, sources', path: '#' },
+        { title: 'Properties', passiveSection: true },
+        { title: 'accessToken', path: '#' },
+        { title: 'baseApiUrl', path: '#' },
+        { title: 'workerCount', path: '#' },
+        { title: 'maxParallelImageRequests', path: '#' }
+      ]
+    },
+    onDropdownChange: () => {}
+  }
+};
+
 testCases.noSecondLevelItems = {
   description: 'No second level items',
   component: NavigationAccordion,

--- a/src/components/navigation-accordion/navigation-accordion.js
+++ b/src/components/navigation-accordion/navigation-accordion.js
@@ -8,6 +8,23 @@ import Tag from '../tag/tag';
 
 const debounceVal = 50;
 
+class PassiveSection extends React.Component {
+  render() {
+    return (
+      <div
+        className="color-gray txt-s txt-uppercase"
+        style={{ letterSpacing: '0.025em' }}
+      >
+        {this.props.title}
+      </div>
+    );
+  }
+}
+
+PassiveSection.propTypes = {
+  title: PropTypes.string.isRequired
+};
+
 class NavigationAccordion extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -122,13 +139,13 @@ class NavigationAccordion extends React.PureComponent {
     const { props, state } = this;
     function itemClasses(isActive) {
       return classnames('color-blue-on-hover', {
-        'txt-bold': isActive
+        'txt-bold color-gray': isActive
       });
     }
 
     const secondLevelContent =
       props.contents.secondLevelItems &&
-      props.contents.secondLevelItems.map(item => {
+      props.contents.secondLevelItems.map((item, index) => {
         const isActive = state.activeh2 === item.path;
         let openSubItems = isActive;
         const subItems =
@@ -162,15 +179,25 @@ class NavigationAccordion extends React.PureComponent {
             );
           });
         return (
-          <li key={item.path} className="mb6">
-            <a
-              href={`#${item.path}`}
-              id={`#${item.path}-sidebar`}
-              className={itemClasses(isActive)}
-            >
-              {item.title}
-              {item.tag ? this.buildTag(item) : ''}
-            </a>
+          <li
+            key={item.path}
+            className={classnames('', {
+              mb3: !item.passiveSection,
+              mt18: item.passiveSection && index !== 0
+            })}
+          >
+            {item.passiveSection ? (
+              <PassiveSection title={item.title} />
+            ) : (
+              <a
+                href={`#${item.path}`}
+                id={`#${item.path}-sidebar`}
+                className={itemClasses(isActive)}
+              >
+                {item.title}
+                {item.tag ? this.buildTag(item) : ''}
+              </a>
+            )}
             <ul className={openSubItems ? 'pl12 color-darken75' : 'none'}>
               {subItems}
             </ul>
@@ -201,7 +228,7 @@ class NavigationAccordion extends React.PureComponent {
         let renderedSecondLevelContent = '';
         if (isActive && secondLevelContent && secondLevelContent.length > 0) {
           renderedSecondLevelContent = (
-            <div className="ml24 pt0">
+            <div className="ml12 pt0">
               <ul className="txt-m pb12 inline-block-mm none unprose">
                 {secondLevelContent}
               </ul>
@@ -283,6 +310,7 @@ NavigationAccordion.propTypes = {
           'new',
           'custom'
         ]),
+        passiveSection: PropTypes.bool,
         /* Required if tag is set to `custom` */
         customTagProps: PropTypes.shape({
           customLabel: PropTypes.string.isRequired,

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -174,13 +174,13 @@ exports[`page-layout Common use case renders as expected 1`] = `
                     </div>
                   </a>
                   <div
-                    className="ml24 pt0"
+                    className="ml12 pt0"
                   >
                     <ul
                       className="txt-m pb12 inline-block-mm none unprose"
                     >
                       <li
-                        className="mb6"
+                        className="mb3"
                       >
                         <a
                           className="color-blue-on-hover"
@@ -195,7 +195,7 @@ exports[`page-layout Common use case renders as expected 1`] = `
                         />
                       </li>
                       <li
-                        className="mb6"
+                        className="mb3"
                       >
                         <a
                           className="color-blue-on-hover"
@@ -529,13 +529,13 @@ exports[`page-layout Many first level items renders as expected 1`] = `
                     </div>
                   </a>
                   <div
-                    className="ml24 pt0"
+                    className="ml12 pt0"
                   >
                     <ul
                       className="txt-m pb12 inline-block-mm none unprose"
                     >
                       <li
-                        className="mb6"
+                        className="mb3"
                       >
                         <a
                           className="color-blue-on-hover"
@@ -550,7 +550,7 @@ exports[`page-layout Many first level items renders as expected 1`] = `
                         />
                       </li>
                       <li
-                        className="mb6"
+                        className="mb3"
                       >
                         <a
                           className="color-blue-on-hover"

--- a/src/components/search/__tests__/__snapshots__/search.test.js.snap
+++ b/src/components/search/__tests__/__snapshots__/search.test.js.snap
@@ -369,13 +369,13 @@ exports[`search Search with \`narrow\` option set renders as expected 2`] = `
                         </div>
                       </a>
                       <div
-                        className="ml24 pt0"
+                        className="ml12 pt0"
                       >
                         <ul
                           className="txt-m pb12 inline-block-mm none unprose"
                         >
                           <li
-                            className="mb6"
+                            className="mb3"
                           >
                             <a
                               className="color-blue-on-hover"
@@ -390,7 +390,7 @@ exports[`search Search with \`narrow\` option set renders as expected 2`] = `
                             />
                           </li>
                           <li
-                            className="mb6"
+                            className="mb3"
                           >
                             <a
                               className="color-blue-on-hover"


### PR DESCRIPTION
When working with content and NavigationAccordion, we use the page's hierarchy to populate the navigation. There are cases, especially in very big documents, that the page's hierarchy doesn't always match with how we want to present the navigation.

This PR proposes adding an optional feature to enable small headings within a section:

- These headings do not link to content and only exist to help group together content.
- These passive headings allow us to surface the most important headings.

In the example below, we would ordinarily need to make "Methods and events" and "Properties" the h2s on the page, but that would place the other headings as h3s, which are hidden until the user scrolls to that section. The h3s are actually the most compelling content, so by adding this passiveSection feature, we can help organize the content without sacrificing with how we're marking up the page:

> ![image](https://user-images.githubusercontent.com/2180540/75915851-44d78f80-5e25-11ea-9912-cfcc63d7ed9e.png)






## How to test

<!-- list steps on how the reviewer can test this change -->

## QA checklist

<!-- complete this checklist when adding a new component or package -->

- [ ] No errors logged to console.
- [ ] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [ ] Component is accessible at mobile-size viewport.
- [ ] Component is accessible at tablet-size viewport.
- [ ] Component is accessible at laptop-size viewport.
- [ ] Component is accessible at big-monitor-size viewport.
- [ ] Create a PR in a site repo, copy the component, and test it. Push to staging and let the reviewer know they can also test the component there.

Open the test cases app locally on:

- [ ] Chrome, no errors logged to console.
- [ ] Firefox, no errors logged to console.
- [ ] Safari, no errors logged to console.
- [ ] Edge, no errors logged to console.
- [ ] IE11, no errors logged to console.
- [ ] Mobile Safari, no errors logged to console.
- [ ] Android Chrome, no errors logged to console.
