### PR TITLE
[info arch] Make NavigationAccordion toggleable

### DIFF
--- a/src/components/navigation-accordion/__tests__/navigation-accordion-test-cases.js
+++ b/src/components/navigation-accordion/__tests__/navigation-accordion-test-cases.js
@@ -5,6 +5,7 @@ const testCases = {};
 const navigation = [
   {
     title: 'Overview',
+    id: 'overview',
     path: '/dr-ui/overview/',
     pages: [
       {
@@ -15,6 +16,7 @@ const navigation = [
   },
   {
     title: 'Examples',
+    id: 'examples',
     path: '/dr-ui/examples/',
     pages: [
       {
@@ -55,6 +57,7 @@ testCases.withTags = {
       {
         title: 'Title one',
         path: 'page-one',
+        id: 'title-one',
         pages: [
           {
             title: 'Heading one',
@@ -79,7 +82,8 @@ testCases.withTags = {
       {
         title: 'Title two',
         tag: 'beta',
-        path: 'page-two'
+        path: 'page-two',
+        id: 'page-two'
       }
     ]
   }

--- a/src/components/navigation-accordion/examples/basic.js
+++ b/src/components/navigation-accordion/examples/basic.js
@@ -9,6 +9,7 @@ export default class Basic extends React.Component {
     const navigation = [
       {
         title: 'Overview',
+        id: 'overview',
         path: '/dr-ui/overview/',
         pages: [
           {
@@ -19,6 +20,7 @@ export default class Basic extends React.Component {
       },
       {
         title: 'Examples',
+        id: 'examples',
         path: '/dr-ui/examples/',
         pages: [
           {

--- a/src/components/navigation-accordion/navigation-accordion.js
+++ b/src/components/navigation-accordion/navigation-accordion.js
@@ -2,47 +2,87 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Icon from '@mapbox/mr-ui/icon';
+// check if client body width is >= 640
+const isMM =
+  typeof document !== 'undefined' ? document.body.clientWidth >= 640 : false;
 
-export default class NavigationAccordion extends React.PureComponent {
-  renderHeader(href, label, hasChildren) {
-    const { parentPage } = this.props;
-    const isActive = parentPage === href;
+export default class NavigationAccordion extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      activeToggles: []
+    };
+  }
+
+  setToggle = (label) => {
+    const { activeToggles } = this.state;
+    // add item or remove it if it already exists in activeToggles
+    if (activeToggles.indexOf(label) > -1)
+      activeToggles.splice(activeToggles.indexOf(label), 1);
+    else activeToggles.push(label);
+    this.setState({ activeToggles: activeToggles });
+  };
+
+  componentDidMount() {
+    // if the component mounts on devices > 640 width
+    // determine which navTab is active
+    // and set that to the state to open subpages (if necessary)
+    const { parentPage, navigation } = this.props;
+    if (isMM) {
+      navigation.forEach((nav) => {
+        if (nav.path === parentPage) {
+          this.setToggle(nav.title);
+        }
+      });
+    }
+  }
+
+  renderHeader(
+    href,
+    label,
+    hasChildren,
+    isActiveToggle,
+    isActiveSection,
+    sectionId
+  ) {
     return (
       <div
         className={classnames(
-          'px12 py3 flex-parent txt-uppercase txt-fancy round-full w-full color-blue-on-hover color-darken75',
+          'px12 flex-parent txt-uppercase txt-fancy round-full w-full color-darken75',
           {
-            'bg-blue-faint color-blue': isActive,
+            'bg-blue-faint color-blue': isActiveSection,
             'flex-parent flex-parent--space-between-main': hasChildren
           }
         )}
       >
         <a
           href={href}
-          className="flex-child flex-child--grow"
+          className="flex-child flex-child--grow  color-blue-on-hover py6 py3-mm"
           style={{ letterSpacing: '0.025em' }}
         >
           {label}
         </a>
         {hasChildren && (
-          <div className="flex-child flex-child--no-shrink">
-            <button>
-              <Icon
-                name={isActive ? 'chevron-up' : 'chevron-down'}
-                inline={true}
-              />
-            </button>
-          </div>
+          <button
+            className="flex-child flex-child--no-shrink color-blue-on-hover px12 px0-mm"
+            onClick={() => this.setToggle(label)}
+            aria-label={`Toggle ${label} menu`}
+            aria-controls={`${sectionId}-menu`}
+            aria-expanded={isActiveToggle}
+          >
+            <Icon
+              name={isActiveToggle ? 'chevron-up' : 'chevron-down'}
+              inline={true}
+            />
+          </button>
         )}
       </div>
     );
   }
-  renderBody(subItems, activeItem) {
+  renderBody(subItems, activeItem, sectionId) {
     const { parentPage } = this.props;
     const subItemEls = subItems
-      .filter((page) => {
-        return page.path !== parentPage;
-      })
+      .filter((page) => page.path !== parentPage)
       .map((page) => (
         <li className="mb3" key={page.title}>
           <a
@@ -56,21 +96,34 @@ export default class NavigationAccordion extends React.PureComponent {
         </li>
       ));
 
-    return <ul className="mb12 ml12">{subItemEls}</ul>;
+    return (
+      <ul id={`${sectionId}-menu`} className="mb12 ml12">
+        {subItemEls}
+      </ul>
+    );
   }
 
   render() {
     const { navigation, parentPage, location } = this.props;
+    const { activeToggles } = this.state;
+
     const activeItem = location.pathname;
     const items = navigation.map((pageSection) => {
-      const { title, path, pages, hideSubpages } = pageSection;
+      const { title, id, path, pages, hideSubpages } = pageSection;
       const hasPages = pages && pages.length > 0 && !hideSubpages;
+      const showPages = activeToggles.indexOf(title) > -1;
+      const isActiveSection = path === parentPage;
       return {
-        header: this.renderHeader(path, title, hasPages),
+        header: this.renderHeader(
+          path,
+          title,
+          hasPages,
+          showPages,
+          isActiveSection,
+          id
+        ),
         body:
-          path === parentPage && hasPages
-            ? this.renderBody(pages, activeItem)
-            : []
+          showPages && hasPages ? this.renderBody(pages, activeItem, id) : []
       };
     });
 
@@ -96,6 +149,7 @@ NavigationAccordion.propTypes = {
     PropTypes.shape({
       title: PropTypes.string.isRequired,
       path: PropTypes.string.isRequired,
+      id: PropTypes.string.isRequired,
       hideSubpages: PropTypes.bool, // needed for /help/tutorials and /help/troublehshooting
       pages: PropTypes.array
     })

--- a/src/components/navigation-accordion/navigation-accordion.js
+++ b/src/components/navigation-accordion/navigation-accordion.js
@@ -67,7 +67,7 @@ export default class NavigationAccordion extends React.Component {
             className="flex-child flex-child--no-shrink color-blue-on-hover px12 px0-mm"
             onClick={() => this.setToggle(label)}
             aria-label={`Toggle ${label} menu`}
-            aria-controls={`${sectionId}-menu`}
+            aria-controls={sectionId}
             aria-expanded={isActiveToggle}
           >
             <Icon
@@ -82,7 +82,9 @@ export default class NavigationAccordion extends React.Component {
   renderBody(subItems, activeItem, sectionId) {
     const { parentPage } = this.props;
     const subItemEls = subItems
-      .filter((page) => page.path !== parentPage)
+      .filter((page) => {
+        return page.path !== parentPage;
+      })
       .map((page) => (
         <li className="mb3" key={page.title}>
           <a
@@ -97,7 +99,7 @@ export default class NavigationAccordion extends React.Component {
       ));
 
     return (
-      <ul id={`${sectionId}-menu`} className="mb12 ml12">
+      <ul id={sectionId} className="mb12 ml12">
         {subItemEls}
       </ul>
     );
@@ -113,6 +115,7 @@ export default class NavigationAccordion extends React.Component {
       const hasPages = pages && pages.length > 0 && !hideSubpages;
       const showPages = activeToggles.indexOf(title) > -1;
       const isActiveSection = path === parentPage;
+      const sectionId = `menu-${id}`;
       return {
         header: this.renderHeader(
           path,
@@ -120,10 +123,12 @@ export default class NavigationAccordion extends React.Component {
           hasPages,
           showPages,
           isActiveSection,
-          id
+          sectionId
         ),
         body:
-          showPages && hasPages ? this.renderBody(pages, activeItem, id) : []
+          showPages && hasPages
+            ? this.renderBody(pages, activeItem, sectionId)
+            : []
       };
     });
 

--- a/src/components/navigation-accordion/navigation-accordion.js
+++ b/src/components/navigation-accordion/navigation-accordion.js
@@ -14,19 +14,23 @@ export default class NavigationAccordion extends React.Component {
     };
   }
 
+  // add item or remove it if it already exists
   setToggle = (label) => {
     const { activeToggles } = this.state;
-    // add item or remove it if it already exists in activeToggles
-    if (activeToggles.indexOf(label) > -1)
-      activeToggles.splice(activeToggles.indexOf(label), 1);
-    else activeToggles.push(label);
+    const labelIndex = activeToggles.indexOf(label);
+    if (labelIndex > -1) {
+      // label already exists, remove it from activeToggles
+      activeToggles.splice(labelIndex, 1);
+    } else {
+      // label does not exist, add it to activeToggles
+      activeToggles.push(label);
+    }
     this.setState({ activeToggles: activeToggles });
   };
 
   componentDidMount() {
-    // if the component mounts on devices > 640 width
-    // determine which navTab is active
-    // and set that to the state to open subpages (if necessary)
+    // if device width is >= 640
+    // determine which section is active and activate its toggle
     const { parentPage, navigation } = this.props;
     if (isMM) {
       navigation.forEach((nav) => {
@@ -108,12 +112,14 @@ export default class NavigationAccordion extends React.Component {
   render() {
     const { navigation, parentPage, location } = this.props;
     const { activeToggles } = this.state;
-
     const activeItem = location.pathname;
     const items = navigation.map((pageSection) => {
       const { title, id, path, pages, hideSubpages } = pageSection;
+      // the section has sub pages
       const hasPages = pages && pages.length > 0 && !hideSubpages;
-      const showPages = activeToggles.indexOf(title) > -1;
+      // the section's toggle is active
+      const isActiveToggle = activeToggles.indexOf(title) > -1;
+      // the section is active
       const isActiveSection = path === parentPage;
       const sectionId = `menu-${id}`;
       return {
@@ -121,12 +127,12 @@ export default class NavigationAccordion extends React.Component {
           path,
           title,
           hasPages,
-          showPages,
+          isActiveToggle,
           isActiveSection,
           sectionId
         ),
         body:
-          showPages && hasPages
+          isActiveToggle && hasPages
             ? this.renderBody(pages, activeItem, sectionId)
             : []
       };

--- a/src/components/navigation-accordion/navigation-accordion.js
+++ b/src/components/navigation-accordion/navigation-accordion.js
@@ -8,23 +8,33 @@ export default class NavigationAccordion extends React.PureComponent {
     const { parentPage } = this.props;
     const isActive = parentPage === href;
     return (
-      <a
-        href={href}
+      <div
         className={classnames(
-          'px12 py3 inline-block txt-uppercase txt-fancy round-full w-full color-blue-on-hover color-darken75',
+          'px12 py3 flex-parent txt-uppercase txt-fancy round-full w-full color-blue-on-hover color-darken75',
           {
             'bg-blue-faint color-blue': isActive,
-            '': !isActive,
             'flex-parent flex-parent--space-between-main': hasChildren
           }
         )}
-        style={{ letterSpacing: '0.025em' }}
       >
-        {label}
+        <a
+          href={href}
+          className="flex-child flex-child--grow"
+          style={{ letterSpacing: '0.025em' }}
+        >
+          {label}
+        </a>
         {hasChildren && (
-          <Icon name={isActive ? 'chevron-up' : 'chevron-down'} inline={true} />
+          <div className="flex-child flex-child--no-shrink">
+            <button>
+              <Icon
+                name={isActive ? 'chevron-up' : 'chevron-down'}
+                inline={true}
+              />
+            </button>
+          </div>
         )}
-      </a>
+      </div>
     );
   }
   renderBody(subItems, activeItem) {

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -51,72 +51,96 @@ Array [
             >
               <ul>
                 <li>
-                  <a
-                    className="px12 py3 inline-block txt-uppercase txt-fancy round-full w-full color-blue-on-hover color-darken75  flex-parent flex-parent--space-between-main"
-                    href="/PageLayout/"
-                    style={
-                      Object {
-                        "letterSpacing": "0.025em",
-                      }
-                    }
+                  <div
+                    className="px12 flex-parent txt-uppercase txt-fancy round-full w-full color-darken75 flex-parent flex-parent--space-between-main"
                   >
-                    Overview
-                    <svg
-                      className="events-none icon inline-block align-t"
-                      focusable="false"
-                      role="presentation"
+                    <a
+                      className="flex-child flex-child--grow  color-blue-on-hover py6 py3-mm"
+                      href="/PageLayout/"
                       style={
                         Object {
-                          "height": 18,
-                          "width": 18,
+                          "letterSpacing": "0.025em",
                         }
                       }
                     >
-                      <use
-                        xlinkHref="#icon-chevron-down"
-                        xmlnsXlink="http://www.w3.org/1999/xlink"
-                      />
-                    </svg>
-                  </a>
+                      Overview
+                    </a>
+                    <button
+                      aria-controls="overview-menu"
+                      aria-expanded={false}
+                      aria-label="Toggle Overview menu"
+                      className="flex-child flex-child--no-shrink color-blue-on-hover px12 px0-mm"
+                      onClick={[Function]}
+                    >
+                      <svg
+                        className="events-none icon inline-block align-t"
+                        focusable="false"
+                        role="presentation"
+                        style={
+                          Object {
+                            "height": 18,
+                            "width": 18,
+                          }
+                        }
+                      >
+                        <use
+                          xlinkHref="#icon-chevron-down"
+                          xmlnsXlink="http://www.w3.org/1999/xlink"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </li>
                 <li>
-                  <a
-                    className="px12 py3 inline-block txt-uppercase txt-fancy round-full w-full color-blue-on-hover color-darken75 "
-                    href="/PageLayout/specification/"
-                    style={
-                      Object {
-                        "letterSpacing": "0.025em",
-                      }
-                    }
+                  <div
+                    className="px12 flex-parent txt-uppercase txt-fancy round-full w-full color-darken75"
                   >
-                    Specification
-                  </a>
+                    <a
+                      className="flex-child flex-child--grow  color-blue-on-hover py6 py3-mm"
+                      href="/PageLayout/specification/"
+                      style={
+                        Object {
+                          "letterSpacing": "0.025em",
+                        }
+                      }
+                    >
+                      Specification
+                    </a>
+                  </div>
                 </li>
                 <li>
-                  <a
-                    className="px12 py3 inline-block txt-uppercase txt-fancy round-full w-full color-blue-on-hover color-darken75 bg-blue-faint color-blue"
-                    href="/PageLayout/examples/"
-                    style={
-                      Object {
-                        "letterSpacing": "0.025em",
-                      }
-                    }
+                  <div
+                    className="px12 flex-parent txt-uppercase txt-fancy round-full w-full color-darken75 bg-blue-faint color-blue"
                   >
-                    Examples
-                  </a>
+                    <a
+                      className="flex-child flex-child--grow  color-blue-on-hover py6 py3-mm"
+                      href="/PageLayout/examples/"
+                      style={
+                        Object {
+                          "letterSpacing": "0.025em",
+                        }
+                      }
+                    >
+                      Examples
+                    </a>
+                  </div>
                 </li>
                 <li>
-                  <a
-                    className="px12 py3 inline-block txt-uppercase txt-fancy round-full w-full color-blue-on-hover color-darken75 "
-                    href="/PageLayout/demo/"
-                    style={
-                      Object {
-                        "letterSpacing": "0.025em",
-                      }
-                    }
+                  <div
+                    className="px12 flex-parent txt-uppercase txt-fancy round-full w-full color-darken75"
                   >
-                    Demo
-                  </a>
+                    <a
+                      className="flex-child flex-child--grow  color-blue-on-hover py6 py3-mm"
+                      href="/PageLayout/demo/"
+                      style={
+                        Object {
+                          "letterSpacing": "0.025em",
+                        }
+                      }
+                    >
+                      Demo
+                    </a>
+                  </div>
                 </li>
               </ul>
             </nav>
@@ -550,72 +574,96 @@ Array [
             >
               <ul>
                 <li>
-                  <a
-                    className="px12 py3 inline-block txt-uppercase txt-fancy round-full w-full color-blue-on-hover color-darken75  flex-parent flex-parent--space-between-main"
-                    href="/PageLayout/"
-                    style={
-                      Object {
-                        "letterSpacing": "0.025em",
-                      }
-                    }
+                  <div
+                    className="px12 flex-parent txt-uppercase txt-fancy round-full w-full color-darken75 flex-parent flex-parent--space-between-main"
                   >
-                    Overview
-                    <svg
-                      className="events-none icon inline-block align-t"
-                      focusable="false"
-                      role="presentation"
+                    <a
+                      className="flex-child flex-child--grow  color-blue-on-hover py6 py3-mm"
+                      href="/PageLayout/"
                       style={
                         Object {
-                          "height": 18,
-                          "width": 18,
+                          "letterSpacing": "0.025em",
                         }
                       }
                     >
-                      <use
-                        xlinkHref="#icon-chevron-down"
-                        xmlnsXlink="http://www.w3.org/1999/xlink"
-                      />
-                    </svg>
-                  </a>
+                      Overview
+                    </a>
+                    <button
+                      aria-controls="overview-menu"
+                      aria-expanded={false}
+                      aria-label="Toggle Overview menu"
+                      className="flex-child flex-child--no-shrink color-blue-on-hover px12 px0-mm"
+                      onClick={[Function]}
+                    >
+                      <svg
+                        className="events-none icon inline-block align-t"
+                        focusable="false"
+                        role="presentation"
+                        style={
+                          Object {
+                            "height": 18,
+                            "width": 18,
+                          }
+                        }
+                      >
+                        <use
+                          xlinkHref="#icon-chevron-down"
+                          xmlnsXlink="http://www.w3.org/1999/xlink"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </li>
                 <li>
-                  <a
-                    className="px12 py3 inline-block txt-uppercase txt-fancy round-full w-full color-blue-on-hover color-darken75 "
-                    href="/PageLayout/specification/"
-                    style={
-                      Object {
-                        "letterSpacing": "0.025em",
-                      }
-                    }
+                  <div
+                    className="px12 flex-parent txt-uppercase txt-fancy round-full w-full color-darken75"
                   >
-                    Specification
-                  </a>
+                    <a
+                      className="flex-child flex-child--grow  color-blue-on-hover py6 py3-mm"
+                      href="/PageLayout/specification/"
+                      style={
+                        Object {
+                          "letterSpacing": "0.025em",
+                        }
+                      }
+                    >
+                      Specification
+                    </a>
+                  </div>
                 </li>
                 <li>
-                  <a
-                    className="px12 py3 inline-block txt-uppercase txt-fancy round-full w-full color-blue-on-hover color-darken75 bg-blue-faint color-blue"
-                    href="/PageLayout/examples/"
-                    style={
-                      Object {
-                        "letterSpacing": "0.025em",
-                      }
-                    }
+                  <div
+                    className="px12 flex-parent txt-uppercase txt-fancy round-full w-full color-darken75 bg-blue-faint color-blue"
                   >
-                    Examples
-                  </a>
+                    <a
+                      className="flex-child flex-child--grow  color-blue-on-hover py6 py3-mm"
+                      href="/PageLayout/examples/"
+                      style={
+                        Object {
+                          "letterSpacing": "0.025em",
+                        }
+                      }
+                    >
+                      Examples
+                    </a>
+                  </div>
                 </li>
                 <li>
-                  <a
-                    className="px12 py3 inline-block txt-uppercase txt-fancy round-full w-full color-blue-on-hover color-darken75 "
-                    href="/PageLayout/demo/"
-                    style={
-                      Object {
-                        "letterSpacing": "0.025em",
-                      }
-                    }
+                  <div
+                    className="px12 flex-parent txt-uppercase txt-fancy round-full w-full color-darken75"
                   >
-                    Demo
-                  </a>
+                    <a
+                      className="flex-child flex-child--grow  color-blue-on-hover py6 py3-mm"
+                      href="/PageLayout/demo/"
+                      style={
+                        Object {
+                          "letterSpacing": "0.025em",
+                        }
+                      }
+                    >
+                      Demo
+                    </a>
+                  </div>
                 </li>
               </ul>
             </nav>
@@ -865,106 +913,96 @@ Array [
             >
               <ul>
                 <li>
-                  <a
-                    className="px12 py3 inline-block txt-uppercase txt-fancy round-full w-full color-blue-on-hover color-darken75 bg-blue-faint color-blue flex-parent flex-parent--space-between-main"
-                    href="/PageLayout/"
-                    style={
-                      Object {
-                        "letterSpacing": "0.025em",
-                      }
-                    }
+                  <div
+                    className="px12 flex-parent txt-uppercase txt-fancy round-full w-full color-darken75 bg-blue-faint color-blue flex-parent flex-parent--space-between-main"
                   >
-                    Overview
-                    <svg
-                      className="events-none icon inline-block align-t"
-                      focusable="false"
-                      role="presentation"
+                    <a
+                      className="flex-child flex-child--grow  color-blue-on-hover py6 py3-mm"
+                      href="/PageLayout/"
                       style={
                         Object {
-                          "height": 18,
-                          "width": 18,
+                          "letterSpacing": "0.025em",
                         }
                       }
                     >
-                      <use
-                        xlinkHref="#icon-chevron-up"
-                        xmlnsXlink="http://www.w3.org/1999/xlink"
-                      />
-                    </svg>
-                  </a>
-                  <ul
-                    className="mb12 ml12"
-                  >
-                    <li
-                      className="mb3"
+                      Overview
+                    </a>
+                    <button
+                      aria-controls="Overview-menu"
+                      aria-expanded={false}
+                      aria-label="Toggle Overview menu"
+                      className="flex-child flex-child--no-shrink color-blue-on-hover px12 px0-mm"
+                      onClick={[Function]}
                     >
-                      <a
-                        className="inline-block w-full color-blue-on-hover"
-                        href="/PageLayout/annotations/"
+                      <svg
+                        className="events-none icon inline-block align-t"
+                        focusable="false"
+                        role="presentation"
+                        style={
+                          Object {
+                            "height": 18,
+                            "width": 18,
+                          }
+                        }
                       >
-                        Annotations
-                      </a>
-                    </li>
-                    <li
-                      className="mb3"
-                    >
-                      <a
-                        className="inline-block w-full color-blue-on-hover"
-                        href="/PageLayout/worldview/"
-                      >
-                        Worldview
-                      </a>
-                    </li>
-                    <li
-                      className="mb3"
-                    >
-                      <a
-                        className="inline-block w-full color-blue-on-hover"
-                        href="/PageLayout/expressions/"
-                      >
-                        Expressions
-                      </a>
-                    </li>
-                  </ul>
+                        <use
+                          xlinkHref="#icon-chevron-down"
+                          xmlnsXlink="http://www.w3.org/1999/xlink"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </li>
                 <li>
-                  <a
-                    className="px12 py3 inline-block txt-uppercase txt-fancy round-full w-full color-blue-on-hover color-darken75 "
-                    href="/PageLayout/specification/"
-                    style={
-                      Object {
-                        "letterSpacing": "0.025em",
-                      }
-                    }
+                  <div
+                    className="px12 flex-parent txt-uppercase txt-fancy round-full w-full color-darken75"
                   >
-                    Specification
-                  </a>
+                    <a
+                      className="flex-child flex-child--grow  color-blue-on-hover py6 py3-mm"
+                      href="/PageLayout/specification/"
+                      style={
+                        Object {
+                          "letterSpacing": "0.025em",
+                        }
+                      }
+                    >
+                      Specification
+                    </a>
+                  </div>
                 </li>
                 <li>
-                  <a
-                    className="px12 py3 inline-block txt-uppercase txt-fancy round-full w-full color-blue-on-hover color-darken75 "
-                    href="/PageLayout/examples/"
-                    style={
-                      Object {
-                        "letterSpacing": "0.025em",
-                      }
-                    }
+                  <div
+                    className="px12 flex-parent txt-uppercase txt-fancy round-full w-full color-darken75"
                   >
-                    Examples
-                  </a>
+                    <a
+                      className="flex-child flex-child--grow  color-blue-on-hover py6 py3-mm"
+                      href="/PageLayout/examples/"
+                      style={
+                        Object {
+                          "letterSpacing": "0.025em",
+                        }
+                      }
+                    >
+                      Examples
+                    </a>
+                  </div>
                 </li>
                 <li>
-                  <a
-                    className="px12 py3 inline-block txt-uppercase txt-fancy round-full w-full color-blue-on-hover color-darken75 "
-                    href="/PageLayout/demo/"
-                    style={
-                      Object {
-                        "letterSpacing": "0.025em",
-                      }
-                    }
+                  <div
+                    className="px12 flex-parent txt-uppercase txt-fancy round-full w-full color-darken75"
                   >
-                    Demo
-                  </a>
+                    <a
+                      className="flex-child flex-child--grow  color-blue-on-hover py6 py3-mm"
+                      href="/PageLayout/demo/"
+                      style={
+                        Object {
+                          "letterSpacing": "0.025em",
+                        }
+                      }
+                    >
+                      Demo
+                    </a>
+                  </div>
                 </li>
               </ul>
             </nav>
@@ -1294,17 +1332,21 @@ Array [
             >
               <ul>
                 <li>
-                  <a
-                    className="px12 py3 inline-block txt-uppercase txt-fancy round-full w-full color-blue-on-hover color-darken75 bg-blue-faint color-blue"
-                    href="/PageLayout/"
-                    style={
-                      Object {
-                        "letterSpacing": "0.025em",
-                      }
-                    }
+                  <div
+                    className="px12 flex-parent txt-uppercase txt-fancy round-full w-full color-darken75 bg-blue-faint color-blue"
                   >
-                    Overview
-                  </a>
+                    <a
+                      className="flex-child flex-child--grow  color-blue-on-hover py6 py3-mm"
+                      href="/PageLayout/"
+                      style={
+                        Object {
+                          "letterSpacing": "0.025em",
+                        }
+                      }
+                    >
+                      Overview
+                    </a>
+                  </div>
                 </li>
               </ul>
             </nav>

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -66,7 +66,7 @@ Array [
                       Overview
                     </a>
                     <button
-                      aria-controls="overview-menu"
+                      aria-controls="menu-overview"
                       aria-expanded={false}
                       aria-label="Toggle Overview menu"
                       className="flex-child flex-child--no-shrink color-blue-on-hover px12 px0-mm"
@@ -589,7 +589,7 @@ Array [
                       Overview
                     </a>
                     <button
-                      aria-controls="overview-menu"
+                      aria-controls="menu-overview"
                       aria-expanded={false}
                       aria-label="Toggle Overview menu"
                       className="flex-child flex-child--no-shrink color-blue-on-hover px12 px0-mm"
@@ -928,7 +928,7 @@ Array [
                       Overview
                     </a>
                     <button
-                      aria-controls="Overview-menu"
+                      aria-controls="menu-overview"
                       aria-expanded={false}
                       aria-label="Toggle Overview menu"
                       className="flex-child flex-child--no-shrink color-blue-on-hover px12 px0-mm"

--- a/src/components/page-layout/examples/example-page.js
+++ b/src/components/page-layout/examples/example-page.js
@@ -47,6 +47,7 @@ export default class Basic extends React.Component {
             {
               path: '/PageLayout/',
               title: 'Overview',
+              id: 'overview',
               pages: [
                 {
                   path: '/PageLayout/specifications/',
@@ -64,15 +65,18 @@ export default class Basic extends React.Component {
             },
             {
               path: '/PageLayout/specification/',
-              title: 'Specification'
+              title: 'Specification',
+              id: 'specification'
             },
             {
               path: '/PageLayout/examples/',
-              title: 'Examples'
+              title: 'Examples',
+              id: 'examples'
             },
             {
               path: '/PageLayout/demo/',
-              title: 'Demo'
+              title: 'Demo',
+              id: 'demo'
             }
           ]
         }}

--- a/src/components/page-layout/examples/example.js
+++ b/src/components/page-layout/examples/example.js
@@ -47,6 +47,7 @@ export default class Basic extends React.Component {
             {
               path: '/PageLayout/',
               title: 'Overview',
+              id: 'overview',
               pages: [
                 {
                   path: '/PageLayout/specifications/',
@@ -64,15 +65,18 @@ export default class Basic extends React.Component {
             },
             {
               path: '/PageLayout/specification/',
-              title: 'Specification'
+              title: 'Specification',
+              id: 'specification'
             },
             {
               path: '/PageLayout/examples/',
-              title: 'Examples'
+              title: 'Examples',
+              id: 'examples'
             },
             {
               path: '/PageLayout/demo/',
-              title: 'Demo'
+              title: 'Demo',
+              id: 'demo'
             }
           ]
         }}

--- a/src/components/page-layout/examples/full.js
+++ b/src/components/page-layout/examples/full.js
@@ -33,7 +33,8 @@ export default class Basic extends React.Component {
           navTabs: [
             {
               title: 'Overview',
-              path: '/PageLayout/'
+              path: '/PageLayout/',
+              id: 'overview'
             }
           ]
         }}

--- a/src/components/page-layout/examples/page.js
+++ b/src/components/page-layout/examples/page.js
@@ -38,7 +38,7 @@ export default class Basic extends React.Component {
             {
               path: '/PageLayout/',
               title: 'Overview',
-              id: 'Overview',
+              id: 'overview',
               pages: [
                 {
                   path: '/PageLayout/annotations/',

--- a/src/components/page-layout/examples/page.js
+++ b/src/components/page-layout/examples/page.js
@@ -38,6 +38,7 @@ export default class Basic extends React.Component {
             {
               path: '/PageLayout/',
               title: 'Overview',
+              id: 'Overview',
               pages: [
                 {
                   path: '/PageLayout/annotations/',
@@ -55,15 +56,18 @@ export default class Basic extends React.Component {
             },
             {
               path: '/PageLayout/specification/',
-              title: 'Specification'
+              title: 'Specification',
+              id: 'specification'
             },
             {
               path: '/PageLayout/examples/',
-              title: 'Examples'
+              title: 'Examples',
+              id: 'examples'
             },
             {
               path: '/PageLayout/demo/',
-              title: 'Demo'
+              title: 'Demo',
+              id: 'demo'
             }
           ]
         }}

--- a/src/helpers/batfish/__tests__/__snapshots__/navigation.test.js.snap
+++ b/src/helpers/batfish/__tests__/__snapshots__/navigation.test.js.snap
@@ -3,6 +3,7 @@
 exports[`buildNavigation help glossary is sorted alphabetical 1`] = `
 Array [
   Object {
+    "id": "how-mapbox-works",
     "navOrder": 2,
     "pages": Array [
       Object {
@@ -94,6 +95,7 @@ Array [
     "title": "How Mapbox Works",
   },
   Object {
+    "id": "tutorials",
     "navOrder": 3,
     "pages": Array [
       Object {
@@ -496,6 +498,7 @@ Array [
     "title": "Tutorials",
   },
   Object {
+    "id": "troubleshooting",
     "navOrder": 4,
     "pages": Array [
       Object {
@@ -698,6 +701,7 @@ Array [
     "title": "Troubleshooting",
   },
   Object {
+    "id": "glossary",
     "navOrder": 5,
     "pages": Array [
       Object {
@@ -1230,6 +1234,7 @@ Object {
   },
   "navTabs": Array [
     Object {
+      "id": "top-page",
       "navOrder": 1,
       "pages": Array [
         Object {
@@ -1250,6 +1255,7 @@ Object {
   "beta/navigation": Object {
     "navTabs": Array [
       Object {
+        "id": "overview",
         "navOrder": 1,
         "pages": Array [
           Object {
@@ -1293,12 +1299,14 @@ Object {
         "title": "Overview",
       },
       Object {
+        "id": "specification",
         "navOrder": 2,
         "pages": Array [],
         "path": "/docs-starter-kit/beta/navigation/specification/",
         "title": "Specification",
       },
       Object {
+        "id": "examples",
         "navOrder": 3,
         "pages": Array [],
         "path": "/docs-starter-kit/beta/navigation/examples/",
@@ -1666,6 +1674,7 @@ Object {
   "maps": Object {
     "navTabs": Array [
       Object {
+        "id": "overview",
         "navOrder": 1,
         "pages": Array [
           Object {
@@ -1709,12 +1718,14 @@ Object {
         "title": "Overview",
       },
       Object {
+        "id": "specification",
         "navOrder": 2,
         "pages": Array [],
         "path": "/docs-starter-kit/maps/specification/",
         "title": "Specification",
       },
       Object {
+        "id": "examples",
         "navOrder": 3,
         "pages": Array [],
         "path": "/docs-starter-kit/maps/examples/",
@@ -1727,6 +1738,7 @@ Object {
   "navigation": Object {
     "navTabs": Array [
       Object {
+        "id": "overview",
         "navOrder": 1,
         "pages": Array [
           Object {
@@ -1770,12 +1782,14 @@ Object {
         "title": "Overview",
       },
       Object {
+        "id": "specification",
         "navOrder": 2,
         "pages": Array [],
         "path": "/docs-starter-kit/navigation/specification/",
         "title": "Specification",
       },
       Object {
+        "id": "examples",
         "navOrder": 3,
         "pages": Array [],
         "path": "/docs-starter-kit/navigation/examples/",
@@ -1788,6 +1802,7 @@ Object {
   "vision": Object {
     "navTabs": Array [
       Object {
+        "id": "overview",
         "navOrder": 1,
         "pages": Array [
           Object {
@@ -1831,12 +1846,14 @@ Object {
         "title": "Overview",
       },
       Object {
+        "id": "specification",
         "navOrder": 2,
         "pages": Array [],
         "path": "/docs-starter-kit/vision/specification/",
         "title": "Specification",
       },
       Object {
+        "id": "examples",
         "navOrder": 3,
         "pages": Array [],
         "path": "/docs-starter-kit/vision/examples/",
@@ -1911,12 +1928,14 @@ Object {
   },
   "navTabs": Array [
     Object {
+      "id": "components",
       "navOrder": 1,
       "pages": Array [],
       "path": "/dr-ui/components/",
       "title": "Components",
     },
     Object {
+      "id": "guides",
       "navOrder": 2,
       "pages": Array [
         Object {
@@ -1949,18 +1968,21 @@ Object {
       "title": "Guides",
     },
     Object {
+      "id": "examples",
       "navOrder": 3,
       "pages": Array [],
       "path": "/dr-ui/examples/",
       "title": "Examples",
     },
     Object {
+      "id": "tutorials",
       "navOrder": 4,
       "pages": Array [],
       "path": "/dr-ui/tutorials/",
       "title": "Tutorials",
     },
     Object {
+      "id": "troubleshooting",
       "navOrder": 5,
       "pages": Array [],
       "path": "/dr-ui/troubleshooting/",

--- a/src/helpers/batfish/__tests__/navigation.test.js
+++ b/src/helpers/batfish/__tests__/navigation.test.js
@@ -26,6 +26,7 @@ describe('buildNavigation', () => {
   it('pages are sorted by order', () => {
     expect(buildNavigation('/api', apiDebug).navTabs).toEqual([
       {
+        id: 'introduction',
         navOrder: 1,
         pages: [
           {

--- a/src/helpers/batfish/navigation.js
+++ b/src/helpers/batfish/navigation.js
@@ -1,5 +1,6 @@
 // creates a page hierarchy based on top navigation item (as dictated by frontMatter.navOrder)
 // see: https://mapbox.github.io/dr-ui/batfish-helpers/
+const slugify = require('slugify');
 
 function buildNavigation(siteBasePath, data, sections) {
   let obj = {};
@@ -119,6 +120,10 @@ function buildNavTabs(organized) {
     return {
       ...organized[path],
       title: organized[path].title,
+      id: slugify(organized[path].title, {
+        replacement: '-',
+        lower: true
+      }),
       path: path
     };
   });


### PR DESCRIPTION
This PR makes a proposal on how to handle the NavigationAccordion items on smaller devices ref https://github.com/mapbox/dr-ui/pull/344#issuecomment-721859813 and if accepted will merge into #344. This PR makes NavigationAccordion sub page menu's toggleable and will collapse the items on smaller devices be default:

- Separates the title/link and the chevron icon. The chevron icon is now a button that controls the sub page menu. The user can toggle a section's sub page menu from any page. 
- A section's sub page menu opens automatically when the section or any of its sub pages are active. However, on smaller devices all toggles are collapsed on load, but the user can toggle to reveal the subpages.
- On smaller devices, the padding for the NavigationAccordion links increases slightly to improve tap target sizes.

## Screenshots

> ![image](https://user-images.githubusercontent.com/2180540/98396971-9b3c4400-202c-11eb-9d69-770c1f0b0da5.png)
> Sub page menu toggle collapses on mobile by default

> ![2020-11-06 at 12 34 PM](https://user-images.githubusercontent.com/2180540/98397070-c888f200-202c-11eb-9715-806caf4188e4.gif)
> Toggle a section's sub page menu from anywhere


## How to test

- Visit the catalog site (`npm run start-docs` -> http://localhost:8080/dr-ui/guides/)
    - From any page, toggle the "Guides" chevron icon. It should expand and collapse its sub page menu.
    - Visit http://localhost:8080/dr-ui/guides/ on desktop, the sub page menu for "Guides" should open on load.
    - Visit http://localhost:8080/dr-ui/guides/ on mobile, the sub page menu for "Guides" should not open on load, but can be open if you press the chevron icon.

## QA checklist

<!-- complete this checklist when adding a new component or package -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.
- [x] Create a PR in a site repo, copy the component, and test it. Push to staging and let the reviewer know they can also test the component there.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] IE11, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.
