### PR TITLE
Remove `limiter` from Topbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Master
+
+- Remove `limiter` from `Topbar`. [#282](https://github.com/mapbox/dr-ui/pull/282)
+
 ## 0.29.0
 
 - Allow Kotlin-only activities in `ContextlessAndroidActivityToggle`. [#278](https://github.com/mapbox/dr-ui/pull/278)

--- a/src/components/feedback/__tests__/feedback-test-cases.js
+++ b/src/components/feedback/__tests__/feedback-test-cases.js
@@ -78,13 +78,15 @@ testCases.common = {
   element: (
     <div>
       <Topbar>
-        <div className="grid grid--gut36 mr-neg36 mr0-mm">
-          <div className="col col--4-mm col--12">
-            <div
-              className="ml24-mm  flex-parent flex-parent--center-cross"
-              style={{ height: 52 }}
-            >
-              <ProductMenu productName="API Documentation" homePage="/api/" />
+        <div className="limiter">
+          <div className="grid grid--gut36 mr-neg36 mr0-mm">
+            <div className="col col--4-mm col--12">
+              <div
+                className="ml24-mm  flex-parent flex-parent--center-cross"
+                style={{ height: 52 }}
+              >
+                <ProductMenu productName="API Documentation" homePage="/api/" />
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/search/__tests__/search-test-cases.js
+++ b/src/components/search/__tests__/search-test-cases.js
@@ -57,29 +57,31 @@ testCases.withLayout = {
   element: (
     <div>
       <Topbar>
-        <div className="grid grid--gut36 mr-neg36 mr0-mm">
-          <div className="col col--4-mm col--12">
-            <div
-              className="ml24-mm  flex-parent flex-parent--center-cross"
-              style={{ height: 52 }}
-            >
-              <ProductMenu productName="API Documentation" homePage="/api/" />
+        <div className="limiter">
+          <div className="grid grid--gut36 mr-neg36 mr0-mm">
+            <div className="col col--4-mm col--12">
+              <div
+                className="ml24-mm  flex-parent flex-parent--center-cross"
+                style={{ height: 52 }}
+              >
+                <ProductMenu productName="API Documentation" homePage="/api/" />
+              </div>
             </div>
-          </div>
-          <div className="col col--6-mm col--12 flex-parent flex-parent--main-mm flex-parent--center-cross align-r mb12 mb0-mm">
-            <TabList
-              items={[
-                { id: 'one', label: 'Label one' },
-                { id: 'two', label: 'Label two' },
-                { id: 'three', label: 'Label three' },
-                { id: 'four', label: 'Label four' }
-              ]}
-            />
-          </div>
+            <div className="col col--6-mm col--12 flex-parent flex-parent--main-mm flex-parent--center-cross align-r mb12 mb0-mm">
+              <TabList
+                items={[
+                  { id: 'one', label: 'Label one' },
+                  { id: 'two', label: 'Label two' },
+                  { id: 'three', label: 'Label three' },
+                  { id: 'four', label: 'Label four' }
+                ]}
+              />
+            </div>
 
-          <div className="col col--2-mm col--12 flex-parent flex-parent--end-main-mm flex-parent--center-cross">
-            <div className="w-full mb12 mb0-mm mr36">
-              <Search inputId="search4" />
+            <div className="col col--2-mm col--12 flex-parent flex-parent--end-main-mm flex-parent--center-cross">
+              <div className="w-full mb12 mb0-mm mr36">
+                <Search inputId="search4" />
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/topbar-sticker/__tests__/topbar-sticker-test-cases.js
+++ b/src/components/topbar-sticker/__tests__/topbar-sticker-test-cases.js
@@ -11,15 +11,17 @@ testCases.basic = {
     <div style={{ background: 'pink', height: 3000 }}>
       <div className="px24 py12">Above the bar.</div>
       <TopbarSticker>
-        <div className="grid">
-          <div className="col col--4-mm col--12">
-            <div className="ml24-mm pt12" style={{ height: 52 }}>
-              <ProductMenu productName="Dr. UI" homePage="/dr-ui/" />
+        <div className="limiter">
+          <div className="grid">
+            <div className="col col--4-mm col--12">
+              <div className="ml24-mm pt12" style={{ height: 52 }}>
+                <ProductMenu productName="Dr. UI" homePage="/dr-ui/" />
+              </div>
             </div>
-          </div>
-          <div className="col col--8-mm col--12">
-            <div className="flex-parent-mm flex-parent--center-cross flex-parent--end-main h-full-mm wmax300 wmax-full-mm mb0-mm mb12">
-              <Search site="dr-ui" />
+            <div className="col col--8-mm col--12">
+              <div className="flex-parent-mm flex-parent--center-cross flex-parent--end-main h-full-mm wmax300 wmax-full-mm mb0-mm mb12">
+                <Search site="dr-ui" />
+              </div>
             </div>
           </div>
         </div>
@@ -37,8 +39,10 @@ testCases.unStickSooner = {
     <div style={{ background: 'blue', height: 3000 }}>
       <div className="px24 py12">Above the bar.</div>
       <TopbarSticker unStickWidth={900}>
-        <div className="px24 py12">
-          I'm going to unstick at 900px wide or less!
+        <div className="limiter">
+          <div className="px24 py12">
+            I'm going to unstick at 900px wide or less!
+          </div>
         </div>
       </TopbarSticker>
       <div className="px24 py12">

--- a/src/components/topbar/__tests__/topbar-test-cases.js
+++ b/src/components/topbar/__tests__/topbar-test-cases.js
@@ -11,15 +11,17 @@ testCases.basic = {
     <div style={{ background: 'pink', height: 3000 }}>
       <div className="px24 py12">Above the bar.</div>
       <Topbar>
-        <div className="grid">
-          <div className="col col--4-mm col--12">
-            <div className="ml24-mm pt12" style={{ height: 52 }}>
-              <ProductMenu productName="Dr. UI" homePage="/dr-ui/" />
+        <div className="limiter">
+          <div className="grid">
+            <div className="col col--4-mm col--12">
+              <div className="ml24-mm pt12" style={{ height: 52 }}>
+                <ProductMenu productName="Dr. UI" homePage="/dr-ui/" />
+              </div>
             </div>
-          </div>
-          <div className="col col--8-mm col--12">
-            <div className="flex-parent-mm flex-parent--center-cross flex-parent--end-main h-full-mm wmax300 wmax-full-mm mb0-mm mb12">
-              <Search site="dr-ui" />
+            <div className="col col--8-mm col--12">
+              <div className="flex-parent-mm flex-parent--center-cross flex-parent--end-main h-full-mm wmax300 wmax-full-mm mb0-mm mb12">
+                <Search site="dr-ui" />
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/topbar/topbar.js
+++ b/src/components/topbar/topbar.js
@@ -8,7 +8,7 @@ class Topbar extends React.PureComponent {
         className="border-t border-b border--gray-light bg-white"
         data-swiftype-index="false"
       >
-        <div className="limiter">{this.props.children}</div>
+        {this.props.children}
       </div>
     );
   }


### PR DESCRIPTION
In https://github.com/mapbox/dr-ui/pull/274, I added `<div className="limiter">` to the new `Topbar` component in an effort to reduce code in individual repos. I think this was an over eager misstep, as it would require us to make a manual update to every page-shell to remove the now duplicated `<div className="limiter">`.

This PR reverts that change to prevent having to make lots of small updates in each repo.

