### PR TITLE
[info arch] Improve filter and showFilters handling

### DIFF
--- a/src/components/page-layout/__tests__/page-layout-test-cases.js
+++ b/src/components/page-layout/__tests__/page-layout-test-cases.js
@@ -27,6 +27,107 @@ testCases.examplePage = {
   element: <ExamplePage />
 };
 
+testCases.examplePageFilters = {
+  description:
+    'Example page layout, does not show filters because "showFilters" sets only "topics" and "topics" has one option.',
+  element: (
+    <PageLayout
+      constants={{
+        SITE: 'dr-ui',
+        BASEURL: '/dr-ui',
+        FORWARD_EVENT_WEBHOOK: {
+          production: '123',
+          staging: '123'
+        }
+      }}
+      location={{
+        pathname: '/PageLayout/examples/'
+      }}
+      frontMatter={{
+        title: 'Examples',
+        layout: 'exampleIndex',
+        description: 'Lots of handy examples.',
+        fullWidthCards: true,
+        showFilters: ['topics']
+      }}
+      navigation={{
+        hierarchy: {
+          '/PageLayout/examples/': {
+            parent: '/PageLayout/examples/',
+            title: 'Examples'
+          }
+        },
+        navTabs: [
+          {
+            path: '/PageLayout/',
+            title: 'Overview',
+            id: 'overview'
+          },
+          {
+            path: '/PageLayout/examples/',
+            title: 'Examples',
+            id: 'examples'
+          }
+        ]
+      }}
+      filters={{
+        '/PageLayout/examples/': {
+          contentType: 'example',
+          description: 'Replace me.',
+          layout: 'example',
+          navOrder: 3,
+          path: '/PageLayout/',
+          title: 'Examples',
+          topics: ['Getting started'],
+          languages: ['Java', 'JavaScript'],
+          products: ['Documentation', 'Mapbox GL JS'],
+          pages: [
+            {
+              contentType: 'example',
+              description: 'Replace me.',
+              language: ['JavaScript'],
+              layout: 'example',
+              path: '/PageLayout/example-1/',
+              text: 'Example 1',
+              thumbnail: 'header-image',
+              title: 'Example 1',
+              topics: ['Getting started'],
+              products: ['Documentation', 'Mapbox GL JS'],
+              url: '/PageLayout/example-1/'
+            },
+            {
+              contentType: 'example',
+              description: 'Replace me.',
+              language: ['JavaScript'],
+              layout: 'example',
+              path: '/PageLayout/example-2/',
+              text: 'Example 2',
+              thumbnail: 'header-image',
+              title: 'Example 2',
+              topics: ['Getting started'],
+              products: ['Documentation', 'Mapbox GL JS'],
+              url: '/PageLayout/example-2/'
+            },
+            {
+              contentType: 'example',
+              description: 'Replace me.',
+              language: ['Java'],
+              layout: 'example',
+              path: '/PageLayout/example-3/',
+              text: 'Example 3',
+              thumbnail: 'header-image',
+              title: 'Example 3',
+              topics: ['Getting started'],
+              products: ['Documentation', 'Mapbox GL JS'],
+              url: '/PageLayout/example-3/'
+            }
+          ]
+        }
+      }}
+    />
+  )
+};
+
 testCases.noSidebar = {
   description: 'No sidebar, show Breadcrumbs on mobile',
   element: (

--- a/src/components/page-layout/components/example-index.js
+++ b/src/components/page-layout/components/example-index.js
@@ -118,60 +118,83 @@ export default class ExampleIndex extends React.PureComponent {
     );
   };
 
+  // return true if array has more than one item
+  hasMoreThanOne = (arr, field) => arr[field] && arr[field].length > 1;
+
+  // return true if filter appears in showFilters array
+  inShowFilters = (field) =>
+    this.props.frontMatter.showFilters.indexOf(field) > -1;
+
+  // return true if filter can be displayed
+  filterisAvailable = (filters, field) =>
+    this.hasMoreThanOne(filters, field) && this.inShowFilters(field);
+
   // build filters
   renderFilters = () => {
     const { filters, frontMatter } = this.props;
     const { topic, language, level, videos, product } = this.state;
 
-    return frontMatter.showFilters.length > 0 ? (
+    // check each filter to make sure it has more than one option
+    // and that it appears in "showFilters"
+    const availableFilters = {
+      products: this.filterisAvailable(filters, 'products'),
+      topics: this.filterisAvailable(filters, 'topics'),
+      languages: this.filterisAvailable(filters, 'languages'),
+      levels: this.filterisAvailable(filters, 'levels'),
+      videos: filters.videos && this.inShowFilters('videos')
+    };
+
+    // remove any item from showFilters that is not true in "availableFilters"
+    if (frontMatter.showFilters) {
+      frontMatter.showFilters = frontMatter.showFilters.filter(
+        (filter) => availableFilters[filter]
+      );
+    }
+
+    // if showFilters length is 0, do not show filters
+    if (frontMatter.showFilters.length === 0) return null;
+
+    return (
       <div className="mb18 mb0-mxl">
         <AsideHeading>Filters</AsideHeading>
         <div className="grid grid--gut6">
-          {filters.products &&
-            filters.products.length > 1 &&
-            frontMatter.showFilters.indexOf('products') > -1 && (
-              <FilterSection
-                title="Products"
-                data={filters.products}
-                id="product"
-                activeItem={product}
-                handleInput={this.handleInput}
-              />
-            )}
-          {filters.topics &&
-            filters.topics.length > 1 &&
-            frontMatter.showFilters.indexOf('topics') > -1 && (
-              <FilterSection
-                title="Topics"
-                data={filters.topics}
-                id="topic"
-                activeItem={topic}
-                handleInput={this.handleInput}
-              />
-            )}
-          {filters.languages &&
-            filters.languages.length > 1 &&
-            frontMatter.showFilters.indexOf('languages') > -1 && (
-              <FilterSection
-                title="Languages"
-                data={filters.languages}
-                id="language"
-                activeItem={language}
-                handleInput={this.handleInput}
-              />
-            )}
-          {filters.levels &&
-            filters.levels.length > 1 &&
-            frontMatter.showFilters.indexOf('levels') > -1 && (
-              <FilterSection
-                title="Levels"
-                data={filters.levels}
-                id="level"
-                activeItem={level}
-                handleInput={this.handleInput}
-              />
-            )}
-          {filters.videos && frontMatter.showFilters.indexOf('videos') > -1 && (
+          {availableFilters.products && (
+            <FilterSection
+              title="Products"
+              data={filters.products}
+              id="product"
+              activeItem={product}
+              handleInput={this.handleInput}
+            />
+          )}
+          {availableFilters.topics && (
+            <FilterSection
+              title="Topics"
+              data={filters.topics}
+              id="topic"
+              activeItem={topic}
+              handleInput={this.handleInput}
+            />
+          )}
+          {availableFilters.languages && (
+            <FilterSection
+              title="Languages"
+              data={filters.languages}
+              id="language"
+              activeItem={language}
+              handleInput={this.handleInput}
+            />
+          )}
+          {availableFilters.levels && (
+            <FilterSection
+              title="Levels"
+              data={filters.levels}
+              id="level"
+              activeItem={level}
+              handleInput={this.handleInput}
+            />
+          )}
+          {availableFilters.videos && (
             <FilterSection
               title="Videos only"
               id="videos"
@@ -182,8 +205,6 @@ export default class ExampleIndex extends React.PureComponent {
           )}
         </div>
       </div>
-    ) : (
-      ''
     );
   };
 
@@ -353,7 +374,7 @@ ExampleIndex.propTypes = {
     hideCardDescription: PropTypes.bool,
     hideCardLanguage: PropTypes.bool,
     cardColSize: PropTypes.number,
-    showFilters: PropTypes.arrayOf(filterOptions)
+    showFilters: PropTypes.arrayOf(PropTypes.oneOf(filterOptions))
   }).isRequired,
   AppropriateImage: PropTypes.func
 };

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -193,7 +193,7 @@ PageLayout.propTypes = {
     hideBreadcrumbs: PropTypes.bool,
     hideSidebar: PropTypes.bool,
     title: PropTypes.string,
-    showFilters: PropTypes.arrayOf(filterOptions),
+    showFilters: PropTypes.arrayOf(PropTypes.oneOf(filterOptions)),
     onThisPage: PropTypes.bool
   }).isRequired,
   /**


### PR DESCRIPTION
This PR fixes an issue where on some pages where `showFilters` is defined in the frontmatter and those filters do not have more than one option, the "Filters" heading appears:

> ![image](https://user-images.githubusercontent.com/2180540/99436786-7d4dc980-28df-11eb-8035-9900d2d216be.png)

This PR cleans up the evaluation of each filter and then will remove an item from `showFilters` if it does not have more than one option. Also, fixes PropTypes `showFilter` as it was formatted incorrectly.


## How to test

Observe /PageLayout test case (`Example page layout, does not show filters because "showFilters" sets only "topics" and "topics" has one option.`)
