### PR TITLE
[info arch] Rework Tag in ProductMenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
   - 🚨 Remove `topics` Batfish helper and replace with `filters`.
   - 🚨 Remove `formatTopics` Batfish helper. Use the `HelpPage` component.
   - 🚨 Remove `accordion` object from `navigation` and moved the dataset into `navTabs` as `pages` array.
+- Add `small` prop and variant to `Tag`.
+- Remove truncation on `ProductMenu` and moves tag above the title.
 
 ## 1.3.0
 

--- a/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
+++ b/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
@@ -567,7 +567,7 @@ exports[`overview-header Beta product renders as expected 1`] = `
           >
             <div
               aria-describedby="tooltip-1"
-              className="txt-s txt-bold round px6 inline-block cursor-default border"
+              className="txt-bold px6 round inline-block cursor-default border txt-s"
               style={
                 Object {
                   "background": "#f1f3fd",

--- a/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
+++ b/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
@@ -567,7 +567,7 @@ exports[`overview-header Beta product renders as expected 1`] = `
           >
             <div
               aria-describedby="tooltip-1"
-              className="txt-bold px6 round inline-block cursor-default border txt-s"
+              className="txt-bold px6 round inline-block cursor-default txt-s border"
               style={
                 Object {
                   "background": "#f1f3fd",

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -1267,7 +1267,7 @@ Array [
               >
                 <div
                   aria-describedby="tooltip-1"
-                  className="txt-bold px6 round inline-block cursor-default border txt-xs border--transparent ml-neg3"
+                  className="txt-bold px6 round inline-block cursor-default txt-xs ml-neg3"
                   style={
                     Object {
                       "background": "#f1f3fd",

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -28,7 +28,7 @@ Array [
             className="mb12 border-b border--darken10 pb12"
           >
             <div
-              className="dr-ui--product-menu relative"
+              className="dr-ui--product-menu"
             >
               <a
                 className="txt-fancy txt-l color-blue-on-hover"
@@ -522,7 +522,7 @@ Array [
             className="mb12 border-b border--darken10 pb12"
           >
             <div
-              className="dr-ui--product-menu relative"
+              className="dr-ui--product-menu"
             >
               <a
                 className="txt-fancy txt-l color-blue-on-hover"
@@ -832,7 +832,7 @@ Array [
             className="mb12 border-b border--darken10 pb12"
           >
             <div
-              className="dr-ui--product-menu relative"
+              className="dr-ui--product-menu"
             >
               <a
                 className="txt-fancy txt-l color-blue-on-hover"
@@ -1256,7 +1256,7 @@ Array [
             className="mb12 border-b border--darken10 pb12"
           >
             <div
-              className="dr-ui--product-menu relative"
+              className="dr-ui--product-menu"
             >
               <div>
                 <div

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -1259,34 +1259,38 @@ Array [
               className="dr-ui--product-menu"
             >
               <div
-                className="inline-block"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
+                className="ml-neg3"
               >
                 <div
-                  aria-describedby="tooltip-1"
-                  className="txt-bold px6 round inline-block cursor-default txt-xs ml-neg3"
-                  style={
-                    Object {
-                      "background": "#f1f3fd",
-                      "borderColor": "#0428c8",
-                      "color": "#0c248d",
-                    }
-                  }
-                >
-                  Beta
-                </div>
-                <div
-                  className="hide-visually"
-                  id="tooltip-1"
-                  role="tooltip"
+                  className="inline-block"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
                 >
                   <div
-                    className="txt-s wmax120"
+                    aria-describedby="tooltip-1"
+                    className="txt-bold px6 round inline-block cursor-default txt-xs"
+                    style={
+                      Object {
+                        "background": "#f1f3fd",
+                        "borderColor": "#0428c8",
+                        "color": "#0c248d",
+                      }
+                    }
                   >
-                    This feature is in public beta and is subject to changes.
+                    Beta
+                  </div>
+                  <div
+                    className="hide-visually"
+                    id="tooltip-1"
+                    role="tooltip"
+                  >
+                    <div
+                      className="txt-s wmax120"
+                    >
+                      This feature is in public beta and is subject to changes.
+                    </div>
                   </div>
                 </div>
               </div>

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -28,15 +28,10 @@ Array [
             className="mb12 border-b border--darken10 pb12"
           >
             <div
-              className="flex-parent"
-              style={
-                Object {
-                  "overflow": "hidden",
-                }
-              }
+              className="dr-ui--product-menu relative"
             >
               <a
-                className="flex-child txt-fancy txt-l txt-truncate color-blue-on-hover"
+                className="txt-fancy txt-l color-blue-on-hover"
                 href="/dr-ui/"
               >
                 dr-ui
@@ -527,15 +522,10 @@ Array [
             className="mb12 border-b border--darken10 pb12"
           >
             <div
-              className="flex-parent"
-              style={
-                Object {
-                  "overflow": "hidden",
-                }
-              }
+              className="dr-ui--product-menu relative"
             >
               <a
-                className="flex-child txt-fancy txt-l txt-truncate color-blue-on-hover"
+                className="txt-fancy txt-l color-blue-on-hover"
                 href="/dr-ui/"
               >
                 dr-ui
@@ -842,15 +832,10 @@ Array [
             className="mb12 border-b border--darken10 pb12"
           >
             <div
-              className="flex-parent"
-              style={
-                Object {
-                  "overflow": "hidden",
-                }
-              }
+              className="dr-ui--product-menu relative"
             >
               <a
-                className="flex-child txt-fancy txt-l txt-truncate color-blue-on-hover"
+                className="txt-fancy txt-l color-blue-on-hover"
                 href="/dr-ui/"
               >
                 dr-ui
@@ -1271,18 +1256,47 @@ Array [
             className="mb12 border-b border--darken10 pb12"
           >
             <div
-              className="flex-parent"
-              style={
-                Object {
-                  "overflow": "hidden",
-                }
-              }
+              className="dr-ui--product-menu relative"
             >
+              <div>
+                <div
+                  className="inline-block"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  <div
+                    aria-describedby="tooltip-1"
+                    className="txt-bold px6 round inline-block cursor-default border txt-xs border--transparent ml-neg3"
+                    style={
+                      Object {
+                        "background": "#f1f3fd",
+                        "borderColor": "#0428c8",
+                        "color": "#0c248d",
+                      }
+                    }
+                  >
+                    Beta
+                  </div>
+                  <div
+                    className="hide-visually"
+                    id="tooltip-1"
+                    role="tooltip"
+                  >
+                    <div
+                      className="txt-s wmax120"
+                    >
+                      This feature is in public beta and is subject to changes.
+                    </div>
+                  </div>
+                </div>
+              </div>
               <a
-                className="flex-child txt-fancy txt-l txt-truncate color-blue-on-hover"
+                className="txt-fancy txt-l color-blue-on-hover"
                 href="/dr-ui/"
               >
-                dr-ui
+                Mapbox Tiling Service
               </a>
             </div>
           </div>
@@ -1348,7 +1362,7 @@ Array [
             className="link"
             href="/dr-ui/"
           >
-            dr-ui
+            Mapbox Tiling Service
           </a>
           <span
             className="color-gray-light inline-block px6"

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -31,7 +31,7 @@ Array [
               className="dr-ui--product-menu"
             >
               <a
-                className="txt-fancy txt-l color-blue-on-hover"
+                className="txt-fancy txt-l block color-blue-on-hover"
                 href="/dr-ui/"
               >
                 dr-ui
@@ -525,7 +525,7 @@ Array [
               className="dr-ui--product-menu"
             >
               <a
-                className="txt-fancy txt-l color-blue-on-hover"
+                className="txt-fancy txt-l block color-blue-on-hover"
                 href="/dr-ui/"
               >
                 dr-ui
@@ -835,7 +835,7 @@ Array [
               className="dr-ui--product-menu"
             >
               <a
-                className="txt-fancy txt-l color-blue-on-hover"
+                className="txt-fancy txt-l block color-blue-on-hover"
                 href="/dr-ui/"
               >
                 dr-ui
@@ -1258,42 +1258,40 @@ Array [
             <div
               className="dr-ui--product-menu"
             >
-              <div>
+              <div
+                className="inline-block"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+              >
                 <div
-                  className="inline-block"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
+                  aria-describedby="tooltip-1"
+                  className="txt-bold px6 round inline-block cursor-default border txt-xs border--transparent ml-neg3"
+                  style={
+                    Object {
+                      "background": "#f1f3fd",
+                      "borderColor": "#0428c8",
+                      "color": "#0c248d",
+                    }
+                  }
+                >
+                  Beta
+                </div>
+                <div
+                  className="hide-visually"
+                  id="tooltip-1"
+                  role="tooltip"
                 >
                   <div
-                    aria-describedby="tooltip-1"
-                    className="txt-bold px6 round inline-block cursor-default border txt-xs border--transparent ml-neg3"
-                    style={
-                      Object {
-                        "background": "#f1f3fd",
-                        "borderColor": "#0428c8",
-                        "color": "#0c248d",
-                      }
-                    }
+                    className="txt-s wmax120"
                   >
-                    Beta
-                  </div>
-                  <div
-                    className="hide-visually"
-                    id="tooltip-1"
-                    role="tooltip"
-                  >
-                    <div
-                      className="txt-s wmax120"
-                    >
-                      This feature is in public beta and is subject to changes.
-                    </div>
+                    This feature is in public beta and is subject to changes.
                   </div>
                 </div>
               </div>
               <a
-                className="txt-fancy txt-l color-blue-on-hover"
+                className="txt-fancy txt-l block color-blue-on-hover"
                 href="/dr-ui/"
               >
                 Mapbox Tiling Service

--- a/src/components/page-layout/examples/full.js
+++ b/src/components/page-layout/examples/full.js
@@ -9,7 +9,7 @@ export default class Basic extends React.Component {
     return (
       <PageLayout
         constants={{
-          SITE: 'dr-ui',
+          SITE: 'Mapbox Tiling Service',
           BASEURL: '/dr-ui',
           FORWARD_EVENT_WEBHOOK: {
             production: '123',
@@ -24,6 +24,7 @@ export default class Basic extends React.Component {
           layout: 'full'
         }}
         navigation={{
+          tag: 'beta',
           hierarchy: {
             '/PageLayout/': {
               parent: '/PageLayout/',

--- a/src/components/product-menu/__tests__/__snapshots__/product-menu.test.js.snap
+++ b/src/components/product-menu/__tests__/__snapshots__/product-menu.test.js.snap
@@ -26,7 +26,7 @@ exports[`product-menu Beta product renders as expected 1`] = `
   >
     <div
       aria-describedby="tooltip-1"
-      className="txt-bold px6 round inline-block cursor-default border txt-xs border--transparent ml-neg3"
+      className="txt-bold px6 round inline-block cursor-default txt-xs ml-neg3"
       style={
         Object {
           "background": "#f1f3fd",
@@ -71,7 +71,7 @@ exports[`product-menu Beta product renders as expected 2`] = `
   >
     <div
       aria-describedby="tooltip-2"
-      className="txt-bold px6 round inline-block cursor-default border txt-xs border--transparent ml-neg3"
+      className="txt-bold px6 round inline-block cursor-default txt-xs ml-neg3"
       style={
         Object {
           "background": "#f1f3fd",

--- a/src/components/product-menu/__tests__/__snapshots__/product-menu.test.js.snap
+++ b/src/components/product-menu/__tests__/__snapshots__/product-menu.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`product-menu Basic renders as expected 1`] = `
 <div
-  className="dr-ui--product-menu relative"
+  className="dr-ui--product-menu"
 >
   <a
     className="txt-fancy txt-l color-blue-on-hover"
@@ -15,7 +15,7 @@ exports[`product-menu Basic renders as expected 1`] = `
 
 exports[`product-menu Beta product renders as expected 1`] = `
 <div
-  className="dr-ui--product-menu relative"
+  className="dr-ui--product-menu"
 >
   <div>
     <div
@@ -62,7 +62,7 @@ exports[`product-menu Beta product renders as expected 1`] = `
 
 exports[`product-menu Beta product renders as expected 2`] = `
 <div
-  className="dr-ui--product-menu relative"
+  className="dr-ui--product-menu"
 >
   <div>
     <div
@@ -112,7 +112,7 @@ exports[`product-menu Custom trigger style - display only renders as expected 1`
   className="bg-gray-dark py6"
 >
   <div
-    className="dr-ui--product-menu relative"
+    className="dr-ui--product-menu"
   >
     <a
       className="txt-fancy txt-l color-white color-gray-light-on-hover"
@@ -126,7 +126,7 @@ exports[`product-menu Custom trigger style - display only renders as expected 1`
 
 exports[`product-menu Fake items, but one matches this test case's location renders as expected 1`] = `
 <div
-  className="dr-ui--product-menu relative"
+  className="dr-ui--product-menu"
 >
   <a
     className="txt-fancy txt-l color-blue-on-hover"
@@ -139,7 +139,7 @@ exports[`product-menu Fake items, but one matches this test case's location rend
 
 exports[`product-menu Product menu with something arbitrary in it renders as expected 1`] = `
 <div
-  className="dr-ui--product-menu relative"
+  className="dr-ui--product-menu"
 >
   <a
     className="txt-fancy txt-l color-blue-on-hover"

--- a/src/components/product-menu/__tests__/__snapshots__/product-menu.test.js.snap
+++ b/src/components/product-menu/__tests__/__snapshots__/product-menu.test.js.snap
@@ -5,7 +5,7 @@ exports[`product-menu Basic renders as expected 1`] = `
   className="dr-ui--product-menu"
 >
   <a
-    className="txt-fancy txt-l color-blue-on-hover"
+    className="txt-fancy txt-l block color-blue-on-hover"
     href="/dr-ui/"
   >
     Mapbox product menu
@@ -17,42 +17,40 @@ exports[`product-menu Beta product renders as expected 1`] = `
 <div
   className="dr-ui--product-menu"
 >
-  <div>
+  <div
+    className="inline-block"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+  >
     <div
-      className="inline-block"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
+      aria-describedby="tooltip-1"
+      className="txt-bold px6 round inline-block cursor-default border txt-xs border--transparent ml-neg3"
+      style={
+        Object {
+          "background": "#f1f3fd",
+          "borderColor": "#0428c8",
+          "color": "#0c248d",
+        }
+      }
+    >
+      Beta
+    </div>
+    <div
+      className="hide-visually"
+      id="tooltip-1"
+      role="tooltip"
     >
       <div
-        aria-describedby="tooltip-1"
-        className="txt-bold px6 round inline-block cursor-default border txt-xs border--transparent ml-neg3"
-        style={
-          Object {
-            "background": "#f1f3fd",
-            "borderColor": "#0428c8",
-            "color": "#0c248d",
-          }
-        }
+        className="txt-s wmax120"
       >
-        Beta
-      </div>
-      <div
-        className="hide-visually"
-        id="tooltip-1"
-        role="tooltip"
-      >
-        <div
-          className="txt-s wmax120"
-        >
-          This feature is in public beta and is subject to changes.
-        </div>
+        This feature is in public beta and is subject to changes.
       </div>
     </div>
   </div>
   <a
-    className="txt-fancy txt-l color-blue-on-hover"
+    className="txt-fancy txt-l block color-blue-on-hover"
     href="/vision/"
   >
     Vision SDK for Android
@@ -64,42 +62,40 @@ exports[`product-menu Beta product renders as expected 2`] = `
 <div
   className="dr-ui--product-menu"
 >
-  <div>
+  <div
+    className="inline-block"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+  >
     <div
-      className="inline-block"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
+      aria-describedby="tooltip-2"
+      className="txt-bold px6 round inline-block cursor-default border txt-xs border--transparent ml-neg3"
+      style={
+        Object {
+          "background": "#f1f3fd",
+          "borderColor": "#0428c8",
+          "color": "#0c248d",
+        }
+      }
+    >
+      Beta
+    </div>
+    <div
+      className="hide-visually"
+      id="tooltip-2"
+      role="tooltip"
     >
       <div
-        aria-describedby="tooltip-2"
-        className="txt-bold px6 round inline-block cursor-default border txt-xs border--transparent ml-neg3"
-        style={
-          Object {
-            "background": "#f1f3fd",
-            "borderColor": "#0428c8",
-            "color": "#0c248d",
-          }
-        }
+        className="txt-s wmax120"
       >
-        Beta
-      </div>
-      <div
-        className="hide-visually"
-        id="tooltip-2"
-        role="tooltip"
-      >
-        <div
-          className="txt-s wmax120"
-        >
-          This feature is in public beta and is subject to changes.
-        </div>
+        This feature is in public beta and is subject to changes.
       </div>
     </div>
   </div>
   <a
-    className="txt-fancy txt-l color-blue-on-hover"
+    className="txt-fancy txt-l block color-blue-on-hover"
     href="/vision/"
   >
     Navigation SDK for Android
@@ -115,7 +111,7 @@ exports[`product-menu Custom trigger style - display only renders as expected 1`
     className="dr-ui--product-menu"
   >
     <a
-      className="txt-fancy txt-l color-white color-gray-light-on-hover"
+      className="txt-fancy txt-l block color-white color-gray-light-on-hover"
       href="/api-documentation/"
     >
       Light on dark
@@ -129,7 +125,7 @@ exports[`product-menu Fake items, but one matches this test case's location rend
   className="dr-ui--product-menu"
 >
   <a
-    className="txt-fancy txt-l color-blue-on-hover"
+    className="txt-fancy txt-l block color-blue-on-hover"
     href="/api-documentation/"
   >
     Items in here
@@ -142,7 +138,7 @@ exports[`product-menu Product menu with something arbitrary in it renders as exp
   className="dr-ui--product-menu"
 >
   <a
-    className="txt-fancy txt-l color-blue-on-hover"
+    className="txt-fancy txt-l block color-blue-on-hover"
     href="/api-documentation/"
   >
     Pizza pie

--- a/src/components/product-menu/__tests__/__snapshots__/product-menu.test.js.snap
+++ b/src/components/product-menu/__tests__/__snapshots__/product-menu.test.js.snap
@@ -18,34 +18,38 @@ exports[`product-menu Beta product renders as expected 1`] = `
   className="dr-ui--product-menu"
 >
   <div
-    className="inline-block"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
+    className="ml-neg3"
   >
     <div
-      aria-describedby="tooltip-1"
-      className="txt-bold px6 round inline-block cursor-default txt-xs ml-neg3"
-      style={
-        Object {
-          "background": "#f1f3fd",
-          "borderColor": "#0428c8",
-          "color": "#0c248d",
-        }
-      }
-    >
-      Beta
-    </div>
-    <div
-      className="hide-visually"
-      id="tooltip-1"
-      role="tooltip"
+      className="inline-block"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
     >
       <div
-        className="txt-s wmax120"
+        aria-describedby="tooltip-1"
+        className="txt-bold px6 round inline-block cursor-default txt-xs"
+        style={
+          Object {
+            "background": "#f1f3fd",
+            "borderColor": "#0428c8",
+            "color": "#0c248d",
+          }
+        }
       >
-        This feature is in public beta and is subject to changes.
+        Beta
+      </div>
+      <div
+        className="hide-visually"
+        id="tooltip-1"
+        role="tooltip"
+      >
+        <div
+          className="txt-s wmax120"
+        >
+          This feature is in public beta and is subject to changes.
+        </div>
       </div>
     </div>
   </div>
@@ -63,34 +67,38 @@ exports[`product-menu Beta product renders as expected 2`] = `
   className="dr-ui--product-menu"
 >
   <div
-    className="inline-block"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
+    className="ml-neg3"
   >
     <div
-      aria-describedby="tooltip-2"
-      className="txt-bold px6 round inline-block cursor-default txt-xs ml-neg3"
-      style={
-        Object {
-          "background": "#f1f3fd",
-          "borderColor": "#0428c8",
-          "color": "#0c248d",
-        }
-      }
-    >
-      Beta
-    </div>
-    <div
-      className="hide-visually"
-      id="tooltip-2"
-      role="tooltip"
+      className="inline-block"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
     >
       <div
-        className="txt-s wmax120"
+        aria-describedby="tooltip-2"
+        className="txt-bold px6 round inline-block cursor-default txt-xs"
+        style={
+          Object {
+            "background": "#f1f3fd",
+            "borderColor": "#0428c8",
+            "color": "#0c248d",
+          }
+        }
       >
-        This feature is in public beta and is subject to changes.
+        Beta
+      </div>
+      <div
+        className="hide-visually"
+        id="tooltip-2"
+        role="tooltip"
+      >
+        <div
+          className="txt-s wmax120"
+        >
+          This feature is in public beta and is subject to changes.
+        </div>
       </div>
     </div>
   </div>

--- a/src/components/product-menu/__tests__/__snapshots__/product-menu.test.js.snap
+++ b/src/components/product-menu/__tests__/__snapshots__/product-menu.test.js.snap
@@ -2,15 +2,10 @@
 
 exports[`product-menu Basic renders as expected 1`] = `
 <div
-  className="flex-parent"
-  style={
-    Object {
-      "overflow": "hidden",
-    }
-  }
+  className="dr-ui--product-menu relative"
 >
   <a
-    className="flex-child txt-fancy txt-l txt-truncate color-blue-on-hover"
+    className="txt-fancy txt-l color-blue-on-hover"
     href="/dr-ui/"
   >
     Mapbox product menu
@@ -20,22 +15,9 @@ exports[`product-menu Basic renders as expected 1`] = `
 
 exports[`product-menu Beta product renders as expected 1`] = `
 <div
-  className="flex-parent"
-  style={
-    Object {
-      "overflow": "hidden",
-    }
-  }
+  className="dr-ui--product-menu relative"
 >
-  <a
-    className="flex-child txt-fancy txt-l txt-truncate color-blue-on-hover"
-    href="/vision/"
-  >
-    Vision SDK for Android
-  </a>
-  <span
-    className="flex-child flex-child--no-shrink mx6"
-  >
+  <div>
     <div
       className="inline-block"
       onBlur={[Function]}
@@ -45,7 +27,7 @@ exports[`product-menu Beta product renders as expected 1`] = `
     >
       <div
         aria-describedby="tooltip-1"
-        className="txt-s txt-bold round px6 inline-block cursor-default border"
+        className="txt-bold px6 round inline-block cursor-default border txt-xs border--transparent ml-neg3"
         style={
           Object {
             "background": "#f1f3fd",
@@ -68,28 +50,21 @@ exports[`product-menu Beta product renders as expected 1`] = `
         </div>
       </div>
     </div>
-  </span>
+  </div>
+  <a
+    className="txt-fancy txt-l color-blue-on-hover"
+    href="/vision/"
+  >
+    Vision SDK for Android
+  </a>
 </div>
 `;
 
 exports[`product-menu Beta product renders as expected 2`] = `
 <div
-  className="flex-parent"
-  style={
-    Object {
-      "overflow": "hidden",
-    }
-  }
+  className="dr-ui--product-menu relative"
 >
-  <a
-    className="flex-child txt-fancy txt-l txt-truncate color-blue-on-hover"
-    href="/vision/"
-  >
-    Navigation SDK for Android
-  </a>
-  <span
-    className="flex-child flex-child--no-shrink mx6"
-  >
+  <div>
     <div
       className="inline-block"
       onBlur={[Function]}
@@ -99,7 +74,7 @@ exports[`product-menu Beta product renders as expected 2`] = `
     >
       <div
         aria-describedby="tooltip-2"
-        className="txt-s txt-bold round px6 inline-block cursor-default border"
+        className="txt-bold px6 round inline-block cursor-default border txt-xs border--transparent ml-neg3"
         style={
           Object {
             "background": "#f1f3fd",
@@ -122,7 +97,13 @@ exports[`product-menu Beta product renders as expected 2`] = `
         </div>
       </div>
     </div>
-  </span>
+  </div>
+  <a
+    className="txt-fancy txt-l color-blue-on-hover"
+    href="/vision/"
+  >
+    Navigation SDK for Android
+  </a>
 </div>
 `;
 
@@ -131,15 +112,10 @@ exports[`product-menu Custom trigger style - display only renders as expected 1`
   className="bg-gray-dark py6"
 >
   <div
-    className="flex-parent"
-    style={
-      Object {
-        "overflow": "hidden",
-      }
-    }
+    className="dr-ui--product-menu relative"
   >
     <a
-      className="flex-child txt-fancy txt-l txt-truncate color-white color-gray-light-on-hover"
+      className="txt-fancy txt-l color-white color-gray-light-on-hover"
       href="/api-documentation/"
     >
       Light on dark
@@ -150,15 +126,10 @@ exports[`product-menu Custom trigger style - display only renders as expected 1`
 
 exports[`product-menu Fake items, but one matches this test case's location renders as expected 1`] = `
 <div
-  className="flex-parent"
-  style={
-    Object {
-      "overflow": "hidden",
-    }
-  }
+  className="dr-ui--product-menu relative"
 >
   <a
-    className="flex-child txt-fancy txt-l txt-truncate color-blue-on-hover"
+    className="txt-fancy txt-l color-blue-on-hover"
     href="/api-documentation/"
   >
     Items in here
@@ -168,15 +139,10 @@ exports[`product-menu Fake items, but one matches this test case's location rend
 
 exports[`product-menu Product menu with something arbitrary in it renders as expected 1`] = `
 <div
-  className="flex-parent"
-  style={
-    Object {
-      "overflow": "hidden",
-    }
-  }
+  className="dr-ui--product-menu relative"
 >
   <a
-    className="flex-child txt-fancy txt-l txt-truncate color-blue-on-hover"
+    className="txt-fancy txt-l color-blue-on-hover"
     href="/api-documentation/"
   >
     Pizza pie

--- a/src/components/product-menu/product-menu.js
+++ b/src/components/product-menu/product-menu.js
@@ -18,26 +18,26 @@ class ProductMenu extends React.PureComponent {
         : undefined
     };
     return (
-      <span className="flex-child flex-child--no-shrink mx6">
-        <Tag {...tagProps} />
-      </span>
+      <div>
+        <Tag {...tagProps} small={true} />
+      </div>
     );
   };
 
   render() {
     const { props } = this;
     return (
-      <div className="flex-parent" style={{ overflow: 'hidden' }}>
+      <div className="dr-ui--product-menu relative">
+        {props.tag && this.buildTag(props)}
         <a
           href={props.homePage}
-          className={classnames('flex-child txt-fancy txt-l txt-truncate', {
+          className={classnames('txt-fancy txt-l', {
             'color-white color-gray-light-on-hover': props.lightText,
             'color-blue-on-hover': !props.lightText
           })}
         >
           {props.productName}
         </a>
-        {props.tag && this.buildTag(props)}
       </div>
     );
   }

--- a/src/components/product-menu/product-menu.js
+++ b/src/components/product-menu/product-menu.js
@@ -17,11 +17,7 @@ class ProductMenu extends React.PureComponent {
         ? item.customTagProps.customStyles
         : undefined
     };
-    return (
-      <div>
-        <Tag {...tagProps} small={true} />
-      </div>
-    );
+    return <Tag {...tagProps} small={true} />;
   };
 
   render() {
@@ -31,7 +27,7 @@ class ProductMenu extends React.PureComponent {
         {props.tag && this.buildTag(props)}
         <a
           href={props.homePage}
-          className={classnames('txt-fancy txt-l', {
+          className={classnames('txt-fancy txt-l block', {
             'color-white color-gray-light-on-hover': props.lightText,
             'color-blue-on-hover': !props.lightText
           })}

--- a/src/components/product-menu/product-menu.js
+++ b/src/components/product-menu/product-menu.js
@@ -17,7 +17,11 @@ class ProductMenu extends React.PureComponent {
         ? item.customTagProps.customStyles
         : undefined
     };
-    return <Tag {...tagProps} small={true} />;
+    return (
+      <div className="ml-neg3">
+        <Tag {...tagProps} small={true} />
+      </div>
+    );
   };
 
   render() {

--- a/src/components/product-menu/product-menu.js
+++ b/src/components/product-menu/product-menu.js
@@ -27,7 +27,7 @@ class ProductMenu extends React.PureComponent {
   render() {
     const { props } = this;
     return (
-      <div className="dr-ui--product-menu relative">
+      <div className="dr-ui--product-menu">
         {props.tag && this.buildTag(props)}
         <a
           href={props.homePage}

--- a/src/components/tag/__tests__/__snapshots__/tag.test.js.snap
+++ b/src/components/tag/__tests__/__snapshots__/tag.test.js.snap
@@ -10,7 +10,7 @@ exports[`tag Beta tag renders as expected 1`] = `
 >
   <div
     aria-describedby="tooltip-1"
-    className="txt-bold px6 round inline-block cursor-default border txt-s"
+    className="txt-bold px6 round inline-block cursor-default txt-s border"
     style={
       Object {
         "background": "#f1f3fd",
@@ -45,7 +45,7 @@ exports[`tag Custom tag renders as expected 1`] = `
 >
   <div
     aria-describedby="tooltip-2"
-    className="txt-bold px6 round inline-block cursor-default border txt-s"
+    className="txt-bold px6 round inline-block cursor-default txt-s border"
     style={
       Object {
         "background": "#FEDADA",
@@ -80,7 +80,7 @@ exports[`tag small variant renders as expected 1`] = `
 >
   <div
     aria-describedby="tooltip-3"
-    className="txt-bold px6 round inline-block cursor-default border txt-xs border--transparent ml-neg3"
+    className="txt-bold px6 round inline-block cursor-default txt-xs ml-neg3"
     style={
       Object {
         "background": "#f1f3fd",

--- a/src/components/tag/__tests__/__snapshots__/tag.test.js.snap
+++ b/src/components/tag/__tests__/__snapshots__/tag.test.js.snap
@@ -80,7 +80,7 @@ exports[`tag small variant renders as expected 1`] = `
 >
   <div
     aria-describedby="tooltip-3"
-    className="txt-bold px6 round inline-block cursor-default txt-xs ml-neg3"
+    className="txt-bold px6 round inline-block cursor-default txt-xs"
     style={
       Object {
         "background": "#f1f3fd",

--- a/src/components/tag/__tests__/__snapshots__/tag.test.js.snap
+++ b/src/components/tag/__tests__/__snapshots__/tag.test.js.snap
@@ -10,7 +10,7 @@ exports[`tag Beta tag renders as expected 1`] = `
 >
   <div
     aria-describedby="tooltip-1"
-    className="txt-s txt-bold round px6 inline-block cursor-default border"
+    className="txt-bold px6 round inline-block cursor-default border txt-s"
     style={
       Object {
         "background": "#f1f3fd",
@@ -45,7 +45,7 @@ exports[`tag Custom tag renders as expected 1`] = `
 >
   <div
     aria-describedby="tooltip-2"
-    className="txt-s txt-bold round px6 inline-block cursor-default border"
+    className="txt-bold px6 round inline-block cursor-default border txt-s"
     style={
       Object {
         "background": "#FEDADA",
@@ -65,6 +65,41 @@ exports[`tag Custom tag renders as expected 1`] = `
       className="txt-s wmax120"
     >
       Contact us for access to this feature.
+    </div>
+  </div>
+</div>
+`;
+
+exports[`tag small variant renders as expected 1`] = `
+<div
+  className="inline-block"
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+>
+  <div
+    aria-describedby="tooltip-3"
+    className="txt-bold px6 round inline-block cursor-default border txt-xs border--transparent ml-neg3"
+    style={
+      Object {
+        "background": "#f1f3fd",
+        "borderColor": "#0428c8",
+        "color": "#0c248d",
+      }
+    }
+  >
+    Beta
+  </div>
+  <div
+    className="hide-visually"
+    id="tooltip-3"
+    role="tooltip"
+  >
+    <div
+      className="txt-s wmax120"
+    >
+      This feature is in public beta and is subject to changes.
     </div>
   </div>
 </div>

--- a/src/components/tag/__tests__/tag-test-cases.js
+++ b/src/components/tag/__tests__/tag-test-cases.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Tag from '../tag';
 import Basic from '../examples/basic';
 import Custom from '../examples/custom';
+import Small from '../examples/small';
 
 const testCases = {};
 const noRenderCases = {};
@@ -38,6 +39,11 @@ testCases.new = {
 testCases.custom = {
   description: 'Custom tag',
   element: <Custom />
+};
+
+testCases.small = {
+  description: 'small variant',
+  element: <Small />
 };
 
 export { testCases, noRenderCases };

--- a/src/components/tag/__tests__/tag.test.js
+++ b/src/components/tag/__tests__/tag.test.js
@@ -33,4 +33,19 @@ describe('tag', () => {
       expect(tree).toMatchSnapshot();
     });
   });
+  describe(testCases.small.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.small;
+      wrapper = renderer.create(testCase.element);
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
 });

--- a/src/components/tag/examples/small.js
+++ b/src/components/tag/examples/small.js
@@ -1,0 +1,11 @@
+/*
+Small.
+*/
+import React from 'react';
+import Tag from '../tag';
+
+export default class Small extends React.Component {
+  render() {
+    return <Tag theme="beta" small={true} />;
+  }
+}

--- a/src/components/tag/tag.js
+++ b/src/components/tag/tag.js
@@ -20,7 +20,7 @@ export default class Tag extends React.Component {
             'txt-bold px6 round inline-block cursor-default',
             {
               'txt-s border': !this.props.small,
-              'txt-xs ml-neg3': this.props.small
+              'txt-xs': this.props.small
             }
           )}
         >

--- a/src/components/tag/tag.js
+++ b/src/components/tag/tag.js
@@ -38,7 +38,7 @@ Tag.defaultProps = {
 Tag.propTypes = {
   theme: PropTypes.oneOf(['beta', 'fundamentals', 'legacy', 'new', 'custom'])
     .isRequired,
-  /** If `true`, display the tag with a smaller font and padding */
+  /** If `true`, display the tag with a smaller font and and no border */
   small: PropTypes.bool,
   /** If the theme is set to "custom", this prop is required. */
   customLabel: (props, componentName) => {

--- a/src/components/tag/tag.js
+++ b/src/components/tag/tag.js
@@ -17,10 +17,10 @@ export default class Tag extends React.Component {
         <div
           style={theme.styles}
           className={classnames(
-            'txt-bold px6 round inline-block cursor-default border',
+            'txt-bold px6 round inline-block cursor-default',
             {
-              'txt-s': !this.props.small,
-              'txt-xs border--transparent ml-neg3': this.props.small
+              'txt-s border': !this.props.small,
+              'txt-xs ml-neg3': this.props.small
             }
           )}
         >

--- a/src/components/tag/tag.js
+++ b/src/components/tag/tag.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Tooltip from '@mapbox/mr-ui/tooltip';
+import classnames from 'classnames';
 import themes from '../themes';
 
 export default class Tag extends React.Component {
@@ -15,7 +16,13 @@ export default class Tag extends React.Component {
       <Tooltip content={theme.tooltipText} maxWidth="small" placement="top">
         <div
           style={theme.styles}
-          className="txt-s txt-bold round px6 inline-block cursor-default border"
+          className={classnames(
+            'txt-bold px6 round inline-block cursor-default border',
+            {
+              'txt-s': !this.props.small,
+              'txt-xs border--transparent ml-neg3': this.props.small
+            }
+          )}
         >
           {theme.label}
         </div>
@@ -24,10 +31,16 @@ export default class Tag extends React.Component {
   }
 }
 
+Tag.defaultProps = {
+  small: false
+};
+
 Tag.propTypes = {
   theme: PropTypes.oneOf(['beta', 'fundamentals', 'legacy', 'new', 'custom'])
     .isRequired,
-  /* If the theme is set to "custom", this prop is required. */
+  /** If `true`, display the tag with a smaller font and padding */
+  small: PropTypes.bool,
+  /** If the theme is set to "custom", this prop is required. */
   customLabel: (props, componentName) => {
     if (props.theme === 'custom' && !props.customLabel) {
       return new Error(

--- a/src/components/themes/__tests__/__snapshots__/themes.test.js.snap
+++ b/src/components/themes/__tests__/__snapshots__/themes.test.js.snap
@@ -117,7 +117,7 @@ exports[`themes beta renders as expected 1`] = `
   >
     <div
       aria-describedby="tooltip-1"
-      className="txt-bold px6 round inline-block cursor-default border txt-s"
+      className="txt-bold px6 round inline-block cursor-default txt-s border"
       style={
         Object {
           "background": "#f1f3fd",
@@ -267,7 +267,7 @@ exports[`themes fundamentals renders as expected 1`] = `
   >
     <div
       aria-describedby="tooltip-3"
-      className="txt-bold px6 round inline-block cursor-default border txt-s"
+      className="txt-bold px6 round inline-block cursor-default txt-s border"
       style={
         Object {
           "background": "#fff0f7",
@@ -355,7 +355,7 @@ exports[`themes legacy or warning renders as expected 1`] = `
   >
     <div
       aria-describedby="tooltip-2"
-      className="txt-bold px6 round inline-block cursor-default border txt-s"
+      className="txt-bold px6 round inline-block cursor-default txt-s border"
       style={
         Object {
           "background": "#feefe2",

--- a/src/components/themes/__tests__/__snapshots__/themes.test.js.snap
+++ b/src/components/themes/__tests__/__snapshots__/themes.test.js.snap
@@ -117,7 +117,7 @@ exports[`themes beta renders as expected 1`] = `
   >
     <div
       aria-describedby="tooltip-1"
-      className="txt-s txt-bold round px6 inline-block cursor-default border"
+      className="txt-bold px6 round inline-block cursor-default border txt-s"
       style={
         Object {
           "background": "#f1f3fd",
@@ -267,7 +267,7 @@ exports[`themes fundamentals renders as expected 1`] = `
   >
     <div
       aria-describedby="tooltip-3"
-      className="txt-s txt-bold round px6 inline-block cursor-default border"
+      className="txt-bold px6 round inline-block cursor-default border txt-s"
       style={
         Object {
           "background": "#fff0f7",
@@ -355,7 +355,7 @@ exports[`themes legacy or warning renders as expected 1`] = `
   >
     <div
       aria-describedby="tooltip-2"
-      className="txt-s txt-bold round px6 inline-block cursor-default border"
+      className="txt-bold px6 round inline-block cursor-default border txt-s"
       style={
         Object {
           "background": "#feefe2",

--- a/src/components/themes/__tests__/__snapshots__/themes.test.js.snap
+++ b/src/components/themes/__tests__/__snapshots__/themes.test.js.snap
@@ -1,6 +1,73 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`themes Custom tag renders as expected 1`] = `null`;
+exports[`themes Custom tag renders as expected 1`] = `
+<div>
+  <div
+    className="inline-block"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+  >
+    <div
+      aria-describedby="tooltip-7"
+      className="txt-bold px6 round inline-block cursor-default txt-s border"
+      style={
+        Object {
+          "background": "#FEDADA",
+          "borderColor": "#FD8383",
+          "color": "#DA2E30",
+        }
+      }
+    >
+      Limited access
+    </div>
+    <div
+      className="hide-visually"
+      id="tooltip-7"
+      role="tooltip"
+    >
+      <div
+        className="txt-s wmax120"
+      >
+        Contact us for access to this feature.
+      </div>
+    </div>
+  </div>
+  <div
+    className="inline-block"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+  >
+    <div
+      aria-describedby="tooltip-8"
+      className="txt-bold px6 round inline-block cursor-default txt-xs"
+      style={
+        Object {
+          "background": "#FEDADA",
+          "borderColor": "#FD8383",
+          "color": "#DA2E30",
+        }
+      }
+    >
+      Limited access
+    </div>
+    <div
+      className="hide-visually"
+      id="tooltip-8"
+      role="tooltip"
+    >
+      <div
+        className="txt-s wmax120"
+      >
+        Contact us for access to this feature.
+      </div>
+    </div>
+  </div>
+</div>
+`;
 
 exports[`themes Default renders as expected 1`] = `
 <div
@@ -140,123 +207,6 @@ exports[`themes beta renders as expected 1`] = `
       </div>
     </div>
   </div>
-</div>
-`;
-
-exports[`themes download renders as expected 1`] = `
-<div>
-   
-  <div
-    className="dr-ui--note py18 px18 round flex-parent flex-parent--row mb18"
-    style={
-      Object {
-        "background": "#f2effa",
-        "color": "#452f92",
-      }
-    }
-  >
-    <div
-      className="flex-child mr18 none block-mm pt3"
-    >
-      <div
-        className="bg-purple-light round-full color-purple flex-parent flex-parent--center-main flex-parent--center-cross"
-        style={
-          Object {
-            "height": 50,
-            "width": 50,
-          }
-        }
-      >
-        <svg
-          className="events-none icon"
-          focusable="false"
-          role="presentation"
-          style={
-            Object {
-              "height": 40,
-              "width": 40,
-            }
-          }
-        >
-          <use
-            xlinkHref="#icon-arrow-down"
-            xmlnsXlink="http://www.w3.org/1999/xlink"
-          />
-        </svg>
-      </div>
-    </div>
-    <div
-      className="flex-child prose"
-    >
-      <div
-        className="txt-bold txt-m mb6"
-      >
-        Download
-      </div>
-      download note
-    </div>
-  </div>
-</div>
-`;
-
-exports[`themes error renders as expected 1`] = `
-<div>
-   
-  <div
-    className="dr-ui--note py18 px18 round flex-parent flex-parent--row mb18"
-    style={
-      Object {
-        "background": "#fbe5e5",
-        "color": "#9b3134",
-      }
-    }
-  >
-    <div
-      className="flex-child mr18 none block-mm pt3"
-    >
-      <div
-        className="bg-red-light round-full color-red flex-parent flex-parent--center-main flex-parent--center-cross"
-        style={
-          Object {
-            "height": 50,
-            "width": 50,
-          }
-        }
-      >
-        <svg
-          className="events-none icon"
-          focusable="false"
-          role="presentation"
-          style={
-            Object {
-              "height": 40,
-              "width": 40,
-            }
-          }
-        >
-          <use
-            xlinkHref="#icon-alert"
-            xmlnsXlink="http://www.w3.org/1999/xlink"
-          />
-        </svg>
-      </div>
-    </div>
-    <div
-      className="flex-child prose"
-    >
-      <div
-        className="txt-bold txt-m mb6"
-      >
-        Error
-      </div>
-      error note
-    </div>
-  </div>
-</div>
-`;
-
-exports[`themes fundamentals renders as expected 1`] = `
-<div>
    
   <div
     className="inline-block"
@@ -266,7 +216,150 @@ exports[`themes fundamentals renders as expected 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      aria-describedby="tooltip-3"
+      aria-describedby="tooltip-2"
+      className="txt-bold px6 round inline-block cursor-default txt-xs"
+      style={
+        Object {
+          "background": "#f1f3fd",
+          "borderColor": "#0428c8",
+          "color": "#0c248d",
+        }
+      }
+    >
+      Beta
+    </div>
+    <div
+      className="hide-visually"
+      id="tooltip-2"
+      role="tooltip"
+    >
+      <div
+        className="txt-s wmax120"
+      >
+        This feature is in public beta and is subject to changes.
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`themes download renders as expected 1`] = `
+<div
+  className="dr-ui--note py18 px18 round flex-parent flex-parent--row mb18"
+  style={
+    Object {
+      "background": "#f2effa",
+      "color": "#452f92",
+    }
+  }
+>
+  <div
+    className="flex-child mr18 none block-mm pt3"
+  >
+    <div
+      className="bg-purple-light round-full color-purple flex-parent flex-parent--center-main flex-parent--center-cross"
+      style={
+        Object {
+          "height": 50,
+          "width": 50,
+        }
+      }
+    >
+      <svg
+        className="events-none icon"
+        focusable="false"
+        role="presentation"
+        style={
+          Object {
+            "height": 40,
+            "width": 40,
+          }
+        }
+      >
+        <use
+          xlinkHref="#icon-arrow-down"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
+        />
+      </svg>
+    </div>
+  </div>
+  <div
+    className="flex-child prose"
+  >
+    <div
+      className="txt-bold txt-m mb6"
+    >
+      Download
+    </div>
+    download note
+  </div>
+</div>
+`;
+
+exports[`themes error renders as expected 1`] = `
+<div
+  className="dr-ui--note py18 px18 round flex-parent flex-parent--row mb18"
+  style={
+    Object {
+      "background": "#fbe5e5",
+      "color": "#9b3134",
+    }
+  }
+>
+  <div
+    className="flex-child mr18 none block-mm pt3"
+  >
+    <div
+      className="bg-red-light round-full color-red flex-parent flex-parent--center-main flex-parent--center-cross"
+      style={
+        Object {
+          "height": 50,
+          "width": 50,
+        }
+      }
+    >
+      <svg
+        className="events-none icon"
+        focusable="false"
+        role="presentation"
+        style={
+          Object {
+            "height": 40,
+            "width": 40,
+          }
+        }
+      >
+        <use
+          xlinkHref="#icon-alert"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
+        />
+      </svg>
+    </div>
+  </div>
+  <div
+    className="flex-child prose"
+  >
+    <div
+      className="txt-bold txt-m mb6"
+    >
+      Error
+    </div>
+    error note
+  </div>
+</div>
+`;
+
+exports[`themes fundamentals renders as expected 1`] = `
+<div>
+  <div
+    className="inline-block"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+  >
+    <div
+      aria-describedby="tooltip-5"
       className="txt-bold px6 round inline-block cursor-default txt-s border"
       style={
         Object {
@@ -280,7 +373,39 @@ exports[`themes fundamentals renders as expected 1`] = `
     </div>
     <div
       className="hide-visually"
-      id="tooltip-3"
+      id="tooltip-5"
+      role="tooltip"
+    >
+      <div
+        className="txt-s wmax120"
+      >
+        The concepts described here are fundamental to using this product.
+      </div>
+    </div>
+  </div>
+  <div
+    className="inline-block"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+  >
+    <div
+      aria-describedby="tooltip-6"
+      className="txt-bold px6 round inline-block cursor-default txt-xs"
+      style={
+        Object {
+          "background": "#fff0f7",
+          "borderColor": "#fd8ac0",
+          "color": "#cf1c61",
+        }
+      }
+    >
+      Fundamentals
+    </div>
+    <div
+      className="hide-visually"
+      id="tooltip-6"
       role="tooltip"
     >
       <div
@@ -295,7 +420,6 @@ exports[`themes fundamentals renders as expected 1`] = `
 
 exports[`themes legacy or warning renders as expected 1`] = `
 <div>
-   
   <div
     className="dr-ui--note py18 px18 round flex-parent flex-parent--row mb18"
     style={
@@ -354,7 +478,7 @@ exports[`themes legacy or warning renders as expected 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      aria-describedby="tooltip-2"
+      aria-describedby="tooltip-3"
       className="txt-bold px6 round inline-block cursor-default txt-s border"
       style={
         Object {
@@ -368,7 +492,39 @@ exports[`themes legacy or warning renders as expected 1`] = `
     </div>
     <div
       className="hide-visually"
-      id="tooltip-2"
+      id="tooltip-3"
+      role="tooltip"
+    >
+      <div
+        className="txt-s wmax120"
+      >
+        This feature is no longer in active development.
+      </div>
+    </div>
+  </div>
+  <div
+    className="inline-block"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+  >
+    <div
+      aria-describedby="tooltip-4"
+      className="txt-bold px6 round inline-block cursor-default txt-xs"
+      style={
+        Object {
+          "background": "#feefe2",
+          "borderColor": "#ba6e2c",
+          "color": "#78471c",
+        }
+      }
+    >
+      Legacy
+    </div>
+    <div
+      className="hide-visually"
+      id="tooltip-4"
       role="tooltip"
     >
       <div

--- a/src/components/themes/__tests__/themes-test-cases.js
+++ b/src/components/themes/__tests__/themes-test-cases.js
@@ -13,29 +13,20 @@ testCases.default = {
 
 testCases.error = {
   description: 'error',
-  element: (
-    <div>
-      {' '}
-      <Note theme="error">error note</Note>
-    </div>
-  )
+  element: <Note theme="error">error note</Note>
 };
 
 testCases.download = {
   description: 'download',
-  element: (
-    <div>
-      {' '}
-      <Note theme="download">download note</Note>
-    </div>
-  )
+  element: <Note theme="download">download note</Note>
 };
 
 testCases.beta = {
   description: 'beta',
   element: (
     <div>
-      <Note theme="beta">Beta note.</Note> <Tag theme="beta" />
+      <Note theme="beta">Beta note.</Note> <Tag theme="beta" />{' '}
+      <Tag theme="beta" small={true} />
     </div>
   )
 };
@@ -49,9 +40,9 @@ testCases.legacy = {
   description: 'legacy or warning',
   element: (
     <div>
-      {' '}
       <Note theme="legacy">legacy note</Note>
       <Tag theme="legacy" />
+      <Tag theme="legacy" small={true} />
     </div>
   )
 };
@@ -60,25 +51,31 @@ testCases.fundamentals = {
   description: 'fundamentals',
   element: (
     <div>
-      {' '}
       <Tag theme="fundamentals" />
+      <Tag theme="fundamentals" small={true} />
     </div>
   )
 };
 
-testCases.custom = {
-  component: Tag,
-  description: 'Custom tag',
-  props: {
-    theme: 'custom',
-    customLabel: 'Limited access',
-    customTooltipText: 'Contact us for access to this feature.',
-    customStyles: {
-      background: '#FEDADA',
-      color: '#DA2E30',
-      borderColor: '#FD8383'
-    }
+const customProps = {
+  theme: 'custom',
+  customLabel: 'Limited access',
+  customTooltipText: 'Contact us for access to this feature.',
+  customStyles: {
+    background: '#FEDADA',
+    color: '#DA2E30',
+    borderColor: '#FD8383'
   }
+};
+
+testCases.custom = {
+  description: 'Custom tag',
+  element: (
+    <div>
+      <Tag {...customProps} />
+      <Tag {...customProps} small={true} />
+    </div>
+  )
 };
 
 export { testCases, noRenderCases };

--- a/src/components/themes/examples/basic.js
+++ b/src/components/themes/examples/basic.js
@@ -11,6 +11,7 @@ export default class Basic extends React.Component {
       <div>
         <Note theme="new">New note.</Note>
         <Tag theme="new" />
+        <Tag theme="new" small={true} />
       </div>
     );
   }

--- a/src/components/topbar-sticker/__tests__/__snapshots__/topbar-sticker.test.js.snap
+++ b/src/components/topbar-sticker/__tests__/__snapshots__/topbar-sticker.test.js.snap
@@ -45,7 +45,7 @@ exports[`topbar-sticker For display only renders as expected 1`] = `
                 }
               >
                 <div
-                  className="dr-ui--product-menu relative"
+                  className="dr-ui--product-menu"
                 >
                   <a
                     className="txt-fancy txt-l color-blue-on-hover"

--- a/src/components/topbar-sticker/__tests__/__snapshots__/topbar-sticker.test.js.snap
+++ b/src/components/topbar-sticker/__tests__/__snapshots__/topbar-sticker.test.js.snap
@@ -48,7 +48,7 @@ exports[`topbar-sticker For display only renders as expected 1`] = `
                   className="dr-ui--product-menu"
                 >
                   <a
-                    className="txt-fancy txt-l color-blue-on-hover"
+                    className="txt-fancy txt-l block color-blue-on-hover"
                     href="/dr-ui/"
                   >
                     Dr. UI

--- a/src/components/topbar-sticker/__tests__/__snapshots__/topbar-sticker.test.js.snap
+++ b/src/components/topbar-sticker/__tests__/__snapshots__/topbar-sticker.test.js.snap
@@ -45,15 +45,10 @@ exports[`topbar-sticker For display only renders as expected 1`] = `
                 }
               >
                 <div
-                  className="flex-parent"
-                  style={
-                    Object {
-                      "overflow": "hidden",
-                    }
-                  }
+                  className="dr-ui--product-menu relative"
                 >
                   <a
-                    className="flex-child txt-fancy txt-l txt-truncate color-blue-on-hover"
+                    className="txt-fancy txt-l color-blue-on-hover"
                     href="/dr-ui/"
                   >
                     Dr. UI

--- a/src/components/topbar/__tests__/__snapshots__/topbar.test.js.snap
+++ b/src/components/topbar/__tests__/__snapshots__/topbar.test.js.snap
@@ -23,7 +23,7 @@ exports[`topbar-sticker Basic renders as expected 1`] = `
           }
         >
           <div
-            className="dr-ui--product-menu relative"
+            className="dr-ui--product-menu"
           >
             <a
               className="txt-fancy txt-l color-blue-on-hover"

--- a/src/components/topbar/__tests__/__snapshots__/topbar.test.js.snap
+++ b/src/components/topbar/__tests__/__snapshots__/topbar.test.js.snap
@@ -26,7 +26,7 @@ exports[`topbar-sticker Basic renders as expected 1`] = `
             className="dr-ui--product-menu"
           >
             <a
-              className="txt-fancy txt-l color-blue-on-hover"
+              className="txt-fancy txt-l block color-blue-on-hover"
               href="/dr-ui/"
             >
               Dr. UI

--- a/src/components/topbar/__tests__/__snapshots__/topbar.test.js.snap
+++ b/src/components/topbar/__tests__/__snapshots__/topbar.test.js.snap
@@ -23,15 +23,10 @@ exports[`topbar-sticker Basic renders as expected 1`] = `
           }
         >
           <div
-            className="flex-parent"
-            style={
-              Object {
-                "overflow": "hidden",
-              }
-            }
+            className="dr-ui--product-menu relative"
           >
             <a
-              className="flex-child txt-fancy txt-l txt-truncate color-blue-on-hover"
+              className="txt-fancy txt-l color-blue-on-hover"
               href="/dr-ui/"
             >
               Dr. UI


### PR DESCRIPTION
This PR solves an issue where the `Tag` in `ProductMenu` causes the title to be too truncated:

- Move the Tag above the title in `ProductMenu`
- Add new `small` prop/variant to `Tag` that condenses the tag and removes the border. **Is `small` a good prop name? Suggestions welcome!**
- Removes truncation from `ProductMenu`. We truncated this component to keep the ProductMenu content on one line because it lived in the TopbarSticker, but now the ProductMenu has lots of room to flow below.

Current | Proposed
---|---
![image](https://user-images.githubusercontent.com/2180540/98735861-0dd15a80-2372-11eb-837f-c5d8656e253c.png) | ![image](https://user-images.githubusercontent.com/2180540/98736036-48d38e00-2372-11eb-83b0-d0b500261f39.png)



## How to test

- Try out the /PageLayout "full" test case (`npm start`)
- Try out the the /ProductMenu test cases (`npm start`)

## QA checklist

<!-- complete this checklist when adding a new component or package -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `6.2.0`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.
- [x] Create a PR in a site repo, copy the component, and test it. Push to staging and let the reviewer know they can also test the component there.


