### PR TITLE
Do not allow Search to sync with the browser url

### DIFF
--- a/src/components/search/search.js
+++ b/src/components/search/search.js
@@ -16,6 +16,7 @@ class Search extends React.Component {
           initialState: {
             resultsPerPage: 10
           },
+          trackUrlState: false,
           searchQuery: {
             facets: {
               site: { type: 'value' }


### PR DESCRIPTION
This PR sets `trackUrlState` to `false`. This will prevent Swiftype from syncing the search query with the url.

Ref https://github.com/mapbox/documentation/issues/515#issuecomment-666481755

## How to test

Open the test cases app to the Search component, complete a search and make sure the URL doesn't change but your query returns results.

## QA checklist

<!-- complete this checklist when adding a new component or package -->

- [ ] No errors logged to console.
- [ ] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [ ] Component is accessible at mobile-size viewport.
- [ ] Component is accessible at tablet-size viewport.
- [ ] Component is accessible at laptop-size viewport.
- [ ] Component is accessible at big-monitor-size viewport.
- [ ] Create a PR in a site repo, copy the component, and test it. Push to staging and let the reviewer know they can also test the component there.

Open the test cases app locally on:

- [ ] Chrome, no errors logged to console.
- [ ] Firefox, no errors logged to console.
- [ ] Safari, no errors logged to console.
- [ ] Edge, no errors logged to console.
- [ ] IE11, no errors logged to console.
- [ ] Mobile Safari, no errors logged to console.
- [ ] Android Chrome, no errors logged to console.
