### PR TITLE
[info arch] Filter improvements

### DIFF
--- a/src/components/card-container/__tests__/__snapshots__/card-container.test.js.snap
+++ b/src/components/card-container/__tests__/__snapshots__/card-container.test.js.snap
@@ -25,7 +25,7 @@ exports[`card-container Basic renders as expected 1`] = `
     className="grid grid--gut36"
   >
     <div
-      className="mb18 col col--12 col--4-ml"
+      className="mb18 col col--12 col--6-ml"
     >
       <a
         className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
@@ -61,7 +61,7 @@ exports[`card-container Basic renders as expected 1`] = `
       </a>
     </div>
     <div
-      className="mb18 col col--12 col--4-ml"
+      className="mb18 col col--12 col--6-ml"
     >
       <a
         className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"

--- a/src/components/card-container/card-container.js
+++ b/src/components/card-container/card-container.js
@@ -42,7 +42,7 @@ class CardContainer extends React.PureComponent {
 }
 
 CardContainer.defaultProps = {
-  cardColSize: 4,
+  cardColSize: 6,
   fullWidthCards: false
 };
 

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -1099,55 +1099,59 @@ Array [
                     Filters
                   </h2>
                   <div
-                    className="mb6"
+                    className="grid grid--gut6"
                   >
                     <div
-                      className="relative "
+                      className="col col--6 col--4-ml col--12-mxl mb6"
                     >
-                      <div>
-                        <label
-                          className="inline-block txt-s txt-bold color-darken75 w70"
-                          htmlFor="topic"
-                        >
-                          Topics
-                           
-                        </label>
-                      </div>
                       <div
-                        className="select-container "
+                        className="relative "
                       >
-                        <select
-                          aria-required={true}
-                          className="select select select--s"
-                          data-test="topic-select"
-                          disabled={false}
-                          id="topic"
-                          onChange={[Function]}
-                          value=""
+                        <div>
+                          <label
+                            className="inline-block txt-s txt-bold color-darken75 w70"
+                            htmlFor="topic"
+                          >
+                            Topics
+                             
+                          </label>
+                        </div>
+                        <div
+                          className="select-container "
                         >
-                          <option
+                          <select
+                            aria-required={true}
+                            className="select select select--s"
+                            data-test="topic-select"
+                            disabled={false}
+                            id="topic"
+                            onChange={[Function]}
                             value=""
                           >
-                            All topics
-                          </option>
-                          <option
-                            value="Cool"
-                          >
-                            Cool
-                          </option>
-                          <option
-                            value="Awesome"
-                          >
-                            Awesome
-                          </option>
-                        </select>
+                            <option
+                              value=""
+                            >
+                              All topics
+                            </option>
+                            <option
+                              value="Cool"
+                            >
+                              Cool
+                            </option>
+                            <option
+                              value="Awesome"
+                            >
+                              Awesome
+                            </option>
+                          </select>
+                          <div
+                            className="select-arrow"
+                          />
+                        </div>
                         <div
-                          className="select-arrow"
+                          role="alert"
                         />
                       </div>
-                      <div
-                        role="alert"
-                      />
                     </div>
                   </div>
                 </div>
@@ -1161,7 +1165,7 @@ Array [
                   className="grid grid--gut36"
                 >
                   <div
-                    className="mb18 col col--12 col--4-ml"
+                    className="mb18 col col--12 col--6-ml"
                   >
                     <a
                       className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
@@ -1214,7 +1218,7 @@ Array [
                     </a>
                   </div>
                   <div
-                    className="mb18 col col--12 col--4-ml"
+                    className="mb18 col col--12 col--6-ml"
                   >
                     <a
                       className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
@@ -1267,7 +1271,7 @@ Array [
                     </a>
                   </div>
                   <div
-                    className="mb18 col col--12 col--4-ml"
+                    className="mb18 col col--12 col--6-ml"
                   >
                     <a
                       className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"

--- a/src/components/page-layout/components/example-index.js
+++ b/src/components/page-layout/components/example-index.js
@@ -123,63 +123,64 @@ export default class ExampleIndex extends React.PureComponent {
     const { filters, frontMatter } = this.props;
     const { topic, language, level, videos, product } = this.state;
 
-    return frontMatter.showFilters.length > 1 ? (
+    return frontMatter.showFilters.length > 0 ? (
       <div className="mb18 mb0-mxl">
         <AsideHeading>Filters</AsideHeading>
-
-        {filters.products &&
-          filters.products.length > 1 &&
-          frontMatter.showFilters.indexOf('products') > -1 && (
+        <div className="grid grid--gut6">
+          {filters.products &&
+            filters.products.length > 1 &&
+            frontMatter.showFilters.indexOf('products') > -1 && (
+              <FilterSection
+                title="Products"
+                data={filters.products}
+                id="product"
+                activeItem={product}
+                handleInput={this.handleInput}
+              />
+            )}
+          {filters.topics &&
+            filters.topics.length > 1 &&
+            frontMatter.showFilters.indexOf('topics') > -1 && (
+              <FilterSection
+                title="Topics"
+                data={filters.topics}
+                id="topic"
+                activeItem={topic}
+                handleInput={this.handleInput}
+              />
+            )}
+          {filters.languages &&
+            filters.languages.length > 1 &&
+            frontMatter.showFilters.indexOf('languages') > -1 && (
+              <FilterSection
+                title="Languages"
+                data={filters.languages}
+                id="language"
+                activeItem={language}
+                handleInput={this.handleInput}
+              />
+            )}
+          {filters.levels &&
+            filters.levels.length > 1 &&
+            frontMatter.showFilters.indexOf('levels') > -1 && (
+              <FilterSection
+                title="Levels"
+                data={filters.levels}
+                id="level"
+                activeItem={level}
+                handleInput={this.handleInput}
+              />
+            )}
+          {filters.videos && frontMatter.showFilters.indexOf('videos') > -1 && (
             <FilterSection
-              title="Products"
-              data={filters.products}
-              id="product"
-              activeItem={product}
+              title="Videos only"
+              id="videos"
+              activeItem={videos}
+              isSwitch={true}
               handleInput={this.handleInput}
             />
           )}
-        {filters.topics &&
-          filters.topics.length > 1 &&
-          frontMatter.showFilters.indexOf('topics') > -1 && (
-            <FilterSection
-              title="Topics"
-              data={filters.topics}
-              id="topic"
-              activeItem={topic}
-              handleInput={this.handleInput}
-            />
-          )}
-        {filters.languages &&
-          filters.languages.length > 1 &&
-          frontMatter.showFilters.indexOf('languages') > -1 && (
-            <FilterSection
-              title="Languages"
-              data={filters.languages}
-              id="language"
-              activeItem={language}
-              handleInput={this.handleInput}
-            />
-          )}
-        {filters.levels &&
-          filters.levels.length > 1 &&
-          frontMatter.showFilters.indexOf('levels') > -1 && (
-            <FilterSection
-              title="Levels"
-              data={filters.levels}
-              id="level"
-              activeItem={level}
-              handleInput={this.handleInput}
-            />
-          )}
-        {filters.videos && frontMatter.showFilters.indexOf('videos') > -1 && (
-          <FilterSection
-            title="Videos only"
-            id="videos"
-            activeItem={videos}
-            isSwitch={true}
-            handleInput={this.handleInput}
-          />
-        )}
+        </div>
       </div>
     ) : (
       ''
@@ -360,7 +361,7 @@ class FilterSection extends React.PureComponent {
     const themeLabel = 'txt-s txt-bold color-darken75';
     return (
       <div
-        className={classnames('', {
+        className={classnames('col col--6 col--4-ml col--12-mxl', {
           mt12: isSwitch,
           mb6: !isSwitch
         })}


### PR DESCRIPTION
This PR makes a few small improvements to filters:

- Reverts the `cardColSize` for `CardContainer` back to `6`. During testing, cards with higher text density (such as Help tutorials) feel too crowded at size `4`. (This value was increased in #345 expecting the extra width in PageLayout would allow size `4` to fit better, but it did not.)
- Fixes logic for `showFilters` (if only one filter was chosen it would hide the filter completely, now it checks that the array has more than 0 items).
- Adds `grid` classes to filters, on smaller screens the filters will display in columns to take up more horizontal space:


Image | Image
---|---
![image](https://user-images.githubusercontent.com/2180540/98690980-8b2da880-233b-11eb-9b4c-bf4994f76c46.png) | ![image](https://user-images.githubusercontent.com/2180540/98691004-9254b680-233b-11eb-80ce-d6b56e279146.png)
![image](https://user-images.githubusercontent.com/2180540/98691157-bc0ddd80-233b-11eb-97d1-f9f69f9c3401.png) | 




## How to test

- Preview http://localhost:8080/dr-ui/examples/ (`npm run start-docs`)

## QA checklist

<!-- complete this checklist when adding a new component or package -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `6.2.0`.
    - Score is 98% due to #348 
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.
- [x] Create a PR in a site repo, copy the component, and test it. Push to staging and let the reviewer know they can also test the component there.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] IE11, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.
