### PR TITLE
Allow Kotlin-only activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Master
+
+- Allow Kotlin-only activities in `ContextlessAndroidActivityToggle`. [#278](https://github.com/mapbox/dr-ui/pull/278)
+
 ## 0.28.0
 
 * Fix padding, background, and color contrast in `NumberedCodeSnippet` component. [#269](https://github.com/mapbox/dr-ui/pull/269)

--- a/src/components/contextless-android-activity-toggle/__tests__/__snapshots__/contextless-android-activity-toggle.test.js.snap
+++ b/src/components/contextless-android-activity-toggle/__tests__/__snapshots__/contextless-android-activity-toggle.test.js.snap
@@ -277,6 +277,129 @@ exports[`contextless-android-activity-toggle Basic renders as expected 1`] = `
 </div>
 `;
 
+exports[`contextless-android-activity-toggle Kotlin only renders as expected 1`] = `
+<div
+  className="my24 prose"
+>
+  <div
+    className="my24"
+  >
+    
+    <div
+      className="relative round z0 scroll-styled scroll-auto"
+      style={
+        Object {
+          "maxHeight": 480,
+        }
+      }
+    >
+      <pre>
+        <code
+          className="px0 hljs"
+        >
+          <div
+            className="relative z2"
+            data-chunk-code="chunk-0"
+          >
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "map<span class=\\"token operator\\">?</span><span class=\\"token punctuation\\">.</span>getStyle <span class=\\"token punctuation\\">{</span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 26.45,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "val settlementLabelLayer <span class=\\"token operator\\">=</span> it<span class=\\"token punctuation\\">.</span><span class=\\"token function\\">getLayer</span><span class=\\"token punctuation\\">(</span><span class=\\"token string\\">\\"settlement-label\\"</span><span class=\\"token punctuation\\">)</span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 26.45,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "settlementLabelLayer<span class=\\"token operator\\">?</span><span class=\\"token punctuation\\">.</span><span class=\\"token function\\">setProperties</span><span class=\\"token punctuation\\">(</span><span class=\\"token function\\">textField</span><span class=\\"token punctuation\\">(</span><span class=\\"token string\\">\\"{name_ru}\\"</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">)</span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<span class=\\"token punctuation\\">}</span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+          </div>
+        </code>
+      </pre>
+      <div
+        className="absolute z2 top right mr6 mt6 color-white"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`contextless-android-activity-toggle Two languages renders as expected 1`] = `
 <div
   className="my24 prose"

--- a/src/components/contextless-android-activity-toggle/__tests__/contextless-android-activity-toggle-test-cases.js
+++ b/src/components/contextless-android-activity-toggle/__tests__/contextless-android-activity-toggle-test-cases.js
@@ -86,6 +86,18 @@ testCases.twoLang = {
   }
 };
 
+testCases.kotlinOnly = {
+  component: ContextlessAndroidActivityToggle,
+  description: 'Kotlin only',
+  props: {
+    context: contextJava,
+    id: 'test-kotlin-only',
+    kotlin: kotlin,
+    limitHeight: true,
+    onCopy: () => {}
+  }
+};
+
 testCases.filename = {
   component: ContextlessAndroidActivityToggle,
   description: 'Two languages with filename',

--- a/src/components/contextless-android-activity-toggle/__tests__/contextless-android-activity-toggle.test.js
+++ b/src/components/contextless-android-activity-toggle/__tests__/contextless-android-activity-toggle.test.js
@@ -38,4 +38,22 @@ describe('contextless-android-activity-toggle', () => {
       expect(tree).toMatchSnapshot();
     });
   });
+
+  describe(testCases.kotlinOnly.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.kotlinOnly;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
 });

--- a/src/components/contextless-android-activity-toggle/__tests__/find-selected-code.test.js
+++ b/src/components/contextless-android-activity-toggle/__tests__/find-selected-code.test.js
@@ -1,0 +1,41 @@
+import { findSelectedCode } from '../contextless-android-activity-toggle';
+
+test(`twoLanguagesKotlinPreferred`, () => {
+  expect(
+    findSelectedCode(
+      'some kotlin code string',
+      'some java code string',
+      'kotlin'
+    )
+  ).toEqual('some kotlin code string');
+});
+
+test(`twoLanguagesJavaPreferred`, () => {
+  expect(
+    findSelectedCode('some kotlin code string', 'some java code string', 'java')
+  ).toEqual('some java code string');
+});
+
+test(`onlyKotlinAvailableJavaPreferred`, () => {
+  expect(
+    findSelectedCode('some kotlin code string', undefined, 'java')
+  ).toEqual('some kotlin code string');
+});
+
+test(`onlyKotlinAvailableKotlinPreferred`, () => {
+  expect(
+    findSelectedCode('some kotlin code string', undefined, 'kotlin')
+  ).toEqual('some kotlin code string');
+});
+
+test(`onlyJavaAvailableKotlinPreferred`, () => {
+  expect(
+    findSelectedCode(undefined, 'some java code string', 'kotlin')
+  ).toEqual('some java code string');
+});
+
+test(`onlyJavaAvailableJavaPreferred`, () => {
+  expect(findSelectedCode(undefined, 'some java code string', 'java')).toEqual(
+    'some java code string'
+  );
+});

--- a/src/components/contextless-android-activity-toggle/contextless-android-activity-toggle.js
+++ b/src/components/contextless-android-activity-toggle/contextless-android-activity-toggle.js
@@ -23,7 +23,19 @@ export default class ContextlessAndroidActivityToggle extends React.Component {
 
     let selectedCode = '';
     if (context) {
-      selectedCode = this.checkPreference('kotlin') ? kotlin : java;
+      if (kotlin === undefined) {
+        /* If there is no kotlin code, use java. */
+        selectedCode = java;
+      } else if (java === undefined) {
+        /* If there is no java code, use kotlin. */
+        selectedCode = kotlin;
+      } else if (this.checkPreference('kotlin')) {
+        /** If there is both java and kotlin code,
+         * use the preferred language. */
+        selectedCode = kotlin;
+      } else {
+        selectedCode = java;
+      }
     }
 
     const snippetProps = {
@@ -89,7 +101,7 @@ ContextlessAndroidActivityToggle.propTypes = {
   /* A unique `id` is required for the language toggle. */
   id: PropTypes.string.isRequired,
   /* Every code snippet must include raw Java code. */
-  java: PropTypes.string.isRequired,
+  java: PropTypes.string,
   /* Optionally, the code snippet can include raw Kotlin code.
   If this is included, the language toggle will be displayed. */
   kotlin: PropTypes.string,

--- a/src/components/contextless-android-activity-toggle/contextless-android-activity-toggle.js
+++ b/src/components/contextless-android-activity-toggle/contextless-android-activity-toggle.js
@@ -4,6 +4,24 @@ import ToggleableCodeBlock from '../toggleable-code-block/toggleable-code-block'
 import { highlightJava } from '../highlight/java';
 import { highlightKotlin } from '../highlight/kotlin';
 
+export function findSelectedCode(kotlin, java, preference) {
+  let selectedCode = '';
+  if (kotlin === undefined) {
+    /* If there is no kotlin code, use java. */
+    selectedCode = java;
+  } else if (java === undefined) {
+    /* If there is no java code, use kotlin. */
+    selectedCode = kotlin;
+  } else if (preference === 'kotlin') {
+    /** If there is both java and kotlin code,
+     * use the preferred language. */
+    selectedCode = kotlin;
+  } else {
+    selectedCode = java;
+  }
+  return selectedCode;
+}
+
 export default class ContextlessAndroidActivityToggle extends React.Component {
   checkPreference = language => {
     return this.props.context.preferredLanguage.android === language;
@@ -21,22 +39,11 @@ export default class ContextlessAndroidActivityToggle extends React.Component {
       limitHeight
     } = this.props;
 
-    let selectedCode = '';
-    if (context) {
-      if (kotlin === undefined) {
-        /* If there is no kotlin code, use java. */
-        selectedCode = java;
-      } else if (java === undefined) {
-        /* If there is no java code, use kotlin. */
-        selectedCode = kotlin;
-      } else if (this.checkPreference('kotlin')) {
-        /** If there is both java and kotlin code,
-         * use the preferred language. */
-        selectedCode = kotlin;
-      } else {
-        selectedCode = java;
-      }
-    }
+    const selectedCode = findSelectedCode(
+      kotlin,
+      java,
+      context.preferredLanguage.android
+    );
 
     const snippetProps = {
       copyRanges: copyRanges || undefined,


### PR DESCRIPTION
In the past, all Android docs had _at least_ Java code snippets and examples so we required the `java` prop in `ContextlessAndroidActivityToggle`. In most future releases, all Android docs will have Kotlin snippets (and will likely _not_ have Java snippets). 

## How to test

A copy of this component is used on the `cmcg-adding-nav-1.0-examples` branch in /android-docs.

## QA checklist

<!-- complete this checklist when adding a new component or package -->

- [ ] No errors logged to console.
- [ ] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [ ] Component is accessible at mobile-size viewport.
- [ ] Component is accessible at tablet-size viewport.
- [ ] Component is accessible at laptop-size viewport.
- [ ] Component is accessible at big-monitor-size viewport.
- [ ] Create a PR in a site repo, copy the component, and test it. Push to staging and let the reviewer know they can also test the component there.

Open the test cases app locally on:

- [ ] Chrome, no errors logged to console.
- [ ] Firefox, no errors logged to console.
- [ ] Safari, no errors logged to console.
- [ ] Edge, no errors logged to console.
- [ ] IE11, no errors logged to console.
- [ ] Mobile Safari, no errors logged to console.
- [ ] Android Chrome, no errors logged to console.
