### PR TITLE
[info arch] Add theming options to `OverviewHeader`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
   - 🚨 Remove `formatTopics` Batfish helper. Use the `HelpPage` component.
   - 🚨 Remove `accordion` object from `navigation` and moved the dataset into `navTabs` as `pages` array.
 - Replace bottom `Feedback` component on examples pages with an `Aside`.
-- Add theming options to `OverviewHeader`: `background` to accept a background CSS class, `lightText` to enable white text, `description` to add a text description. The `features` prop is now optional.
+- Add theming options to `OverviewHeader`: `theme` to accept CSS classes to customize the container, `lightText` to enable white text, `description` to add a text description. The `features` prop is now optional.
 
 ## 1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   - Add aside feature which includes the `OnThisPage` and `Feedback` components. On larger devices, the aside is stuck to the right-side of the screen. On smaller devices, `OnThisPage` moves inline below the page's title and `Feedback` will appear at the bottom of the page. The aside feature does not stick on IE 11 and remains static, but still performs the core functionality of providing anchor links.
   - Remove `TopbarSticker` from `PageLayout`. The main navigation now uses the `NavigationAccordion` on the sidebar to display main pages and subpages.
   - 🚨Redesigned `NavigationAccordion` to work as site navigation menu. The component will no longer track headings. We deprecated several props and introduced new ones, please consult the [NavigationAccordion documentation](https://mapbox.github.io/dr-ui/components/#navigationaccordion).
-  - Add option to add `OverviewHeader` component to the page by passing the component's properties in the frontMatter.
+  - Add option to add `OverviewHeader` component to the page by passing the component's properties in the frontMatter. When `overviewHeader` is defined in the frontMatter, then the title (h1) will not show on the page.
   - Add filter functionality to `exampleIndex` layout. All page cards will be displayed in order of the `order` frontMatter property and then alphabetically by title. Filters will automatically appear for topics, levels, languages, and video if the pages have at least more than one unique option for each filter category. Filter selections are pushed to the query param and are set by a rendered query string.
 - Update `Feedback` component.
   - Remove background color and use `AsideHeading` component to style the component's heading.
@@ -23,6 +23,7 @@
   - 🚨 Remove `formatTopics` Batfish helper. Use the `HelpPage` component.
   - 🚨 Remove `accordion` object from `navigation` and moved the dataset into `navTabs` as `pages` array.
 - Replace bottom `Feedback` component on examples pages with an `Aside`.
+- Add theming options to `OverviewHeader`: `background` to accept a background CSS class, `lightText` to enable white text, `description` to add a text description. The `features` prop is now optional.
 
 ## 1.3.0
 

--- a/docs/src/pages/components/index.md
+++ b/docs/src/pages/components/index.md
@@ -18,8 +18,7 @@ overviewHeader:
   changelogLink: /dr-ui/changelog/
   installLink: https://github.com/mapbox/dr-ui/blob/main/README.md
   ghLink: https://github.com/mapbox/dr-ui
-  background: bg-purple-faint
-  # lightText: true
+  theme: bg-purple-faint
   # version: "" dynamic version is set in pages-shell.js
   # image: "" set in page-shell.js
 ---

--- a/docs/src/pages/components/index.md
+++ b/docs/src/pages/components/index.md
@@ -6,7 +6,6 @@ layout: page
 contentType: reference
 products:
   - Documentation
-hideTitle: true
 unProse: true
 prependJs:
   - "import Note from '../../../../src/components/note'"
@@ -19,6 +18,8 @@ overviewHeader:
   changelogLink: /dr-ui/changelog/
   installLink: https://github.com/mapbox/dr-ui/blob/main/README.md
   ghLink: https://github.com/mapbox/dr-ui
+  background: bg-purple-faint
+  # lightText: true
   # version: "" dynamic version is set in pages-shell.js
   # image: "" set in page-shell.js
 ---

--- a/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
+++ b/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`overview-header Adds Contact Us button renders as expected 1`] = `
 <div
-  className="dr-ui--overview-header border-b border--darken10 prose mb24 pr60-mxl"
+  className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--darken10"
 >
   <div
     className="flex-parent"
@@ -27,6 +27,7 @@ exports[`overview-header Adds Contact Us button renders as expected 1`] = `
            
         </span>
         <a
+          className="unprose link txt-underline"
           href="https://keepachangelog.com/en/0.3.0/"
         >
           View changelog
@@ -132,7 +133,7 @@ exports[`overview-header Adds Contact Us button renders as expected 1`] = `
         className="mb24"
       >
         <a
-          className="btn txt-l round inline-block color-white unprose mr24"
+          className="btn txt-l round inline-block unprose mr24 btn--blue"
           href="https://www.mapbox.com/contact/"
         >
           Contact us
@@ -140,7 +141,7 @@ exports[`overview-header Adds Contact Us button renders as expected 1`] = `
       </div>
     </div>
     <div
-      className="flex-child-ml flex-child--no-shrink w300-mxl"
+      className="flex-child-ml flex-child--no-shrink w300-mxl align-r"
     >
       <div
         className="none block-mxl"
@@ -156,7 +157,7 @@ exports[`overview-header Adds Contact Us button renders as expected 1`] = `
 
 exports[`overview-header All, plus Contact Us button renders as expected 1`] = `
 <div
-  className="dr-ui--overview-header border-b border--darken10 prose mb24 pr60-mxl"
+  className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--darken10"
 >
   <div
     className="flex-parent"
@@ -181,6 +182,7 @@ exports[`overview-header All, plus Contact Us button renders as expected 1`] = `
            
         </span>
         <a
+          className="unprose link txt-underline"
           href="https://keepachangelog.com/en/0.3.0/"
         >
           View changelog
@@ -286,13 +288,13 @@ exports[`overview-header All, plus Contact Us button renders as expected 1`] = `
         className="mb24"
       >
         <a
-          className="btn txt-l round inline-block color-white unprose mr24"
+          className="btn txt-l round inline-block unprose mr24 btn--blue"
           href="https://www.mapbox.com/install"
         >
           Install
         </a>
         <a
-          className="btn txt-l round inline-block color-white unprose mr24"
+          className="btn txt-l round inline-block unprose mr24 btn--blue"
           href="https://www.mapbox.com/contact/"
         >
           Contact us
@@ -334,7 +336,7 @@ exports[`overview-header All, plus Contact Us button renders as expected 1`] = `
       </div>
     </div>
     <div
-      className="flex-child-ml flex-child--no-shrink w300-mxl"
+      className="flex-child-ml flex-child--no-shrink w300-mxl align-r"
     >
       <div
         className="none block-mxl"
@@ -350,7 +352,7 @@ exports[`overview-header All, plus Contact Us button renders as expected 1`] = `
 
 exports[`overview-header Basic renders as expected 1`] = `
 <div
-  className="dr-ui--overview-header border-b border--darken10 prose mb24 pr60-mxl"
+  className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--darken10"
 >
   <div
     className="flex-parent"
@@ -375,6 +377,7 @@ exports[`overview-header Basic renders as expected 1`] = `
            
         </span>
         <a
+          className="unprose link txt-underline"
           href="https://keepachangelog.com/en/0.3.0/"
         >
           View changelog
@@ -480,7 +483,7 @@ exports[`overview-header Basic renders as expected 1`] = `
         className="mb24"
       >
         <a
-          className="btn txt-l round inline-block color-white unprose mr24"
+          className="btn txt-l round inline-block unprose mr24 btn--blue"
           href="https://www.mapbox.com/install"
         >
           Install
@@ -522,7 +525,7 @@ exports[`overview-header Basic renders as expected 1`] = `
       </div>
     </div>
     <div
-      className="flex-child-ml flex-child--no-shrink w300-mxl"
+      className="flex-child-ml flex-child--no-shrink w300-mxl align-r"
     >
       <div
         className="none block-mxl"
@@ -538,7 +541,7 @@ exports[`overview-header Basic renders as expected 1`] = `
 
 exports[`overview-header Beta product renders as expected 1`] = `
 <div
-  className="dr-ui--overview-header border-b border--darken10 prose mb24 pr60-mxl"
+  className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--darken10"
 >
   <div
     className="flex-parent"
@@ -690,7 +693,7 @@ exports[`overview-header Beta product renders as expected 1`] = `
       </ul>
     </div>
     <div
-      className="flex-child-ml flex-child--no-shrink w300-mxl"
+      className="flex-child-ml flex-child--no-shrink w300-mxl align-r"
     >
       <div
         className="none block-mxl"
@@ -706,7 +709,7 @@ exports[`overview-header Beta product renders as expected 1`] = `
 
 exports[`overview-header No optional props renders as expected 1`] = `
 <div
-  className="dr-ui--overview-header border-b border--darken10 prose mb24 pr60-mxl"
+  className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--darken10"
 >
   <div
     className="flex-parent"
@@ -875,7 +878,7 @@ exports[`overview-header No optional props renders as expected 1`] = `
       </ul>
     </div>
     <div
-      className="flex-child-ml flex-child--no-shrink w300-mxl"
+      className="flex-child-ml flex-child--no-shrink w300-mxl align-r"
     >
       <div
         className="none block-mxl"
@@ -891,7 +894,7 @@ exports[`overview-header No optional props renders as expected 1`] = `
 
 exports[`overview-header Some optional props renders as expected 1`] = `
 <div
-  className="dr-ui--overview-header border-b border--darken10 prose mb24 pr60-mxl"
+  className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--darken10"
 >
   <div
     className="flex-parent"
@@ -1052,7 +1055,7 @@ exports[`overview-header Some optional props renders as expected 1`] = `
       </div>
     </div>
     <div
-      className="flex-child-ml flex-child--no-shrink w300-mxl"
+      className="flex-child-ml flex-child--no-shrink w300-mxl align-r"
     >
       <div
         className="none block-mxl"

--- a/src/components/overview-header/__tests__/overview-header-test-cases.js
+++ b/src/components/overview-header/__tests__/overview-header-test-cases.js
@@ -122,7 +122,7 @@ testCases.everything = {
     features: ['Smooth scrambled eggs', 'Vegetarian sausage', 'Fruit syrups'],
     title: 'Mapbox SDK for Breakfast',
     version: '0.1.0',
-    background: 'bg-gray-dark',
+    theme: 'bg-gray-dark',
     tag: 'beta',
     lightText: true,
     changelogLink: 'https://keepachangelog.com/en/0.3.0/',

--- a/src/components/overview-header/__tests__/overview-header-test-cases.js
+++ b/src/components/overview-header/__tests__/overview-header-test-cases.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Basic from '../examples/basic';
+import Custom from '../examples/custom';
 import OverviewHeader from '../overview-header';
 
 const testCases = {};
@@ -7,6 +8,11 @@ const testCases = {};
 testCases.basic = {
   description: 'Basic',
   element: <Basic />
+};
+
+testCases.custom = {
+  description: 'Custom background',
+  element: <Custom />
 };
 
 testCases.none = {
@@ -102,6 +108,27 @@ testCases.customTag = {
         borderColor: '#FD8383'
       }
     },
+    image: (
+      <img src="https://farm2.staticflickr.com/1790/29050447978_41e671dcd5_o.jpg" />
+    )
+  }
+};
+
+testCases.everything = {
+  description: 'Everything.',
+  component: OverviewHeader,
+  props: {
+    description: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.',
+    features: ['Smooth scrambled eggs', 'Vegetarian sausage', 'Fruit syrups'],
+    title: 'Mapbox SDK for Breakfast',
+    version: '0.1.0',
+    background: 'bg-gray-dark',
+    tag: 'beta',
+    lightText: true,
+    changelogLink: 'https://keepachangelog.com/en/0.3.0/',
+    installLink: 'https://www.mapbox.com/install',
+    ghLink: 'https://github.com/mapbox',
+    contactLink: 'https://www.mapbox.com/contact/',
     image: (
       <img src="https://farm2.staticflickr.com/1790/29050447978_41e671dcd5_o.jpg" />
     )

--- a/src/components/overview-header/examples/custom.js
+++ b/src/components/overview-header/examples/custom.js
@@ -1,0 +1,21 @@
+/*
+Change background and text with `background` and `lightText`.
+*/
+import React from 'react';
+import OverviewHeader from '../overview-header';
+
+export default class Custom extends React.Component {
+  render() {
+    return (
+      <OverviewHeader
+        title="How Mapbox Works"
+        description="Learn about the building blocks that Mapbox provides so you can create custom mapping applications."
+        background="bg-blue"
+        lightText={true}
+        image={
+          <img src="https://farm2.staticflickr.com/1790/29050447978_41e671dcd5_o.jpg" />
+        }
+      />
+    );
+  }
+}

--- a/src/components/overview-header/examples/custom.js
+++ b/src/components/overview-header/examples/custom.js
@@ -1,5 +1,5 @@
 /*
-Change background and text with `background` and `lightText`.
+Change background color and text with `theme` and `lightText`.
 */
 import React from 'react';
 import OverviewHeader from '../overview-header';

--- a/src/components/overview-header/examples/custom.js
+++ b/src/components/overview-header/examples/custom.js
@@ -10,7 +10,7 @@ export default class Custom extends React.Component {
       <OverviewHeader
         title="How Mapbox Works"
         description="Learn about the building blocks that Mapbox provides so you can create custom mapping applications."
-        background="bg-blue"
+        theme="bg-blue"
         lightText={true}
         image={
           <img src="https://farm2.staticflickr.com/1790/29050447978_41e671dcd5_o.jpg" />

--- a/src/components/overview-header/overview-header.js
+++ b/src/components/overview-header/overview-header.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Icon from '@mapbox/mr-ui/icon';
+import classnames from 'classnames';
 import Tag from '../tag/tag';
 
 class OverviewHeader extends React.PureComponent {
@@ -14,7 +15,14 @@ class OverviewHeader extends React.PureComponent {
     );
 
     const changelogLinkEl = props.changelogLink && (
-      <a href={props.changelogLink}>View changelog</a>
+      <a
+        className={classnames('unprose link txt-underline', {
+          'link--white': props.lightText
+        })}
+        href={props.changelogLink}
+      >
+        View changelog
+      </a>
     );
 
     if (!versionEl && !changelogLinkEl) {
@@ -32,17 +40,24 @@ class OverviewHeader extends React.PureComponent {
   renderFooter() {
     const { props } = this;
 
+    const btnClasses = classnames('btn txt-l round inline-block unprose mr24', {
+      'btn--white color-gray-dark': props.lightText,
+      'btn--blue': !props.lightText
+    });
+
     const installLinkEl = props.installLink && (
-      <a
-        href={props.installLink}
-        className="btn txt-l round inline-block color-white unprose mr24"
-      >
+      <a href={props.installLink} className={btnClasses}>
         Install
       </a>
     );
 
     const ghLinkEl = props.ghLink && (
-      <a href={props.ghLink} className="inline-block unprose link">
+      <a
+        href={props.ghLink}
+        className={classnames('inline-block unprose link', {
+          'link--white': props.lightText
+        })}
+      >
         <span className="flex-parent flex-parent--center-cross">
           <span className="flex-child mr6">
             <Icon name="github" inline={true} />
@@ -53,10 +68,7 @@ class OverviewHeader extends React.PureComponent {
     );
 
     const contactLinkEl = props.contactLink && (
-      <a
-        href={props.contactLink}
-        className="btn txt-l round inline-block color-white unprose mr24"
-      >
+      <a href={props.contactLink} className={btnClasses}>
         Contact us
       </a>
     );
@@ -90,33 +102,48 @@ class OverviewHeader extends React.PureComponent {
   render() {
     const { props } = this;
 
-    const featuresList = props.features.map((feature, index) => {
-      return (
-        <li key={index} className="ml-neg24 flex-parent">
-          <div className="flex-child flex-child--no-shrink mr6 m3 color-gray-light">
-            <Icon name="check" inline={true} />
-          </div>
-          <div className="flex-child flex-child--grow">{feature}</div>
-        </li>
-      );
-    });
+    const featuresList = props.features
+      ? props.features.map((feature, index) => {
+          return (
+            <li key={index} className="ml-neg24 flex-parent">
+              <div className="flex-child flex-child--no-shrink mr6 m3 color-gray-light">
+                <Icon name="check" inline={true} />
+              </div>
+              <div className="flex-child flex-child--grow">{feature}</div>
+            </li>
+          );
+        })
+      : undefined;
 
     return (
-      <div className="dr-ui--overview-header border-b border--darken10 prose mb24 pr60-mxl">
+      <div
+        className={classnames(
+          `dr-ui--overview-header prose mb24 pr60-mxl ${props.background}`,
+          {
+            'border-b border--darken10': !props.background,
+            'round py12 px24': props.background,
+            'color-white': props.lightText
+          }
+        )}
+      >
         <div className="flex-parent">
           <div className="flex-child flex-child--grow">
             <h1 className="mb6 txt-fancy">
               {props.title}
               {props.tag && this.buildTag(props)}
             </h1>
+            {props.description && <p className="txt-l">{props.description}</p>}
             {this.renderVersion()}
-            <ul className="mb24" style={{ listStyle: 'none' }}>
-              {featuresList}
-            </ul>
+
+            {featuresList && (
+              <ul className="mb24" style={{ listStyle: 'none' }}>
+                {featuresList}
+              </ul>
+            )}
             {this.renderFooter()}
           </div>
           {props.image && (
-            <div className="flex-child-ml flex-child--no-shrink w300-mxl">
+            <div className="flex-child-ml flex-child--no-shrink w300-mxl align-r">
               <div className="none block-mxl">{props.image}</div>
             </div>
           )}
@@ -126,9 +153,15 @@ class OverviewHeader extends React.PureComponent {
   }
 }
 
+OverviewHeader.defaultProps = {
+  lightText: false
+};
+
 OverviewHeader.propTypes = {
   /** features of the product */
-  features: PropTypes.arrayOf(PropTypes.string).isRequired,
+  features: PropTypes.arrayOf(PropTypes.string),
+  /** description of the product */
+  description: PropTypes.string,
   /** title of the product */
   title: PropTypes.string.isRequired,
   tag: PropTypes.oneOf(['legacy', 'beta', 'fundamentals', 'new', 'custom']),
@@ -153,7 +186,11 @@ OverviewHeader.propTypes = {
   /** creates a "Contribute on GitHub" link */
   ghLink: PropTypes.string,
   /** creates a "Contact us" button */
-  contactLink: PropTypes.string
+  contactLink: PropTypes.string,
+  /** An Assembly background class (or other background class in your site's stylesheet): https://labs.mapbox.com/assembly/documentation/#Background-colors */
+  background: PropTypes.string,
+  /** If `true`, the component will use white text */
+  lightText: PropTypes.bool
 };
 
 export default OverviewHeader;

--- a/src/components/overview-header/overview-header.js
+++ b/src/components/overview-header/overview-header.js
@@ -118,10 +118,10 @@ class OverviewHeader extends React.PureComponent {
     return (
       <div
         className={classnames(
-          `dr-ui--overview-header prose mb24 pr60-mxl ${props.background}`,
+          `dr-ui--overview-header prose mb24 pr60-mxl ${props.theme}`,
           {
-            'border-b border--darken10': !props.background,
-            'round py12 px24': props.background,
+            'border-b border--darken10': !props.theme,
+            'round py12 px24': props.theme,
             'color-white': props.lightText
           }
         )}
@@ -187,8 +187,8 @@ OverviewHeader.propTypes = {
   ghLink: PropTypes.string,
   /** creates a "Contact us" button */
   contactLink: PropTypes.string,
-  /** An Assembly background class (or other background class in your site's stylesheet): https://labs.mapbox.com/assembly/documentation/#Background-colors */
-  background: PropTypes.string,
+  /** Classes to apply to the OverviewHeader containter, usually an Assembly backgroun color: https://labs.mapbox.com/assembly/documentation/#Background-colors */
+  theme: PropTypes.string,
   /** If `true`, the component will use white text */
   lightText: PropTypes.bool
 };

--- a/src/components/overview-header/overview-header.js
+++ b/src/components/overview-header/overview-header.js
@@ -187,7 +187,7 @@ OverviewHeader.propTypes = {
   ghLink: PropTypes.string,
   /** creates a "Contact us" button */
   contactLink: PropTypes.string,
-  /** Classes to apply to the OverviewHeader containter, usually an Assembly backgroun color: https://labs.mapbox.com/assembly/documentation/#Background-colors */
+  /** Classes to apply to the OverviewHeader containter, usually an Assembly background color: https://labs.mapbox.com/assembly/documentation/#Background-colors */
   theme: PropTypes.string,
   /** If `true`, the component will use white text */
   lightText: PropTypes.bool

--- a/src/components/page-layout/components/content.js
+++ b/src/components/page-layout/components/content.js
@@ -100,9 +100,12 @@ export class ContentWrapper extends React.Component {
       ? !hideFeedback
       : !layoutConfig.hideFeedback;
 
+    // do not show h1 if `hideTitle: true` or `overviewHeader` is enabled
+    const showTitle = !hideTitle && !overviewHeader;
+
     return (
       <div id="docs-content">
-        {!hideTitle && (
+        {showTitle && (
           <div
             className={classnames('col prose', {
               'col--8-mxl col--12': layoutConfig.aside !== 'none'

--- a/src/helpers/batfish/__tests__/fixtures/data.json
+++ b/src/helpers/batfish/__tests__/fixtures/data.json
@@ -15,7 +15,6 @@
         "layout": "page",
         "contentType": "reference",
         "products": ["Documentation"],
-        "hideTitle": true,
         "unProse": true,
         "prependJs": [
           "import Note from '../../../../src/components/note'",
@@ -29,7 +28,8 @@
           ],
           "changelogLink": "/dr-ui/changelog/",
           "installLink": "https://github.com/mapbox/dr-ui/blob/main/README.md",
-          "ghLink": "https://github.com/mapbox/dr-ui"
+          "ghLink": "https://github.com/mapbox/dr-ui",
+          "background": "bg-purple-faint"
         }
       }
     },

--- a/src/helpers/batfish/__tests__/fixtures/data.json
+++ b/src/helpers/batfish/__tests__/fixtures/data.json
@@ -29,7 +29,7 @@
           "changelogLink": "/dr-ui/changelog/",
           "installLink": "https://github.com/mapbox/dr-ui/blob/main/README.md",
           "ghLink": "https://github.com/mapbox/dr-ui",
-          "background": "bg-purple-faint"
+          "theme": "bg-purple-faint"
         }
       }
     },


### PR DESCRIPTION
This PR adds theming options to `OverviewHeader`:

- Adds `theme` prop that accepts CSS classes (usually an assembly background class).
- Adds `lightText` prop, when `true` the text color of the component will switch to white.
- Adds `description` prop to display a text description for the page.
- Makes `features` prop optional.
- In `PageLayout`, if `overviewHeader` is defined, then the title of the page (h1) will automatically not show. Previously, you had to set `hideTitle: true` in the page's frontMatter to prevent double headings from appearing.

![image](https://user-images.githubusercontent.com/2180540/98992518-4b152400-24fb-11eb-9265-d1eb8801c824.png)


## How to test

- Observe the catalog page home page: /dr-ui/components/
- Observe the Overview header test cases page

## QA checklist

<!-- complete this checklist when adding a new component or package -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.
- [x] Create a PR in a site repo, copy the component, and test it. Push to staging and let the reviewer know they can also test the component there.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] IE11, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.
