### PR TITLE
Add `resultBorder` prop to Search component

### DIFF
--- a/src/components/search/__tests__/__snapshots__/search.test.js.snap
+++ b/src/components/search/__tests__/__snapshots__/search.test.js.snap
@@ -221,7 +221,7 @@ exports[`search Search with dark background, custom placeholder. Open https://ap
 </div>
 `;
 
-exports[`search Set \`resultsOnly: true\` to true. Select an item to see search results, with a custom message when there are no search results for a particular query. Open https://app.swiftype.com/engines/docs/analytics/live while developing to watch query usage. renders as expected 1`] = `
+exports[`search Set \`resultsOnly: true\` to true. Select an item to see search results, with a custom message when there are no search results for a particular query, and borders added to each search result. Open https://app.swiftype.com/engines/docs/analytics/live while developing to watch query usage. renders as expected 1`] = `
 <div>
   <select
     aria-label="Select a product"

--- a/src/components/search/__tests__/results.js
+++ b/src/components/search/__tests__/results.js
@@ -39,6 +39,7 @@ export default class Example extends React.Component {
                 once you get in touch!
               </p>
             }
+            resultBorder={true}
           />
         </div>
       </div>

--- a/src/components/search/__tests__/search-test-cases.js
+++ b/src/components/search/__tests__/search-test-cases.js
@@ -58,7 +58,7 @@ testCases.withConnector = {
 testCases.resultsOnly = {
   component: Search,
   description:
-    'Set `resultsOnly: true` to true. Select an item to see search results, with a custom message when there are no search results for a particular query.',
+    'Set `resultsOnly: true` to true. Select an item to see search results, with a custom message when there are no search results for a particular query, and borders added to each search result.',
   element: <Results />
 };
 

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -229,6 +229,7 @@ class SearchBox extends React.Component {
                                 index={index}
                                 downshiftProps={downshiftProps}
                                 themeCompact={props.themeCompact}
+                                resultBorder={props.resultBorder}
                               />
                             ))}
                           </ul>
@@ -334,7 +335,8 @@ SearchBox.propTypes = {
   segmentTrackEvent: PropTypes.string,
   overrideSearchTerm: PropTypes.string,
   themeCompact: PropTypes.bool,
-  emptyResultMessage: PropTypes.node
+  emptyResultMessage: PropTypes.node,
+  resultBorder: PropTypes.bool
 };
 
 export default SearchBox;

--- a/src/components/search/search-result.js
+++ b/src/components/search/search-result.js
@@ -38,6 +38,8 @@ class SearchResult extends React.Component {
           item: props.result,
           className: `${highlighted && 'bg-gray-faint'} px12 ${
             props.themeCompact ? 'py6 txt-s' : 'py12'
+          } ${
+            props.resultBorder ? 'border-t border--gray-light' : ''
           } link--gray cursor-pointer`
         })}
       >
@@ -102,7 +104,8 @@ SearchResult.propTypes = {
   result: PropTypes.object,
   index: PropTypes.number,
   downshiftProps: PropTypes.object,
-  themeCompact: PropTypes.bool
+  themeCompact: PropTypes.bool,
+  resultBorder: PropTypes.bool
 };
 
 export default SearchResult;

--- a/src/components/search/search.js
+++ b/src/components/search/search.js
@@ -75,6 +75,7 @@ class Search extends React.Component {
                   overrideSearchTerm={props.overrideSearchTerm}
                   themeCompact={props.themeCompact}
                   emptyResultMessage={props.emptyResultMessage}
+                  resultBorder={props.resultBorder}
                 />
               </div>
             );
@@ -108,7 +109,9 @@ Search.propTypes = {
   /** If true, enable compact mode utilizing smaller text and padding, default false */
   themeCompact: PropTypes.bool,
   /** Node to display when there are no search results for the given query */
-  emptyResultMessage: PropTypes.node
+  emptyResultMessage: PropTypes.node,
+  /** If true, add borders to each search result */
+  resultBorder: PropTypes.bool
 };
 
 Search.defaultProps = {


### PR DESCRIPTION
<!-- list what changes this PR introduces -->
This PR adds one new property to Search:
* `resultBorder` - If true, add a light gray border to each search result rendered.

This adds on to the properties introduced in https://github.com/mapbox/dr-ui/pull/329. This property only introduces a small styling change, so it is not critical to make a release for it soon.

## How to test

<!-- list steps on how the reviewer can test this change -->
1. Run `npm start`.
2. Open /Search test cases page.
3. Scroll to `Set resultsOnly to true.` test case.
4. Select an item from the test cases Select element.
5. Observe that each result has a light gray border.

## QA checklist

<!-- complete this checklist when adding a new component or package -->

- [ ] No errors logged to console.
- [ ] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [ ] Component is accessible at mobile-size viewport.
- [ ] Component is accessible at tablet-size viewport.
- [ ] Component is accessible at laptop-size viewport.
- [ ] Component is accessible at big-monitor-size viewport.
- [ ] Create a PR in a site repo, copy the component, and test it. Push to staging and let the reviewer know they can also test the component there.

Open the test cases app locally on:

- [ ] Chrome, no errors logged to console.
- [ ] Firefox, no errors logged to console.
- [ ] Safari, no errors logged to console.
- [ ] Edge, no errors logged to console.
- [ ] IE11, no errors logged to console.
- [ ] Mobile Safari, no errors logged to console.
- [ ] Android Chrome, no errors logged to console.
