### PR TITLE
Add `iframe` option to `Video` component

### DIFF
--- a/src/components/related-page/vimeo.js
+++ b/src/components/related-page/vimeo.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Modal from '@mapbox/mr-ui/modal';
+import Video from '../video';
 
 // creates the modal
 export class VimeoModal extends React.Component {
@@ -13,21 +14,11 @@ export class VimeoModal extends React.Component {
         onExit={closeModal}
       >
         <div className="py36">
-          <div style={{ padding: '62.5% 0 0 0', position: 'relative' }}>
-            <iframe
-              src={`https://player.vimeo.com/video/${vimeoId}?title=0&byline=0&portrait=0`}
-              style={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                width: '100%',
-                height: '100%'
-              }}
-              frameBorder="0"
-              allow="autoplay; fullscreen"
-              allowFullScreen
-            />
-          </div>
+          <Video
+            iframe={true}
+            title={`Video: ${title}`}
+            src={`https://player.vimeo.com/video/${vimeoId}?title=0&byline=0&portrait=0`}
+          />
         </div>
       </Modal>
     );

--- a/src/components/video/__tests__/__snapshots__/video.test.js.snap
+++ b/src/components/video/__tests__/__snapshots__/video.test.js.snap
@@ -26,6 +26,35 @@ exports[`video Basic renders as expected 1`] = `
 </div>
 `;
 
+exports[`video Load video with an iframe (for Vimeo, YouTube, etc) renders as expected 1`] = `
+<div
+  className="bg-gray-dark"
+  style={
+    Object {
+      "padding": "62.5% 0 0 0",
+      "position": "relative",
+    }
+  }
+>
+  <iframe
+    allow="autoplay; fullscreen"
+    allowFullScreen={true}
+    frameBorder="0"
+    src="https://player.vimeo.com/video/388379420"
+    style={
+      Object {
+        "height": "100%",
+        "left": 0,
+        "position": "absolute",
+        "top": 0,
+        "width": "100%",
+      }
+    }
+    title="Another video!"
+  />
+</div>
+`;
+
 exports[`video Reduced motion renders as expected 1`] = `
 <div>
   <video

--- a/src/components/video/__tests__/video-test-cases.js
+++ b/src/components/video/__tests__/video-test-cases.js
@@ -21,4 +21,15 @@ noRenderCases.reducedMotion = {
   }
 };
 
+testCases.iframe = {
+  component: Video,
+  description: 'Load video with an iframe (for Vimeo, YouTube, etc)',
+  props: {
+    src: 'https://player.vimeo.com/video/388379420',
+    themeVideoContainer: 'bg-gray-dark',
+    iframe: true,
+    title: 'Another video!'
+  }
+};
+
 export { testCases, noRenderCases };

--- a/src/components/video/__tests__/video.test.js
+++ b/src/components/video/__tests__/video.test.js
@@ -58,4 +58,22 @@ describe('video', () => {
       expect(tree).toMatchSnapshot();
     });
   });
+
+  describe(testCases.iframe.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.iframe;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
 });

--- a/src/components/video/iframe.js
+++ b/src/components/video/iframe.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class Iframe extends React.Component {
+  render() {
+    return (
+      <div
+        className={this.props.themeVideoContainer}
+        style={{ padding: '62.5% 0 0 0', position: 'relative' }}
+      >
+        <iframe
+          src={this.props.src}
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%'
+          }}
+          title={this.props.title}
+          frameBorder="0"
+          allow="autoplay; fullscreen"
+          allowFullScreen
+        />
+      </div>
+    );
+  }
+}
+
+Iframe.propTypes = {
+  src: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  themeVideoContainer: PropTypes.string
+};

--- a/src/components/video/player.js
+++ b/src/components/video/player.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class Player extends React.Component {
+  render() {
+    let videoProps = {
+      autoPlay: true,
+      loop: true
+    };
+    const reducedMotion =
+      typeof window !== 'undefined'
+        ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+        : false;
+    if (reducedMotion) {
+      videoProps = {
+        autoPlay: undefined,
+        loop: undefined,
+        controls: true
+      };
+    }
+    return (
+      <div className={this.props.themeVideoContainer}>
+        <video
+          {...videoProps}
+          muted
+          width="100%"
+          className="block mx-auto"
+          src={this.props.src}
+          type="video/mp4"
+          title={this.props.title}
+        >
+          <p>
+            Your browser doesn't support HTML5 video. Here is a{' '}
+            <a href={this.props.src}>link to the video</a> instead.
+          </p>
+        </video>
+      </div>
+    );
+  }
+}
+
+Player.propTypes = {
+  src: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  themeVideoContainer: PropTypes.string
+};

--- a/src/components/video/video.js
+++ b/src/components/video/video.js
@@ -1,45 +1,34 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Player from './player';
+import Iframe from './iframe';
 
 export default class Video extends React.Component {
   render() {
-    let videoProps = {
-      autoPlay: true,
-      loop: true
-    };
-    const reducedMotion =
-      typeof window !== 'undefined'
-        ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
-        : false;
-    if (reducedMotion) {
-      videoProps = {
-        autoPlay: undefined,
-        loop: undefined,
-        controls: true
-      };
-    }
-    return (
-      <div>
-        <video
-          {...videoProps}
-          muted
-          width="100%"
-          className="block mx-auto"
-          src={this.props.src}
-          type="video/mp4"
-          title={this.props.title}
-        >
-          <p>
-            Your browser doesn't support HTML5 video. Here is a{' '}
-            <a href={this.props.src}>link to the video</a> instead.
-          </p>
-        </video>
-      </div>
+    const { src, title, iframe, themeVideoContainer } = this.props;
+    return iframe ? (
+      <Iframe
+        themeVideoContainer={themeVideoContainer}
+        src={src}
+        title={title}
+      />
+    ) : (
+      <Player
+        themeVideoContainer={themeVideoContainer}
+        src={src}
+        title={title}
+      />
     );
   }
 }
 
+Video.defaultProps = {
+  iframe: false
+};
+
 Video.propTypes = {
   src: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  themeVideoContainer: PropTypes.string,
+  iframe: PropTypes.bool // if true, load with iframe. If false (default), load with player.
 };


### PR DESCRIPTION
This PR adds an `iframe` option to the `Video` component so it can be used with external (Vimeo, YouTube) video embeds. 

- The component is split into `Player` and `Iframe` components. The default loads the `Player` which is the original `Video` component. There are no breaking changes to the current usage of this component.
- To enable the iframe for external videos, set `iframe={true}` `Video` and the component will load the `Iframe` component instead.
- Updated the RelatedPage vimeo embed to use the `Video` component with iframe option.
- Added new `themeVideoContainer` prop to pass class names to the container of the video for further customization.

Example on how to use Video component with an external video:

```jsx
<Video iframe={true} title="How to customize or hide text on a single label" src="https://player.vimeo.com/video/388379420"  />
```



Fixes #287 



## How to test

1. Open the Video test case.
2. Make sure both video tests cases load without errors.
3. Open the RelatedPage test case.
4. Make sure all video test cases load without errors.

## QA checklist

<!-- complete this checklist when adding a new component or package -->

- [ ] No errors logged to console.
- [ ] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [ ] Component is accessible at mobile-size viewport.
- [ ] Component is accessible at tablet-size viewport.
- [ ] Component is accessible at laptop-size viewport.
- [ ] Component is accessible at big-monitor-size viewport.
- [ ] Create a PR in a site repo, copy the component, and test it. Push to staging and let the reviewer know they can also test the component there.

Open the test cases app locally on:

- [ ] Chrome, no errors logged to console.
- [ ] Firefox, no errors logged to console.
- [ ] Safari, no errors logged to console.
- [ ] Edge, no errors logged to console.
- [ ] IE11, no errors logged to console.
- [ ] Mobile Safari, no errors logged to console.
- [ ] Android Chrome, no errors logged to console.
