### PR TITLE
Add Sentry to forward-event client

### DIFF
--- a/src/components/feedback/forward-event.js
+++ b/src/components/feedback/forward-event.js
@@ -1,3 +1,9 @@
+import * as Sentry from '@sentry/browser';
+
+Sentry.init({
+  dsn: 'https://b3f28ae6545c49a8a294f5b8cdf057e6@sentry.io/2991114',
+  environment: 'staging'
+});
 /**
  * A XHR-powered function that accepts your Segment event, sends it to the endpoint, and then forwards it to Segment.
  * Events will be sent to one of two Segment projects:
@@ -14,8 +20,15 @@ export default function forwardEvent(event, webhook, callback) {
   // window and event must be present to make the proper request
   if (typeof window === 'undefined') return;
   if (!event) {
+    Sentry.captureException('event argument required');
     throw new Error('event argument required');
   }
+
+  // set the event as extra context
+  Sentry.configureScope((scope) => {
+    scope.setExtra('event', event);
+  });
+
   // checks if the current page is on production or staging
   // then determines which webhook to post to
   const isProduction = /(^|\S+\.)mapbox\.com/.test(window.location.host);
@@ -57,6 +70,7 @@ export default function forwardEvent(event, webhook, callback) {
 
   // handles xhr error
   function handleError(error) {
+    Sentry.captureException(error);
     callback(error);
   }
 }


### PR DESCRIPTION
So continues our quest to capture forward-event issues.

A few months ago we added Sentry to forward-event repo, but I think that we also need to add it to our client that invokes forward-event.

This will give us:
- Exact page the failed forward-event request happened on.
- The event payload



## How to test

1. Pull down this branch && `npm ci`.
2. Replace `xhr.send(JSON.stringify(event));` with `xhr.send('test'));` This will trigger a 4xx error.
3. Run `npm start` and visit the /Feedback test case.
4. Submit feedback for the first feedback component.
5. Check to see that a 400 HTTP error event came through at `docs-forward-event` Sentry Project.