### PR TITLE
[info arch] Update Breadcrumbs on mobile

### DIFF
--- a/src/components/breadcrumb/__tests__/__snapshots__/breadcrumb.test.js.snap
+++ b/src/components/breadcrumb/__tests__/__snapshots__/breadcrumb.test.js.snap
@@ -5,60 +5,88 @@ exports[`Breadcrumb Basic renders as expected 1`] = `
   className="dr-ui--breadcrumb "
   data-swiftype-index="false"
 >
-  <a
-    className="link"
-    href="/mapbox-gl-js/"
-  >
-    Mapbox GL JS
-  </a>
   <span
-    className="color-gray-light inline-block px6"
+    className="none inline-block-mm"
   >
-    <svg
-      className="events-none icon inline-block align-t"
-      focusable="false"
-      role="presentation"
-      style={
-        Object {
-          "height": 18,
-          "width": 18,
-        }
-      }
+    <a
+      className="link"
+      href="/mapbox-gl-js/"
     >
-      <use
-        xlinkHref="#icon-chevron-right"
-        xmlnsXlink="http://www.w3.org/1999/xlink"
-      />
-    </svg>
-  </span>
-  <a
-    className="link"
-    href="/mapbox-gl-js/examples/"
-  >
-    Examples
-  </a>
-  <span
-    className="color-gray-light inline-block px6"
-  >
-    <svg
-      className="events-none icon inline-block align-t"
-      focusable="false"
-      role="presentation"
-      style={
-        Object {
-          "height": 18,
-          "width": 18,
-        }
-      }
+      Mapbox GL JS
+    </a>
+    <span
+      className="color-gray-light inline-block-mm none px6"
     >
-      <use
-        xlinkHref="#icon-chevron-right"
-        xmlnsXlink="http://www.w3.org/1999/xlink"
-      />
-    </svg>
+      <svg
+        className="events-none icon inline-block align-t"
+        focusable="false"
+        role="presentation"
+        style={
+          Object {
+            "height": 18,
+            "width": 18,
+          }
+        }
+      >
+        <use
+          xlinkHref="#icon-chevron-right"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
+        />
+      </svg>
+    </span>
   </span>
   <span
-    className="color-gray"
+    className=""
+  >
+    <span
+      className="color-gray-light inline-block none-mm pr6"
+    >
+      <svg
+        className="events-none icon inline-block align-t"
+        focusable="false"
+        role="presentation"
+        style={
+          Object {
+            "height": 18,
+            "width": 18,
+          }
+        }
+      >
+        <use
+          xlinkHref="#icon-arrow-left"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
+        />
+      </svg>
+    </span>
+    <a
+      className="link"
+      href="/mapbox-gl-js/examples/"
+    >
+      Examples
+    </a>
+    <span
+      className="color-gray-light inline-block-mm none px6"
+    >
+      <svg
+        className="events-none icon inline-block align-t"
+        focusable="false"
+        role="presentation"
+        style={
+          Object {
+            "height": 18,
+            "width": 18,
+          }
+        }
+      >
+        <use
+          xlinkHref="#icon-chevron-right"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
+        />
+      </svg>
+    </span>
+  </span>
+  <span
+    className="color-gray none inline-block-mm"
   >
     Display a map
   </span>
@@ -70,86 +98,118 @@ exports[`Breadcrumb Example of Platform docs site renders as expected 1`] = `
   className="dr-ui--breadcrumb "
   data-swiftype-index="false"
 >
-  <a
-    className="link"
-    href="https://platform.mapbox.com"
-  >
-    Platform
-  </a>
   <span
-    className="color-gray-light inline-block px6"
+    className="none inline-block-mm"
   >
-    <svg
-      className="events-none icon inline-block align-t"
-      focusable="false"
-      role="presentation"
-      style={
-        Object {
-          "height": 18,
-          "width": 18,
-        }
-      }
+    <a
+      className="link"
+      href="https://platform.mapbox.com"
     >
-      <use
-        xlinkHref="#icon-chevron-right"
-        xmlnsXlink="http://www.w3.org/1999/xlink"
-      />
-    </svg>
-  </span>
-  <a
-    className="link"
-    href="/developer-experience/ci-systems/"
-  >
-    CI Systems
-  </a>
-  <span
-    className="color-gray-light inline-block px6"
-  >
-    <svg
-      className="events-none icon inline-block align-t"
-      focusable="false"
-      role="presentation"
-      style={
-        Object {
-          "height": 18,
-          "width": 18,
-        }
-      }
+      Platform
+    </a>
+    <span
+      className="color-gray-light inline-block-mm none px6"
     >
-      <use
-        xlinkHref="#icon-chevron-right"
-        xmlnsXlink="http://www.w3.org/1999/xlink"
-      />
-    </svg>
-  </span>
-  <a
-    className="link"
-    href="/developer-experience/ci-systems/reference/"
-  >
-    Reference
-  </a>
-  <span
-    className="color-gray-light inline-block px6"
-  >
-    <svg
-      className="events-none icon inline-block align-t"
-      focusable="false"
-      role="presentation"
-      style={
-        Object {
-          "height": 18,
-          "width": 18,
+      <svg
+        className="events-none icon inline-block align-t"
+        focusable="false"
+        role="presentation"
+        style={
+          Object {
+            "height": 18,
+            "width": 18,
+          }
         }
-      }
-    >
-      <use
-        xlinkHref="#icon-chevron-right"
-        xmlnsXlink="http://www.w3.org/1999/xlink"
-      />
-    </svg>
+      >
+        <use
+          xlinkHref="#icon-chevron-right"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
+        />
+      </svg>
+    </span>
   </span>
   <span
-    className="color-gray"
+    className="none inline-block-mm"
+  >
+    <a
+      className="link"
+      href="/developer-experience/ci-systems/"
+    >
+      CI Systems
+    </a>
+    <span
+      className="color-gray-light inline-block-mm none px6"
+    >
+      <svg
+        className="events-none icon inline-block align-t"
+        focusable="false"
+        role="presentation"
+        style={
+          Object {
+            "height": 18,
+            "width": 18,
+          }
+        }
+      >
+        <use
+          xlinkHref="#icon-chevron-right"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
+        />
+      </svg>
+    </span>
+  </span>
+  <span
+    className=""
+  >
+    <span
+      className="color-gray-light inline-block none-mm pr6"
+    >
+      <svg
+        className="events-none icon inline-block align-t"
+        focusable="false"
+        role="presentation"
+        style={
+          Object {
+            "height": 18,
+            "width": 18,
+          }
+        }
+      >
+        <use
+          xlinkHref="#icon-arrow-left"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
+        />
+      </svg>
+    </span>
+    <a
+      className="link"
+      href="/developer-experience/ci-systems/reference/"
+    >
+      Reference
+    </a>
+    <span
+      className="color-gray-light inline-block-mm none px6"
+    >
+      <svg
+        className="events-none icon inline-block align-t"
+        focusable="false"
+        role="presentation"
+        style={
+          Object {
+            "height": 18,
+            "width": 18,
+          }
+        }
+      >
+        <use
+          xlinkHref="#icon-chevron-right"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
+        />
+      </svg>
+    </span>
+  </span>
+  <span
+    className="color-gray none inline-block-mm"
   >
     Managing credentials
   </span>
@@ -161,86 +221,118 @@ exports[`Breadcrumb Has subsite renders as expected 1`] = `
   className="dr-ui--breadcrumb "
   data-swiftype-index="false"
 >
-  <a
-    className="link"
-    href="/android/"
-  >
-    Android
-  </a>
   <span
-    className="color-gray-light inline-block px6"
+    className="none inline-block-mm"
   >
-    <svg
-      className="events-none icon inline-block align-t"
-      focusable="false"
-      role="presentation"
-      style={
-        Object {
-          "height": 18,
-          "width": 18,
-        }
-      }
+    <a
+      className="link"
+      href="/android/"
     >
-      <use
-        xlinkHref="#icon-chevron-right"
-        xmlnsXlink="http://www.w3.org/1999/xlink"
-      />
-    </svg>
-  </span>
-  <a
-    className="link"
-    href="/android/maps/overview/"
-  >
-    Maps SDK
-  </a>
-  <span
-    className="color-gray-light inline-block px6"
-  >
-    <svg
-      className="events-none icon inline-block align-t"
-      focusable="false"
-      role="presentation"
-      style={
-        Object {
-          "height": 18,
-          "width": 18,
-        }
-      }
+      Android
+    </a>
+    <span
+      className="color-gray-light inline-block-mm none px6"
     >
-      <use
-        xlinkHref="#icon-chevron-right"
-        xmlnsXlink="http://www.w3.org/1999/xlink"
-      />
-    </svg>
-  </span>
-  <a
-    className="link"
-    href="/android/maps/overview/"
-  >
-    Overview
-  </a>
-  <span
-    className="color-gray-light inline-block px6"
-  >
-    <svg
-      className="events-none icon inline-block align-t"
-      focusable="false"
-      role="presentation"
-      style={
-        Object {
-          "height": 18,
-          "width": 18,
+      <svg
+        className="events-none icon inline-block align-t"
+        focusable="false"
+        role="presentation"
+        style={
+          Object {
+            "height": 18,
+            "width": 18,
+          }
         }
-      }
-    >
-      <use
-        xlinkHref="#icon-chevron-right"
-        xmlnsXlink="http://www.w3.org/1999/xlink"
-      />
-    </svg>
+      >
+        <use
+          xlinkHref="#icon-chevron-right"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
+        />
+      </svg>
+    </span>
   </span>
   <span
-    className="color-gray"
+    className="none inline-block-mm"
+  >
+    <a
+      className="link"
+      href="/android/maps/overview/"
+    >
+      Maps SDK
+    </a>
+    <span
+      className="color-gray-light inline-block-mm none px6"
+    >
+      <svg
+        className="events-none icon inline-block align-t"
+        focusable="false"
+        role="presentation"
+        style={
+          Object {
+            "height": 18,
+            "width": 18,
+          }
+        }
+      >
+        <use
+          xlinkHref="#icon-chevron-right"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
+        />
+      </svg>
+    </span>
+  </span>
+  <span
+    className=""
+  >
+    <span
+      className="color-gray-light inline-block none-mm pr6"
+    >
+      <svg
+        className="events-none icon inline-block align-t"
+        focusable="false"
+        role="presentation"
+        style={
+          Object {
+            "height": 18,
+            "width": 18,
+          }
+        }
+      >
+        <use
+          xlinkHref="#icon-arrow-left"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
+        />
+      </svg>
+    </span>
+    <a
+      className="link"
+      href="/android/maps/overview/"
+    >
+      Overview
+    </a>
+    <span
+      className="color-gray-light inline-block-mm none px6"
+    >
+      <svg
+        className="events-none icon inline-block align-t"
+        focusable="false"
+        role="presentation"
+        style={
+          Object {
+            "height": 18,
+            "width": 18,
+          }
+        }
+      >
+        <use
+          xlinkHref="#icon-chevron-right"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
+        />
+      </svg>
+    </span>
+  </span>
+  <span
+    className="color-gray none inline-block-mm"
   >
     Camera
   </span>

--- a/src/components/breadcrumb/breadcrumb.js
+++ b/src/components/breadcrumb/breadcrumb.js
@@ -1,34 +1,47 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Icon from '@mapbox/mr-ui/icon';
+import classnames from 'classnames';
 
 export default class Breadcrumb extends React.Component {
   render() {
     const { links, location, themeWrapper } = this.props;
-
-    const Link = (props) => (
-      <React.Fragment>
-        <a className="link" href={props.href}>
-          {props.children}
-        </a>
-        <span className="color-gray-light inline-block px6">
-          <Icon name="chevron-right" inline={true} />
+    const secondLastItem = links.length - 2;
+    const Link = (props) => {
+      const isSecondLastItem = secondLastItem === props.index;
+      return (
+        <span
+          className={classnames('', {
+            'none inline-block-mm': !isSecondLastItem
+          })}
+        >
+          {isSecondLastItem && (
+            <span className="color-gray-light inline-block none-mm pr6">
+              <Icon name="arrow-left" inline={true} />
+            </span>
+          )}
+          <a className="link" href={props.href}>
+            {props.children}
+          </a>
+          <span className="color-gray-light inline-block-mm none px6">
+            <Icon name="chevron-right" inline={true} />
+          </span>
         </span>
-      </React.Fragment>
-    );
+      );
+    };
 
     return links.length > 1 ? (
       <div
         className={`dr-ui--breadcrumb ${themeWrapper}`}
         data-swiftype-index="false"
       >
-        {links.map((link) => {
+        {links.map((link, index) => {
           return link.path !== location.pathname ? (
-            <Link key={link.title} href={link.path}>
+            <Link key={link.title} href={link.path} index={index}>
               {link.title}
             </Link>
           ) : (
-            <span key={link.title} className="color-gray">
+            <span key={link.title} className="color-gray none inline-block-mm">
               {link.title}
             </span>
           );

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -967,6 +967,211 @@ Array [
 ]
 `;
 
+exports[`page-layout No sidebar, show Breadcrumbs on mobile renders as expected 1`] = `
+Array [
+  <div
+    className="shell-header-buffer"
+  />,
+  <div
+    className="limiter limiter--wide"
+  >
+    <div
+      className="flex-parent-mm"
+    >
+      <div
+        className="flex-child flex-child--grow"
+      >
+        <div
+          className="dr-ui--breadcrumb py12"
+          data-swiftype-index="false"
+        >
+          <span
+            className="none inline-block-mm"
+          >
+            <a
+              className="link"
+              href="https://docs.mapbox.com"
+            >
+              All docs
+            </a>
+            <span
+              className="color-gray-light inline-block-mm none px6"
+            >
+              <svg
+                className="events-none icon inline-block align-t"
+                focusable="false"
+                role="presentation"
+                style={
+                  Object {
+                    "height": 18,
+                    "width": 18,
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#icon-chevron-right"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className=""
+          >
+            <span
+              className="color-gray-light inline-block none-mm pr6"
+            >
+              <svg
+                className="events-none icon inline-block align-t"
+                focusable="false"
+                role="presentation"
+                style={
+                  Object {
+                    "height": 18,
+                    "width": 18,
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#icon-arrow-left"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                />
+              </svg>
+            </span>
+            <a
+              className="link"
+              href="/dr-ui/"
+            >
+              Dr. UI
+            </a>
+            <span
+              className="color-gray-light inline-block-mm none px6"
+            >
+              <svg
+                className="events-none icon inline-block align-t"
+                focusable="false"
+                role="presentation"
+                style={
+                  Object {
+                    "height": 18,
+                    "width": 18,
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#icon-chevron-right"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className="color-gray none inline-block-mm"
+          >
+            Overview
+          </span>
+        </div>
+        <div
+          id="docs-content"
+        >
+          <div
+            className="col prose"
+          >
+            <h1
+              className="txt-fancy"
+            >
+              Overview
+            </h1>
+          </div>
+          <div
+            className="grid grid--gut60"
+          >
+            <div
+              className="col prose"
+            >
+              <p>
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+              </p>
+              <div
+                className="my36"
+              >
+                <div
+                  className="dr-ui--feedback"
+                >
+                  <div>
+                    <h2
+                      className="unprose txt-m txt-bold mb6"
+                    >
+                      Was this 
+                      page
+                       helpful?
+                    </h2>
+                    <button
+                      className="btn btn--s"
+                      id="dr-ui--feedback-page-yes"
+                      onClick={[Function]}
+                    >
+                      Yes
+                    </button>
+                    <button
+                      className="btn btn--s ml6"
+                      id="dr-ui--feedback-page-no"
+                      onClick={[Function]}
+                    >
+                      No
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="fixed block none-mm mx24 my24 z5 bottom right"
+  >
+    <div
+      className="block mx24 my24 z5"
+    >
+      <div
+        className="inline-block"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+      >
+        <button
+          aria-label="Back to top"
+          className="btn--blue w60 h60 px0 round-full shadow-darken25 color-white flex-parent flex-parent--center-main flex-parent--center-cross"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            className="events-none icon"
+            focusable="false"
+            role="presentation"
+            style={
+              Object {
+                "height": 30,
+                "width": 30,
+              }
+            }
+          >
+            <use
+              xlinkHref="#icon-arrow-up"
+              xmlnsXlink="http://www.w3.org/1999/xlink"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
 exports[`page-layout Page layout renders as expected 1`] = `
 Array [
   <div

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -151,7 +151,7 @@ Array [
         className="flex-child flex-child--grow"
       >
         <div
-          className="dr-ui--breadcrumb py12"
+          className="dr-ui--breadcrumb py12 none block-mm"
           data-swiftype-index="false"
         >
           <span
@@ -702,7 +702,7 @@ Array [
         className="flex-child flex-child--grow"
       >
         <div
-          className="dr-ui--breadcrumb py12"
+          className="dr-ui--breadcrumb py12 none block-mm"
           data-swiftype-index="false"
         >
           <span
@@ -1073,7 +1073,7 @@ Array [
         className="flex-child flex-child--grow"
       >
         <div
-          className="dr-ui--breadcrumb py12"
+          className="dr-ui--breadcrumb py12 none block-mm"
           data-swiftype-index="false"
         >
           <span
@@ -1445,7 +1445,7 @@ Array [
         className="flex-child flex-child--grow"
       >
         <div
-          className="dr-ui--breadcrumb py12"
+          className="dr-ui--breadcrumb py12 none block-mm"
           data-swiftype-index="false"
         >
           <span

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -151,63 +151,91 @@ Array [
         className="flex-child flex-child--grow"
       >
         <div
-          className="dr-ui--breadcrumb none block-mm py12"
+          className="dr-ui--breadcrumb py12"
           data-swiftype-index="false"
         >
-          <a
-            className="link"
-            href="https://docs.mapbox.com"
-          >
-            All docs
-          </a>
           <span
-            className="color-gray-light inline-block px6"
+            className="none inline-block-mm"
           >
-            <svg
-              className="events-none icon inline-block align-t"
-              focusable="false"
-              role="presentation"
-              style={
-                Object {
-                  "height": 18,
-                  "width": 18,
-                }
-              }
+            <a
+              className="link"
+              href="https://docs.mapbox.com"
             >
-              <use
-                xlinkHref="#icon-chevron-right"
-                xmlnsXlink="http://www.w3.org/1999/xlink"
-              />
-            </svg>
-          </span>
-          <a
-            className="link"
-            href="/dr-ui/"
-          >
-            dr-ui
-          </a>
-          <span
-            className="color-gray-light inline-block px6"
-          >
-            <svg
-              className="events-none icon inline-block align-t"
-              focusable="false"
-              role="presentation"
-              style={
-                Object {
-                  "height": 18,
-                  "width": 18,
-                }
-              }
+              All docs
+            </a>
+            <span
+              className="color-gray-light inline-block-mm none px6"
             >
-              <use
-                xlinkHref="#icon-chevron-right"
-                xmlnsXlink="http://www.w3.org/1999/xlink"
-              />
-            </svg>
+              <svg
+                className="events-none icon inline-block align-t"
+                focusable="false"
+                role="presentation"
+                style={
+                  Object {
+                    "height": 18,
+                    "width": 18,
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#icon-chevron-right"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                />
+              </svg>
+            </span>
           </span>
           <span
-            className="color-gray"
+            className=""
+          >
+            <span
+              className="color-gray-light inline-block none-mm pr6"
+            >
+              <svg
+                className="events-none icon inline-block align-t"
+                focusable="false"
+                role="presentation"
+                style={
+                  Object {
+                    "height": 18,
+                    "width": 18,
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#icon-arrow-left"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                />
+              </svg>
+            </span>
+            <a
+              className="link"
+              href="/dr-ui/"
+            >
+              dr-ui
+            </a>
+            <span
+              className="color-gray-light inline-block-mm none px6"
+            >
+              <svg
+                className="events-none icon inline-block align-t"
+                focusable="false"
+                role="presentation"
+                style={
+                  Object {
+                    "height": 18,
+                    "width": 18,
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#icon-chevron-right"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className="color-gray none inline-block-mm"
           >
             Examples
           </span>
@@ -674,89 +702,121 @@ Array [
         className="flex-child flex-child--grow"
       >
         <div
-          className="dr-ui--breadcrumb none block-mm py12"
+          className="dr-ui--breadcrumb py12"
           data-swiftype-index="false"
         >
-          <a
-            className="link"
-            href="https://docs.mapbox.com"
-          >
-            All docs
-          </a>
           <span
-            className="color-gray-light inline-block px6"
+            className="none inline-block-mm"
           >
-            <svg
-              className="events-none icon inline-block align-t"
-              focusable="false"
-              role="presentation"
-              style={
-                Object {
-                  "height": 18,
-                  "width": 18,
-                }
-              }
+            <a
+              className="link"
+              href="https://docs.mapbox.com"
             >
-              <use
-                xlinkHref="#icon-chevron-right"
-                xmlnsXlink="http://www.w3.org/1999/xlink"
-              />
-            </svg>
-          </span>
-          <a
-            className="link"
-            href="/dr-ui/"
-          >
-            dr-ui
-          </a>
-          <span
-            className="color-gray-light inline-block px6"
-          >
-            <svg
-              className="events-none icon inline-block align-t"
-              focusable="false"
-              role="presentation"
-              style={
-                Object {
-                  "height": 18,
-                  "width": 18,
-                }
-              }
+              All docs
+            </a>
+            <span
+              className="color-gray-light inline-block-mm none px6"
             >
-              <use
-                xlinkHref="#icon-chevron-right"
-                xmlnsXlink="http://www.w3.org/1999/xlink"
-              />
-            </svg>
-          </span>
-          <a
-            className="link"
-            href="/PageLayout/examples/"
-          >
-            Examples
-          </a>
-          <span
-            className="color-gray-light inline-block px6"
-          >
-            <svg
-              className="events-none icon inline-block align-t"
-              focusable="false"
-              role="presentation"
-              style={
-                Object {
-                  "height": 18,
-                  "width": 18,
+              <svg
+                className="events-none icon inline-block align-t"
+                focusable="false"
+                role="presentation"
+                style={
+                  Object {
+                    "height": 18,
+                    "width": 18,
+                  }
                 }
-              }
-            >
-              <use
-                xlinkHref="#icon-chevron-right"
-                xmlnsXlink="http://www.w3.org/1999/xlink"
-              />
-            </svg>
+              >
+                <use
+                  xlinkHref="#icon-chevron-right"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                />
+              </svg>
+            </span>
           </span>
           <span
-            className="color-gray"
+            className="none inline-block-mm"
+          >
+            <a
+              className="link"
+              href="/dr-ui/"
+            >
+              dr-ui
+            </a>
+            <span
+              className="color-gray-light inline-block-mm none px6"
+            >
+              <svg
+                className="events-none icon inline-block align-t"
+                focusable="false"
+                role="presentation"
+                style={
+                  Object {
+                    "height": 18,
+                    "width": 18,
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#icon-chevron-right"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className=""
+          >
+            <span
+              className="color-gray-light inline-block none-mm pr6"
+            >
+              <svg
+                className="events-none icon inline-block align-t"
+                focusable="false"
+                role="presentation"
+                style={
+                  Object {
+                    "height": 18,
+                    "width": 18,
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#icon-arrow-left"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                />
+              </svg>
+            </span>
+            <a
+              className="link"
+              href="/PageLayout/examples/"
+            >
+              Examples
+            </a>
+            <span
+              className="color-gray-light inline-block-mm none px6"
+            >
+              <svg
+                className="events-none icon inline-block align-t"
+                focusable="false"
+                role="presentation"
+                style={
+                  Object {
+                    "height": 18,
+                    "width": 18,
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#icon-chevron-right"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className="color-gray none inline-block-mm"
           >
             An example
           </span>
@@ -1013,63 +1073,91 @@ Array [
         className="flex-child flex-child--grow"
       >
         <div
-          className="dr-ui--breadcrumb none block-mm py12"
+          className="dr-ui--breadcrumb py12"
           data-swiftype-index="false"
         >
-          <a
-            className="link"
-            href="https://docs.mapbox.com"
-          >
-            All docs
-          </a>
           <span
-            className="color-gray-light inline-block px6"
+            className="none inline-block-mm"
           >
-            <svg
-              className="events-none icon inline-block align-t"
-              focusable="false"
-              role="presentation"
-              style={
-                Object {
-                  "height": 18,
-                  "width": 18,
-                }
-              }
+            <a
+              className="link"
+              href="https://docs.mapbox.com"
             >
-              <use
-                xlinkHref="#icon-chevron-right"
-                xmlnsXlink="http://www.w3.org/1999/xlink"
-              />
-            </svg>
-          </span>
-          <a
-            className="link"
-            href="/dr-ui/"
-          >
-            dr-ui
-          </a>
-          <span
-            className="color-gray-light inline-block px6"
-          >
-            <svg
-              className="events-none icon inline-block align-t"
-              focusable="false"
-              role="presentation"
-              style={
-                Object {
-                  "height": 18,
-                  "width": 18,
-                }
-              }
+              All docs
+            </a>
+            <span
+              className="color-gray-light inline-block-mm none px6"
             >
-              <use
-                xlinkHref="#icon-chevron-right"
-                xmlnsXlink="http://www.w3.org/1999/xlink"
-              />
-            </svg>
+              <svg
+                className="events-none icon inline-block align-t"
+                focusable="false"
+                role="presentation"
+                style={
+                  Object {
+                    "height": 18,
+                    "width": 18,
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#icon-chevron-right"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                />
+              </svg>
+            </span>
           </span>
           <span
-            className="color-gray"
+            className=""
+          >
+            <span
+              className="color-gray-light inline-block none-mm pr6"
+            >
+              <svg
+                className="events-none icon inline-block align-t"
+                focusable="false"
+                role="presentation"
+                style={
+                  Object {
+                    "height": 18,
+                    "width": 18,
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#icon-arrow-left"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                />
+              </svg>
+            </span>
+            <a
+              className="link"
+              href="/dr-ui/"
+            >
+              dr-ui
+            </a>
+            <span
+              className="color-gray-light inline-block-mm none px6"
+            >
+              <svg
+                className="events-none icon inline-block align-t"
+                focusable="false"
+                role="presentation"
+                style={
+                  Object {
+                    "height": 18,
+                    "width": 18,
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#icon-chevron-right"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className="color-gray none inline-block-mm"
           >
             Overview
           </span>
@@ -1357,63 +1445,91 @@ Array [
         className="flex-child flex-child--grow"
       >
         <div
-          className="dr-ui--breadcrumb none block-mm py12"
+          className="dr-ui--breadcrumb py12"
           data-swiftype-index="false"
         >
-          <a
-            className="link"
-            href="https://docs.mapbox.com"
-          >
-            All docs
-          </a>
           <span
-            className="color-gray-light inline-block px6"
+            className="none inline-block-mm"
           >
-            <svg
-              className="events-none icon inline-block align-t"
-              focusable="false"
-              role="presentation"
-              style={
-                Object {
-                  "height": 18,
-                  "width": 18,
-                }
-              }
+            <a
+              className="link"
+              href="https://docs.mapbox.com"
             >
-              <use
-                xlinkHref="#icon-chevron-right"
-                xmlnsXlink="http://www.w3.org/1999/xlink"
-              />
-            </svg>
-          </span>
-          <a
-            className="link"
-            href="/dr-ui/"
-          >
-            dr-ui
-          </a>
-          <span
-            className="color-gray-light inline-block px6"
-          >
-            <svg
-              className="events-none icon inline-block align-t"
-              focusable="false"
-              role="presentation"
-              style={
-                Object {
-                  "height": 18,
-                  "width": 18,
-                }
-              }
+              All docs
+            </a>
+            <span
+              className="color-gray-light inline-block-mm none px6"
             >
-              <use
-                xlinkHref="#icon-chevron-right"
-                xmlnsXlink="http://www.w3.org/1999/xlink"
-              />
-            </svg>
+              <svg
+                className="events-none icon inline-block align-t"
+                focusable="false"
+                role="presentation"
+                style={
+                  Object {
+                    "height": 18,
+                    "width": 18,
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#icon-chevron-right"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                />
+              </svg>
+            </span>
           </span>
           <span
-            className="color-gray"
+            className=""
+          >
+            <span
+              className="color-gray-light inline-block none-mm pr6"
+            >
+              <svg
+                className="events-none icon inline-block align-t"
+                focusable="false"
+                role="presentation"
+                style={
+                  Object {
+                    "height": 18,
+                    "width": 18,
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#icon-arrow-left"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                />
+              </svg>
+            </span>
+            <a
+              className="link"
+              href="/dr-ui/"
+            >
+              dr-ui
+            </a>
+            <span
+              className="color-gray-light inline-block-mm none px6"
+            >
+              <svg
+                className="events-none icon inline-block align-t"
+                focusable="false"
+                role="presentation"
+                style={
+                  Object {
+                    "height": 18,
+                    "width": 18,
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#icon-chevron-right"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className="color-gray none inline-block-mm"
           >
             Overview
           </span>

--- a/src/components/page-layout/__tests__/page-layout-test-cases.js
+++ b/src/components/page-layout/__tests__/page-layout-test-cases.js
@@ -3,6 +3,7 @@ import Page from '../examples/page';
 import Example from '../examples/example';
 import ExamplePage from '../examples/example-page';
 import Full from '../examples/full';
+import PageLayout from '../../page-layout';
 
 const testCases = {};
 
@@ -24,6 +25,57 @@ testCases.example = {
 testCases.examplePage = {
   description: 'Example page layout',
   element: <ExamplePage />
+};
+
+testCases.noSidebar = {
+  description: 'No sidebar, show Breadcrumbs on mobile',
+  element: (
+    <PageLayout
+      constants={{
+        SITE: 'Dr. UI',
+        BASEURL: '/dr-ui',
+        FORWARD_EVENT_WEBHOOK: {
+          production: '123',
+          staging: '123'
+        }
+      }}
+      location={{
+        pathname: '/PageLayout/'
+      }}
+      frontMatter={{
+        title: 'Overview',
+        layout: 'full',
+        hideSidebar: true
+      }}
+      navigation={{
+        hierarchy: {
+          '/PageLayout/': {
+            parent: '/PageLayout/',
+            title: 'Overview'
+          }
+        },
+        navTabs: [
+          {
+            title: 'Overview',
+            path: '/PageLayout/',
+            id: 'overview'
+          }
+        ]
+      }}
+    >
+      <React.Fragment>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum.
+        </p>
+      </React.Fragment>
+    </PageLayout>
+  )
 };
 
 export { testCases };

--- a/src/components/page-layout/__tests__/page-layout.test.js
+++ b/src/components/page-layout/__tests__/page-layout.test.js
@@ -65,4 +65,20 @@ describe('page-layout', () => {
       expect(tree).toMatchSnapshot();
     });
   });
+
+  describe(testCases.noSidebar.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.noSidebar;
+      wrapper = renderer.create(testCase.element);
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
 });

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -35,27 +35,26 @@ export default class PageLayout extends React.Component {
   // render the page's content
   renderContent = (config, parentPath, parent, hasSection) => {
     const { constants, frontMatter, location } = this.props;
-    // removes "for (Platform)" from section titles to avoid repetition
-    const trimSectionTitle = (title) =>
-      title.replace(/\sfor\s(iOS|Android|Vision|Unity)/, '');
     const crumbs = createUniqueCrumbs([
       {
         title: 'All docs',
         path: 'https://docs.mapbox.com'
       },
-      {
-        title: constants.SITE,
-        path: `${constants.BASEURL}/`
-      },
-      // if multi-structured site add the section name
+      // if multi-structured show section name
+      // if single-structured show site name
       ...(hasSection
         ? [
             {
-              title: trimSectionTitle(hasSection.title),
+              title: hasSection.title,
               path: `${constants.BASEURL}/${hasSection.path}/`
             }
           ]
-        : []),
+        : [
+            {
+              title: constants.SITE,
+              path: `${constants.BASEURL}/`
+            }
+          ]),
       ...(parent && parent.title
         ? [
             {

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -73,7 +73,7 @@ export default class PageLayout extends React.Component {
       <div className="flex-child flex-child--grow">
         {!frontMatter.hideBreadcrumbs && (
           <Breadcrumb
-            themeWrapper="none block-mm py12"
+            themeWrapper="py12"
             domain={false}
             location={location}
             links={crumbs}

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -7,6 +7,7 @@ import Content from './components/content';
 import Sidebar from './components/sidebar';
 import { filterOptions } from './components/example-index';
 import { findHasSection, findParentPath, createUniqueCrumbs } from './utils';
+import classnames from 'classnames';
 
 // default configuration for each layout
 // every option can be overriden in the frontMatter
@@ -72,7 +73,11 @@ export default class PageLayout extends React.Component {
       <div className="flex-child flex-child--grow">
         {!frontMatter.hideBreadcrumbs && (
           <Breadcrumb
-            themeWrapper="py12"
+            themeWrapper={classnames('py12', {
+              // hide breadcrumbs on mobile if sidebar is on the page
+              // show breadcrumbs on mobile if sidebar is hidden from the page
+              'none block-mm': !frontMatter.hideSidebar
+            })}
             domain={false}
             location={location}
             links={crumbs}
@@ -165,7 +170,7 @@ PageLayout.propTypes = {
 `noShellHeaderBuffer` | If `true`, remove the header buffer div. This is helpful for custom headers like on the Help page. |
 `hideFromNav` | If `true`, remove an item from appearing in NavigationAccordion. (This is used in API docs.) | 
 `hideBreadcrumbs` | If `true`, remove the breadcrumbs. (This is used by Help home page.) |
-`hideSidebar` | If `true`, remove the sidebar. (This is used by Help home page.) |
+`hideSidebar` | If `true`, remove the sidebar. (This is used by Help home page and Playground.). This setting will also enable breadcrumbs to display on mobile (unless `hideBreadcrumbs: true`). |
 `showFilters` | All filters for an exampleIndex page are shown if the data is available. Use `showFilters` to define only the filters you want the page to display. | `exampleIndex` layout
 */
   frontMatter: PropTypes.shape({


### PR DESCRIPTION
This PR makes some updates to the Breadcrumbs component and how PageLayout displays the Breadcrumb component:

- On mobile, Breadcrumbs will display the second to last link with a back arrow. (Ignore the dotted border, that's from the test cases app).

Device size | Image
---|---
Large | ![image](https://user-images.githubusercontent.com/2180540/98958427-425b2880-24d0-11eb-9b04-52015fcff427.png)
Small | ![image](https://user-images.githubusercontent.com/2180540/98958388-38392a00-24d0-11eb-8970-41b8ecd128a6.png)

- While testing, I noticed that Breadcrumbs should only be shown on mobile if there is no sidebar. Otherwise the breadcrumbs site underneath the navigation and is redundant. This PR will make it so that the Breadcrumb component in PageLayout will only display on mobile if there is no sidebar. This is helpful in sites like Playground which we project will not have a sidebar, so the Breadcrumbs will be vital in allowing the user to return the the Playground homepage from a given playground.

- While testing, I also noticed the the Breadcrumbs on multi-structured sites were a little misleading. This PR will update PageLayout’s Breadcrumb data for multi-structured sites to **not** show the site name. For multi-structured sites, the site name is not an independent page and redirects to one of the subsides. For example /android redirects to /android/maps. In the future, if we decide to add platform pages, then we can update the crumbs. In the images below, if you are on the Navigation SDK Overview page and click "Android" it will send you to Maps SDK for Android -- which would likely be confusing to the user.

Stage | Image
---|---
Current | ![image](https://user-images.githubusercontent.com/2180540/98958580-6b7bb900-24d0-11eb-991e-2058bbb21dc4.png)
Proposed | ![image](https://user-images.githubusercontent.com/2180540/98958603-720a3080-24d0-11eb-9a01-4c739bc3f723.png)


## How to test

- Observe the /Breadcrumb test cases app
- Observe the /PageLayout test cases, including "No sidebar, show Breadcrumbs on mobile." 

## QA checklist

<!-- complete this checklist when adding a new component or package -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.
- [x] Create a PR in a site repo, copy the component, and test it. Push to staging and let the reviewer know they can also test the component there.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] IE11, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.
