### PR TITLE
[info arch] Fix Breadcrumb padding

### DIFF
--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -146,7 +146,7 @@ Array [
         className="flex-child flex-child--grow"
       >
         <div
-          className="dr-ui--breadcrumb py12 none block-mm"
+          className="dr-ui--breadcrumb pt3 pb12 none block-mm"
           data-swiftype-index="false"
         >
           <span
@@ -692,7 +692,7 @@ Array [
         className="flex-child flex-child--grow"
       >
         <div
-          className="dr-ui--breadcrumb py12 none block-mm"
+          className="dr-ui--breadcrumb pt3 pb12 none block-mm"
           data-swiftype-index="false"
         >
           <span
@@ -972,7 +972,7 @@ Array [
         className="flex-child flex-child--grow"
       >
         <div
-          className="dr-ui--breadcrumb py12"
+          className="dr-ui--breadcrumb pt3 pb12"
           data-swiftype-index="false"
         >
           <span
@@ -1308,7 +1308,7 @@ Array [
         className="flex-child flex-child--grow"
       >
         <div
-          className="dr-ui--breadcrumb py12 none block-mm"
+          className="dr-ui--breadcrumb pt3 pb12 none block-mm"
           data-swiftype-index="false"
         >
           <span
@@ -1711,7 +1711,7 @@ Array [
         className="flex-child flex-child--grow"
       >
         <div
-          className="dr-ui--breadcrumb py12 none block-mm"
+          className="dr-ui--breadcrumb pt3 pb12 none block-mm"
           data-swiftype-index="false"
         >
           <span

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -73,7 +73,7 @@ export default class PageLayout extends React.Component {
       <div className="flex-child flex-child--grow">
         {!frontMatter.hideBreadcrumbs && (
           <Breadcrumb
-            themeWrapper={classnames('py12', {
+            themeWrapper={classnames('pt3 pb12', {
               // hide breadcrumbs on mobile if sidebar is on the page
               // show breadcrumbs on mobile if sidebar is hidden from the page
               'none block-mm': !frontMatter.hideSidebar


### PR DESCRIPTION
This PR fixes the padding on the Breadcrumb component in PageLayout to better align with ProductMenu:

Stage | Image
---|---
Current |![image](https://user-images.githubusercontent.com/2180540/99431977-889df680-28d9-11eb-899c-791c7bcf80a0.png)
Proposed | ![image](https://user-images.githubusercontent.com/2180540/99431922-76bc5380-28d9-11eb-9b53-9c431ab2f857.png)


## How to test

Visit /PageLayout test cases to make sure ProductMenu and Breadcrumb are aligned.

