### PR TITLE
[info arch] Add "domain" prop to PageShell; remove old search-related props

### DIFF
--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -1719,9 +1719,9 @@ Array [
           >
             <a
               className="link"
-              href="https://docs.mapbox.com"
+              href="https://mapbox.github.io/dr-ui/"
             >
-              All docs
+              Documentation
             </a>
             <span
               className="color-gray-light inline-block-mm none px6"

--- a/src/components/page-layout/examples/full.js
+++ b/src/components/page-layout/examples/full.js
@@ -1,5 +1,5 @@
 /*
-"full" layout.
+"full" layout with custom "domain" prop
 */
 import React from 'react';
 import PageLayout from '../page-layout';
@@ -15,6 +15,10 @@ export default class Basic extends React.Component {
             production: '123',
             staging: '123'
           }
+        }}
+        domain={{
+          title: 'Documentation',
+          path: 'https://mapbox.github.io/dr-ui/'
         }}
         location={{
           pathname: '/PageLayout/'

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -240,7 +240,7 @@ PageLayout.propTypes = {
   headings: PropTypes.array,
   /** For `Feedback` component */
   feedbackSentryDsn: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-  /** */
+  /** The domain's title and homepage path to be added as the first Breadcrumb link */
   domain: PropTypes.shape({
     title: PropTypes.string.isRequired,
     path: PropTypes.string.isRequired

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -12,7 +12,6 @@ import classnames from 'classnames';
 // default configuration for each layout
 // every option can be overriden in the frontMatter
 import layoutConfig from './layout.config.js';
-import SiteSearchAPIConnector from '@elastic/search-ui-site-search-connector';
 
 export default class PageLayout extends React.Component {
   // render the page's sidebar
@@ -35,12 +34,9 @@ export default class PageLayout extends React.Component {
 
   // render the page's content
   renderContent = (config, parentPath, parent, hasSection) => {
-    const { constants, frontMatter, location } = this.props;
+    const { constants, frontMatter, location, domain } = this.props;
     const crumbs = createUniqueCrumbs([
-      {
-        title: 'All docs',
-        path: 'https://docs.mapbox.com'
-      },
+      domain,
       // if multi-structured show section name
       // if single-structured show site name
       ...(hasSection
@@ -146,6 +142,13 @@ export default class PageLayout extends React.Component {
   }
 }
 
+PageLayout.defaultProps = {
+  domain: {
+    title: 'All docs',
+    path: 'https://docs.mapbox.com'
+  }
+};
+
 PageLayout.propTypes = {
   children: PropTypes.node,
   /** Provided by Batfish, the `pathname` (relative url) of the current page is required */
@@ -235,10 +238,11 @@ PageLayout.propTypes = {
   AppropriateImage: PropTypes.func,
   /** For when headings are dynamic, this is used by API docs */
   headings: PropTypes.array,
-  /** For `Search` component */
-  placeholder: PropTypes.string,
-  /** For `Search` component */
-  connector: PropTypes.instanceOf(SiteSearchAPIConnector),
   /** For `Feedback` component */
-  feedbackSentryDsn: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
+  feedbackSentryDsn: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  /** */
+  domain: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    path: PropTypes.string.isRequired
+  })
 };


### PR DESCRIPTION
This PR adds a new `domain` prop to PageShell. The props accepts an object with `title` and `path` to allow you to customize the first item in the breadcrumb. This PR also removes unused search-related props.

## How to test

The "full layout" PageLayout test cases is now using the `domain` prop.