### PR TITLE
[Info arch] Add aside with feedback to examples page layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   - 🚨 Remove `topics` Batfish helper and replace with `filters`.
   - 🚨 Remove `formatTopics` Batfish helper. Use the `HelpPage` component.
   - 🚨 Remove `accordion` object from `navigation` and moved the dataset into `navTabs` as `pages` array.
+- Replace bottom `Feedback` component on examples pages with an `Aside`.
 
 ## 1.3.0
 

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -717,7 +717,7 @@ Array [
           id="docs-content"
         >
           <div
-            className="col prose"
+            className="col prose col--8-mxl col--12"
           >
             <h1
               className="txt-fancy"
@@ -729,13 +729,58 @@ Array [
             className="grid grid--gut60"
           >
             <div
-              className="col prose"
+              className="dr-ui--page-layout-aside col col--12 col--4-mxl"
+            >
+              <aside
+                className="scroll-auto-mxl scroll-styled viewport-almost-mxl sticky-mxl"
+                data-swiftype-index="false"
+                style={
+                  Object {
+                    "top": "10px",
+                  }
+                }
+              >
+                <div
+                  className="none block-mxl"
+                >
+                  <div
+                    className="dr-ui--feedback"
+                  >
+                    <div>
+                      <h2
+                        className="unprose txt-m txt-bold mb6"
+                      >
+                        Was this 
+                        example
+                         helpful?
+                      </h2>
+                      <button
+                        className="btn btn--s"
+                        id="dr-ui--feedback-page-yes"
+                        onClick={[Function]}
+                      >
+                        Yes
+                      </button>
+                      <button
+                        className="btn btn--s ml6"
+                        id="dr-ui--feedback-page-no"
+                        onClick={[Function]}
+                      >
+                        No
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </aside>
+            </div>
+            <div
+              className="col col--8-mxl col--12 prose"
             >
               <p>
                 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
               </p>
               <div
-                className="my36"
+                className="my36 block none-mxl"
               >
                 <div
                   className="dr-ui--feedback"

--- a/src/components/page-layout/components/content.js
+++ b/src/components/page-layout/components/content.js
@@ -130,7 +130,7 @@ export class ContentWrapper extends React.Component {
             {showFeedback && (
               <div
                 className={classnames('my36', {
-                  'block none-mxl': layout !== 'example' && layout !== 'full' // hide feedback at bottom of page on larger screens, unless layout is example or full (always show it on the bottom)
+                  'block none-mxl': layout !== 'full' // hide feedback at bottom of page on larger screens unless layout is full (always show it on the bottom)
                 })}
               >
                 {this.renderFeedback()}

--- a/src/components/page-layout/layout.config.js
+++ b/src/components/page-layout/layout.config.js
@@ -3,9 +3,6 @@ export default {
     sidebar: 'toc', // heading table of contents
     sidebarTheme: '' // blank sidebar background
   },
-  example: {
-    aside: 'none' // do not show aside
-  },
   exampleIndex: {
     aside: 'none', // do not show aside
     showCards: true, // show example cards


### PR DESCRIPTION
This is a small PR that addresses long horizontal text in the examples layout: 

- Adds an aside to the examples layout (or, really, un-hides it).
- Removes the bottom feedback from the examples page to avoid duplication.

## How to test

- Pull down this branch
- `npm run start-docs` to view locally.

<img width="1064" alt="image" src="https://user-images.githubusercontent.com/2365503/98750352-57767100-2383-11eb-9e4e-c56e28269555.png">


## QA checklist

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.
- [ ] Create a PR in a site repo, copy the component, and test it. Push to staging and let the reviewer know they can also test the component there.