### PR TITLE
[Info arch] Allow children to appear at the top of example index pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Add `small` prop and variant to `Tag`.
 - Remove truncation on `ProductMenu` and moves tag above the title.
 - Replace bottom `Feedback` component on examples pages with an `Aside`.
+- Allow passing children to the `ExamplesIndex` component.
 - Add theming options to `OverviewHeader`: `theme` to accept CSS classes to customize the container, `lightText` to enable white text, `description` to add a text description. The `features` prop is now optional.
 
 ## 1.3.0

--- a/docs/src/pages/examples/index.md
+++ b/docs/src/pages/examples/index.md
@@ -9,3 +9,5 @@ layout: example
 products:
   - Documentation
 ---
+
+This page demonstrates how an `ExampleIndex` might look.

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -332,172 +332,168 @@ Array [
             <div
               className="col prose"
             >
-              <div
-                className=""
-              >
-                <div>
+              <div>
+                <div
+                  className="grid grid--gut36"
+                >
                   <div
-                    className="grid grid--gut36"
+                    className="mb18 col col--12 col--6-ml"
                   >
-                    <div
-                      className="mb18 col col--12 col--6-ml"
+                    <a
+                      className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
+                      href="/PageLayout/example-1/"
                     >
-                      <a
-                        className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
-                        href="/PageLayout/example-1/"
+                      <div
+                        className="relative h120 mb6"
                       >
+                        <div />
+                      </div>
+                      <div>
                         <div
-                          className="relative h120 mb6"
+                          className="mb6"
                         >
-                          <div />
-                        </div>
-                        <div>
+                          
                           <div
-                            className="mb6"
+                            className="inline-block color-gray txt-s txt-bold"
                           >
-                            
-                            <div
-                              className="inline-block color-gray txt-s txt-bold"
-                            >
-                              <svg
-                                className="events-none icon inline-block align-t"
-                                focusable="false"
-                                role="presentation"
-                                style={
-                                  Object {
-                                    "height": 18,
-                                    "width": 18,
-                                  }
+                            <svg
+                              className="events-none icon inline-block align-t"
+                              focusable="false"
+                              role="presentation"
+                              style={
+                                Object {
+                                  "height": 18,
+                                  "width": 18,
                                 }
-                              >
-                                <use
-                                  xlinkHref="#icon-code"
-                                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                                />
-                              </svg>
-                               
-                              JavaScript
-                            </div>
-                          </div>
-                          <div
-                            className="mb6"
-                          >
-                            Example 1
-                          </div>
-                          <div
-                            className="color-gray color-gray-on-hover"
-                          >
-                            Replace me.
+                              }
+                            >
+                              <use
+                                xlinkHref="#icon-code"
+                                xmlnsXlink="http://www.w3.org/1999/xlink"
+                              />
+                            </svg>
+                             
+                            JavaScript
                           </div>
                         </div>
-                      </a>
-                    </div>
-                    <div
-                      className="mb18 col col--12 col--6-ml"
+                        <div
+                          className="mb6"
+                        >
+                          Example 1
+                        </div>
+                        <div
+                          className="color-gray color-gray-on-hover"
+                        >
+                          Replace me.
+                        </div>
+                      </div>
+                    </a>
+                  </div>
+                  <div
+                    className="mb18 col col--12 col--6-ml"
+                  >
+                    <a
+                      className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
+                      href="/PageLayout/example-2/"
                     >
-                      <a
-                        className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
-                        href="/PageLayout/example-2/"
+                      <div
+                        className="relative h120 mb6"
                       >
+                        <div />
+                      </div>
+                      <div>
                         <div
-                          className="relative h120 mb6"
+                          className="mb6"
                         >
-                          <div />
-                        </div>
-                        <div>
+                          
                           <div
-                            className="mb6"
+                            className="inline-block color-gray txt-s txt-bold"
                           >
-                            
-                            <div
-                              className="inline-block color-gray txt-s txt-bold"
-                            >
-                              <svg
-                                className="events-none icon inline-block align-t"
-                                focusable="false"
-                                role="presentation"
-                                style={
-                                  Object {
-                                    "height": 18,
-                                    "width": 18,
-                                  }
+                            <svg
+                              className="events-none icon inline-block align-t"
+                              focusable="false"
+                              role="presentation"
+                              style={
+                                Object {
+                                  "height": 18,
+                                  "width": 18,
                                 }
-                              >
-                                <use
-                                  xlinkHref="#icon-code"
-                                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                                />
-                              </svg>
-                               
-                              JavaScript
-                            </div>
-                          </div>
-                          <div
-                            className="mb6"
-                          >
-                            Example 2
-                          </div>
-                          <div
-                            className="color-gray color-gray-on-hover"
-                          >
-                            Replace me.
+                              }
+                            >
+                              <use
+                                xlinkHref="#icon-code"
+                                xmlnsXlink="http://www.w3.org/1999/xlink"
+                              />
+                            </svg>
+                             
+                            JavaScript
                           </div>
                         </div>
-                      </a>
-                    </div>
-                    <div
-                      className="mb18 col col--12 col--6-ml"
+                        <div
+                          className="mb6"
+                        >
+                          Example 2
+                        </div>
+                        <div
+                          className="color-gray color-gray-on-hover"
+                        >
+                          Replace me.
+                        </div>
+                      </div>
+                    </a>
+                  </div>
+                  <div
+                    className="mb18 col col--12 col--6-ml"
+                  >
+                    <a
+                      className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
+                      href="/PageLayout/example-3/"
                     >
-                      <a
-                        className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
-                        href="/PageLayout/example-3/"
+                      <div
+                        className="relative h120 mb6"
                       >
+                        <div />
+                      </div>
+                      <div>
                         <div
-                          className="relative h120 mb6"
+                          className="mb6"
                         >
-                          <div />
-                        </div>
-                        <div>
+                          
                           <div
-                            className="mb6"
+                            className="inline-block color-gray txt-s txt-bold"
                           >
-                            
-                            <div
-                              className="inline-block color-gray txt-s txt-bold"
-                            >
-                              <svg
-                                className="events-none icon inline-block align-t"
-                                focusable="false"
-                                role="presentation"
-                                style={
-                                  Object {
-                                    "height": 18,
-                                    "width": 18,
-                                  }
+                            <svg
+                              className="events-none icon inline-block align-t"
+                              focusable="false"
+                              role="presentation"
+                              style={
+                                Object {
+                                  "height": 18,
+                                  "width": 18,
                                 }
-                              >
-                                <use
-                                  xlinkHref="#icon-code"
-                                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                                />
-                              </svg>
-                               
-                              JavaScript
-                            </div>
-                          </div>
-                          <div
-                            className="mb6"
-                          >
-                            Example 3
-                          </div>
-                          <div
-                            className="color-gray color-gray-on-hover"
-                          >
-                            Replace me.
+                              }
+                            >
+                              <use
+                                xlinkHref="#icon-code"
+                                xmlnsXlink="http://www.w3.org/1999/xlink"
+                              />
+                            </svg>
+                             
+                            JavaScript
                           </div>
                         </div>
-                      </a>
-                    </div>
+                        <div
+                          className="mb6"
+                        >
+                          Example 3
+                        </div>
+                        <div
+                          className="color-gray color-gray-on-hover"
+                        >
+                          Replace me.
+                        </div>
+                      </div>
+                    </a>
                   </div>
                 </div>
               </div>

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -332,168 +332,172 @@ Array [
             <div
               className="col prose"
             >
-              <div>
-                <div
-                  className="grid grid--gut36"
-                >
+              <div
+                className=""
+              >
+                <div>
                   <div
-                    className="mb18 col col--12 col--6-ml"
+                    className="grid grid--gut36"
                   >
-                    <a
-                      className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
-                      href="/PageLayout/example-1/"
+                    <div
+                      className="mb18 col col--12 col--6-ml"
                     >
-                      <div
-                        className="relative h120 mb6"
+                      <a
+                        className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
+                        href="/PageLayout/example-1/"
                       >
-                        <div />
-                      </div>
-                      <div>
                         <div
-                          className="mb6"
+                          className="relative h120 mb6"
                         >
-                          
+                          <div />
+                        </div>
+                        <div>
                           <div
-                            className="inline-block color-gray txt-s txt-bold"
+                            className="mb6"
                           >
-                            <svg
-                              className="events-none icon inline-block align-t"
-                              focusable="false"
-                              role="presentation"
-                              style={
-                                Object {
-                                  "height": 18,
-                                  "width": 18,
-                                }
-                              }
+                            
+                            <div
+                              className="inline-block color-gray txt-s txt-bold"
                             >
-                              <use
-                                xlinkHref="#icon-code"
-                                xmlnsXlink="http://www.w3.org/1999/xlink"
-                              />
-                            </svg>
-                             
-                            JavaScript
+                              <svg
+                                className="events-none icon inline-block align-t"
+                                focusable="false"
+                                role="presentation"
+                                style={
+                                  Object {
+                                    "height": 18,
+                                    "width": 18,
+                                  }
+                                }
+                              >
+                                <use
+                                  xlinkHref="#icon-code"
+                                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                                />
+                              </svg>
+                               
+                              JavaScript
+                            </div>
+                          </div>
+                          <div
+                            className="mb6"
+                          >
+                            Example 1
+                          </div>
+                          <div
+                            className="color-gray color-gray-on-hover"
+                          >
+                            Replace me.
                           </div>
                         </div>
-                        <div
-                          className="mb6"
-                        >
-                          Example 1
-                        </div>
-                        <div
-                          className="color-gray color-gray-on-hover"
-                        >
-                          Replace me.
-                        </div>
-                      </div>
-                    </a>
-                  </div>
-                  <div
-                    className="mb18 col col--12 col--6-ml"
-                  >
-                    <a
-                      className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
-                      href="/PageLayout/example-2/"
+                      </a>
+                    </div>
+                    <div
+                      className="mb18 col col--12 col--6-ml"
                     >
-                      <div
-                        className="relative h120 mb6"
+                      <a
+                        className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
+                        href="/PageLayout/example-2/"
                       >
-                        <div />
-                      </div>
-                      <div>
                         <div
-                          className="mb6"
+                          className="relative h120 mb6"
                         >
-                          
+                          <div />
+                        </div>
+                        <div>
                           <div
-                            className="inline-block color-gray txt-s txt-bold"
+                            className="mb6"
                           >
-                            <svg
-                              className="events-none icon inline-block align-t"
-                              focusable="false"
-                              role="presentation"
-                              style={
-                                Object {
-                                  "height": 18,
-                                  "width": 18,
-                                }
-                              }
+                            
+                            <div
+                              className="inline-block color-gray txt-s txt-bold"
                             >
-                              <use
-                                xlinkHref="#icon-code"
-                                xmlnsXlink="http://www.w3.org/1999/xlink"
-                              />
-                            </svg>
-                             
-                            JavaScript
+                              <svg
+                                className="events-none icon inline-block align-t"
+                                focusable="false"
+                                role="presentation"
+                                style={
+                                  Object {
+                                    "height": 18,
+                                    "width": 18,
+                                  }
+                                }
+                              >
+                                <use
+                                  xlinkHref="#icon-code"
+                                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                                />
+                              </svg>
+                               
+                              JavaScript
+                            </div>
+                          </div>
+                          <div
+                            className="mb6"
+                          >
+                            Example 2
+                          </div>
+                          <div
+                            className="color-gray color-gray-on-hover"
+                          >
+                            Replace me.
                           </div>
                         </div>
-                        <div
-                          className="mb6"
-                        >
-                          Example 2
-                        </div>
-                        <div
-                          className="color-gray color-gray-on-hover"
-                        >
-                          Replace me.
-                        </div>
-                      </div>
-                    </a>
-                  </div>
-                  <div
-                    className="mb18 col col--12 col--6-ml"
-                  >
-                    <a
-                      className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
-                      href="/PageLayout/example-3/"
+                      </a>
+                    </div>
+                    <div
+                      className="mb18 col col--12 col--6-ml"
                     >
-                      <div
-                        className="relative h120 mb6"
+                      <a
+                        className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
+                        href="/PageLayout/example-3/"
                       >
-                        <div />
-                      </div>
-                      <div>
                         <div
-                          className="mb6"
+                          className="relative h120 mb6"
                         >
-                          
+                          <div />
+                        </div>
+                        <div>
                           <div
-                            className="inline-block color-gray txt-s txt-bold"
+                            className="mb6"
                           >
-                            <svg
-                              className="events-none icon inline-block align-t"
-                              focusable="false"
-                              role="presentation"
-                              style={
-                                Object {
-                                  "height": 18,
-                                  "width": 18,
-                                }
-                              }
+                            
+                            <div
+                              className="inline-block color-gray txt-s txt-bold"
                             >
-                              <use
-                                xlinkHref="#icon-code"
-                                xmlnsXlink="http://www.w3.org/1999/xlink"
-                              />
-                            </svg>
-                             
-                            JavaScript
+                              <svg
+                                className="events-none icon inline-block align-t"
+                                focusable="false"
+                                role="presentation"
+                                style={
+                                  Object {
+                                    "height": 18,
+                                    "width": 18,
+                                  }
+                                }
+                              >
+                                <use
+                                  xlinkHref="#icon-code"
+                                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                                />
+                              </svg>
+                               
+                              JavaScript
+                            </div>
+                          </div>
+                          <div
+                            className="mb6"
+                          >
+                            Example 3
+                          </div>
+                          <div
+                            className="color-gray color-gray-on-hover"
+                          >
+                            Replace me.
                           </div>
                         </div>
-                        <div
-                          className="mb6"
-                        >
-                          Example 3
-                        </div>
-                        <div
-                          className="color-gray color-gray-on-hover"
-                        >
-                          Replace me.
-                        </div>
-                      </div>
-                    </a>
+                      </a>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/src/components/page-layout/components/content.js
+++ b/src/components/page-layout/components/content.js
@@ -26,7 +26,9 @@ export default class Content extends React.Component {
         frontMatter={frontMatter}
         sectionPath={parentPath}
         AppropriateImage={AppropriateImage}
-      />
+      >
+        {children}
+      </ExampleIndex>
     ) : (
       <ContentWrapper {...this.props}>{children}</ContentWrapper>
     );

--- a/src/components/page-layout/components/example-index.js
+++ b/src/components/page-layout/components/example-index.js
@@ -272,60 +272,54 @@ export default class ExampleIndex extends React.PureComponent {
     const { topic, language, level, videos, product } = this.state;
     const showResultIndicator = topic || language || level || videos || product;
     const resultsLength = filteredPages.length;
-    const indexWrapperClasses = classnames({
-      mt18: children
-    });
     return (
       <ContentWrapper {...this.props} customAside={this.renderFilters()}>
-        {children}
-        <div className={indexWrapperClasses}>
-          {showResultIndicator && (
-            <div className="mb18">
-              <div className="inline-block mr12 color-gray">
-                {resultsLength === 0
-                  ? 'No results found.'
-                  : `Found ${resultsLength} result${
-                      resultsLength === 1 ? '' : 's'
-                    }.`}
-              </div>
-              <button
-                onClick={() => this.handleReset()}
-                className="btn btn--s btn--gray btn--stroke round"
-              >
-                Reset filters
-              </button>
+        {/* If the example index's jsxtreme is not empty, show it before the examples */}
+        {children && <div className="mb18">{children}</div>}
+        {showResultIndicator && (
+          <div className="mb18">
+            <div className="inline-block mr12 color-gray">
+              {resultsLength === 0
+                ? 'No results found.'
+                : `Found ${resultsLength} result${
+                    resultsLength === 1 ? '' : 's'
+                  }.`}
             </div>
-          )}
-          {resultsLength > 0 && (
-            <CardContainer
-              cardColSize={cardColSize}
-              fullWidthCards={fullWidthCards ? fullWidthCards : false} // default is false
-              cards={filteredPages.map((page) => (
-                <Card
-                  key={page.title}
-                  title={page.title}
-                  description={
-                    hideCardDescription ? undefined : page.description
-                  }
-                  path={page.path}
-                  thumbnail={
-                    page.thumbnail
-                      ? this.renderThumbnail(page.thumbnail, AppropriateImage)
-                      : undefined
-                  }
-                  level={page.level}
-                  language={
-                    hideCardLanguage
-                      ? undefined
-                      : page.language
-                      ? page.language.join(', ')
-                      : undefined
-                  }
-                />
-              ))}
-            />
-          )}
-        </div>
+            <button
+              onClick={() => this.handleReset()}
+              className="btn btn--s btn--gray btn--stroke round"
+            >
+              Reset filters
+            </button>
+          </div>
+        )}
+        {resultsLength > 0 && (
+          <CardContainer
+            cardColSize={cardColSize}
+            fullWidthCards={fullWidthCards ? fullWidthCards : false} // default is false
+            cards={filteredPages.map((page) => (
+              <Card
+                key={page.title}
+                title={page.title}
+                description={hideCardDescription ? undefined : page.description}
+                path={page.path}
+                thumbnail={
+                  page.thumbnail
+                    ? this.renderThumbnail(page.thumbnail, AppropriateImage)
+                    : undefined
+                }
+                level={page.level}
+                language={
+                  hideCardLanguage
+                    ? undefined
+                    : page.language
+                    ? page.language.join(', ')
+                    : undefined
+                }
+              />
+            ))}
+          />
+        )}
       </ContentWrapper>
     );
   }

--- a/src/components/page-layout/components/example-index.js
+++ b/src/components/page-layout/components/example-index.js
@@ -257,7 +257,7 @@ export default class ExampleIndex extends React.PureComponent {
   };
 
   render() {
-    const { frontMatter, AppropriateImage } = this.props;
+    const { frontMatter, AppropriateImage, children } = this.props;
     // set default filters
     if (!frontMatter.showFilters) frontMatter.showFilters = filterOptions;
 
@@ -272,52 +272,60 @@ export default class ExampleIndex extends React.PureComponent {
     const { topic, language, level, videos, product } = this.state;
     const showResultIndicator = topic || language || level || videos || product;
     const resultsLength = filteredPages.length;
+    const indexWrapperClasses = classnames({
+      mt18: children
+    });
     return (
       <ContentWrapper {...this.props} customAside={this.renderFilters()}>
-        {showResultIndicator && (
-          <div className="mb18">
-            <div className="inline-block mr12 color-gray">
-              {resultsLength === 0
-                ? 'No results found.'
-                : `Found ${resultsLength} result${
-                    resultsLength === 1 ? '' : 's'
-                  }.`}
+        {children}
+        <div className={indexWrapperClasses}>
+          {showResultIndicator && (
+            <div className="mb18">
+              <div className="inline-block mr12 color-gray">
+                {resultsLength === 0
+                  ? 'No results found.'
+                  : `Found ${resultsLength} result${
+                      resultsLength === 1 ? '' : 's'
+                    }.`}
+              </div>
+              <button
+                onClick={() => this.handleReset()}
+                className="btn btn--s btn--gray btn--stroke round"
+              >
+                Reset filters
+              </button>
             </div>
-            <button
-              onClick={() => this.handleReset()}
-              className="btn btn--s btn--gray btn--stroke round"
-            >
-              Reset filters
-            </button>
-          </div>
-        )}
-        {resultsLength > 0 && (
-          <CardContainer
-            cardColSize={cardColSize}
-            fullWidthCards={fullWidthCards ? fullWidthCards : false} // default is false
-            cards={filteredPages.map((page) => (
-              <Card
-                key={page.title}
-                title={page.title}
-                description={hideCardDescription ? undefined : page.description}
-                path={page.path}
-                thumbnail={
-                  page.thumbnail
-                    ? this.renderThumbnail(page.thumbnail, AppropriateImage)
-                    : undefined
-                }
-                level={page.level}
-                language={
-                  hideCardLanguage
-                    ? undefined
-                    : page.language
-                    ? page.language.join(', ')
-                    : undefined
-                }
-              />
-            ))}
-          />
-        )}
+          )}
+          {resultsLength > 0 && (
+            <CardContainer
+              cardColSize={cardColSize}
+              fullWidthCards={fullWidthCards ? fullWidthCards : false} // default is false
+              cards={filteredPages.map((page) => (
+                <Card
+                  key={page.title}
+                  title={page.title}
+                  description={
+                    hideCardDescription ? undefined : page.description
+                  }
+                  path={page.path}
+                  thumbnail={
+                    page.thumbnail
+                      ? this.renderThumbnail(page.thumbnail, AppropriateImage)
+                      : undefined
+                  }
+                  level={page.level}
+                  language={
+                    hideCardLanguage
+                      ? undefined
+                      : page.language
+                      ? page.language.join(', ')
+                      : undefined
+                  }
+                />
+              ))}
+            />
+          )}
+        </div>
       </ContentWrapper>
     );
   }
@@ -343,6 +351,7 @@ ExampleIndex.propTypes = {
       })
     ).isRequired
   }),
+  children: PropTypes.node,
   frontMatter: PropTypes.shape({
     title: PropTypes.string.isRequired,
     description: PropTypes.string.isRequired,


### PR DESCRIPTION
This PR allows contributors to place normal jsxtreme content in their examples index files. That content will be rendered above the examples content.

## How to test

Check out the examples index in this repo's docs site! 

<img width="1070" alt="image" src="https://user-images.githubusercontent.com/2365503/99123612-2043d200-25c6-11eb-8ecc-c27d70ea65e4.png">
