### PR TITLE
[info arch] Filter out pages in filter helper that have no title

### DIFF
--- a/src/helpers/batfish/__tests__/filters.test.js
+++ b/src/helpers/batfish/__tests__/filters.test.js
@@ -8,10 +8,19 @@ const {
 } = require('../filters.js');
 const data = require('./fixtures/data.json');
 const dataMulti = require('./fixtures/data-multi.json');
+const glJsDebug = require('./fixtures/gl-js-debug.json');
 
 describe('buildFilters', () => {
   it('single structure', () => {
     expect(buildFilters(data)).toMatchSnapshot();
+  });
+
+  it('filter out pages without titles', () => {
+    // GL JS has page redirects that do not have title
+    // and need to be filtered out to prevent errors
+    expect(() => {
+      buildFilters(glJsDebug);
+    }).not.toThrow();
   });
 
   it('multi structure', () => {

--- a/src/helpers/batfish/__tests__/fixtures/gl-js-debug.json
+++ b/src/helpers/batfish/__tests__/fixtures/gl-js-debug.json
@@ -1,0 +1,43 @@
+{
+  "pages": [
+    {
+      "filePath": "/Users/katydecorah/Documents/GitHub/mapbox/mapbox-gl-js-docs/docs/pages/example/index.md",
+      "path": "/mapbox-gl-js/example/",
+      "frontMatter": {
+        "title": "Examples",
+        "description": "Code examples for Mapbox GL JS.",
+        "contentType": "example",
+        "layout": "example",
+        "navOrder": 2,
+        "language": ["JavaScript"],
+        "hideCardLanguage": true,
+        "hideCardDescription": true,
+        "products": ["Mapbox GL JS"]
+      }
+    },
+
+    {
+      "filePath": "/Users/katydecorah/Documents/GitHub/mapbox/mapbox-gl-js-docs/docs/pages/example/using-featuresin.js",
+      "path": "/mapbox-gl-js/example/using-featuresin/",
+      "frontMatter": {}
+    },
+    {
+      "filePath": "/Users/katydecorah/Documents/GitHub/mapbox/mapbox-gl-js-docs/docs/pages/example/toggle-worldviews.md",
+      "path": "/mapbox-gl-js/example/toggle-worldviews/",
+      "frontMatter": {
+        "title": "Change worldview of administrative boundaries",
+        "description": "Uses the `worldview` value to adjust administrative boundaries based on the map's audience. Read more about [worldviews](https://docs.mapbox.com/help/glossary/worldview/).\n",
+        "topics": ["Layers", "User interaction"],
+        "thumbnail": "toggle-worldviews",
+        "contentType": "example",
+        "layout": "example",
+        "language": ["JavaScript"],
+        "products": ["Mapbox GL JS", "Mapbox Streets tileset"],
+        "prependJs": [
+          "import Example from '../../components/example';",
+          "import html from './toggle-worldviews.html';"
+        ]
+      }
+    }
+  ]
+}

--- a/src/helpers/batfish/filters.js
+++ b/src/helpers/batfish/filters.js
@@ -4,10 +4,12 @@ const { sortAlpha } = require('./navigation');
 
 function buildFilters(data) {
   // format page data
-  const pages = data.pages.map((p) => ({
-    path: p.path, // each path is the page's primary key
-    ...p.frontMatter
-  }));
+  const pages = data.pages
+    .map((p) => ({
+      path: p.path, // each path is the page's primary key
+      ...p.frontMatter
+    }))
+    .filter((f) => f.title); // page must have title
 
   // find every example index page
   const exampleIndexPages = pages.filter(


### PR DESCRIPTION
In attempting to test Mapbox GL JS, I received the error:

```
TypeError: Cannot read property 'localeCompare' of undefined
```

There are several redirect pages in Mapbox GL JS example folder and the Batfish filter function was attempting to include them in building the filters. Since redirects do not have title, it failed while attempting to sort.

This PR filters out all pages that do not have a title to prevent pages without the correct amount of context from being included in the filter.

## How to test

I created a reduced test case by carrying over three pages from Mapbox GL JS (the Examples index page, an examples redirect, and an examples page). I created a test to make sure that when filters are built with that dataset that no errors are thrown. 
