### PR TITLE
[info arch] IE 11 fixes: replace find with reduce, fix flex-child

### DIFF
--- a/docs/batfish.config.js
+++ b/docs/batfish.config.js
@@ -47,6 +47,7 @@ module.exports = () => {
         require('../src/plugins/make-table-scroll')
       ]
     },
+    devBrowserslist: false, // allow site to load on IE 11
     dataSelectors: {
       navigation: (data) => buildNavigation({ siteBasePath, data, addPages }),
       filters: (data) => buildFilters(data),

--- a/src/components/on-this-page/helpers.js
+++ b/src/components/on-this-page/helpers.js
@@ -45,10 +45,15 @@ export function getActiveHeaderAnchor(topOffset) {
   // if there are no found header anchors, return undefined
   if (!headersAnchors || headersAnchors.length === 0) return undefined;
 
-  const firstAnchorUnderViewportTop = headersAnchors.filter((anchor) => {
+  const anchorsUnderViewportTop = headersAnchors.filter((anchor) => {
     const { top } = anchor.getBoundingClientRect();
     if (top >= topOffset) return anchor;
-  })[0];
+  });
+
+  const firstAnchorUnderViewportTop =
+    anchorsUnderViewportTop && anchorsUnderViewportTop.length
+      ? anchorsUnderViewportTop[0]
+      : undefined;
 
   const lastAnchor = headersAnchors[headersAnchors.length - 1];
 

--- a/src/components/on-this-page/helpers.js
+++ b/src/components/on-this-page/helpers.js
@@ -45,10 +45,10 @@ export function getActiveHeaderAnchor(topOffset) {
   // if there are no found header anchors, return undefined
   if (!headersAnchors || headersAnchors.length === 0) return undefined;
 
-  const firstAnchorUnderViewportTop = headersAnchors.find((anchor) => {
+  const firstAnchorUnderViewportTop = headersAnchors.filter((anchor) => {
     const { top } = anchor.getBoundingClientRect();
-    return top >= topOffset;
-  });
+    if (top >= topOffset) return anchor;
+  })[0];
 
   const lastAnchor = headersAnchors[headersAnchors.length - 1];
 

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -13,6 +13,11 @@ Array [
     >
       <div
         className="flex-child flex-child--no-shrink w-full w180-mm w240-ml mr36-mm undefined"
+        style={
+          Object {
+            "width": "100%",
+          }
+        }
       >
         <div
           className="sticky-mm scroll-auto-mm scroll-styled viewport-almost-mm px12-mm"
@@ -144,6 +149,11 @@ Array [
       </div>
       <div
         className="flex-child flex-child--grow"
+        style={
+          Object {
+            "width": "100%",
+          }
+        }
       >
         <div
           className="dr-ui--breadcrumb py12 none block-mm"
@@ -559,6 +569,11 @@ Array [
     >
       <div
         className="flex-child flex-child--no-shrink w-full w180-mm w240-ml mr36-mm undefined"
+        style={
+          Object {
+            "width": "100%",
+          }
+        }
       >
         <div
           className="sticky-mm scroll-auto-mm scroll-styled viewport-almost-mm px12-mm"
@@ -690,6 +705,11 @@ Array [
       </div>
       <div
         className="flex-child flex-child--grow"
+        style={
+          Object {
+            "width": "100%",
+          }
+        }
       >
         <div
           className="dr-ui--breadcrumb py12 none block-mm"
@@ -970,6 +990,11 @@ Array [
     >
       <div
         className="flex-child flex-child--grow"
+        style={
+          Object {
+            "width": "100%",
+          }
+        }
       >
         <div
           className="dr-ui--breadcrumb py12"
@@ -1175,6 +1200,11 @@ Array [
     >
       <div
         className="flex-child flex-child--no-shrink w-full w180-mm w240-ml mr36-mm "
+        style={
+          Object {
+            "width": "100%",
+          }
+        }
       >
         <div
           className="sticky-mm scroll-auto-mm scroll-styled viewport-almost-mm px12-mm"
@@ -1306,6 +1336,11 @@ Array [
       </div>
       <div
         className="flex-child flex-child--grow"
+        style={
+          Object {
+            "width": "100%",
+          }
+        }
       >
         <div
           className="dr-ui--breadcrumb py12 none block-mm"
@@ -1617,6 +1652,11 @@ Array [
     >
       <div
         className="flex-child flex-child--no-shrink w-full w180-mm w240-ml mr36-mm undefined"
+        style={
+          Object {
+            "width": "100%",
+          }
+        }
       >
         <div
           className="sticky-mm scroll-auto-mm scroll-styled viewport-almost-mm px12-mm"
@@ -1709,6 +1749,11 @@ Array [
       </div>
       <div
         className="flex-child flex-child--grow"
+        style={
+          Object {
+            "width": "100%",
+          }
+        }
       >
         <div
           className="dr-ui--breadcrumb py12 none block-mm"

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -21,6 +21,7 @@ export default class PageLayout extends React.Component {
     return (
       <div
         className={`flex-child flex-child--no-shrink w-full w180-mm w240-ml mr36-mm ${config.sidebarTheme}`}
+        style={{ width: '100%' /* for ie 11 support */ }}
       >
         <Sidebar
           {...this.props}
@@ -70,7 +71,10 @@ export default class PageLayout extends React.Component {
       }
     ]);
     return (
-      <div className="flex-child flex-child--grow">
+      <div
+        className="flex-child flex-child--grow"
+        style={{ width: '100%' /* for ie 11 support */ }}
+      >
         {!frontMatter.hideBreadcrumbs && (
           <Breadcrumb
             themeWrapper={classnames('py12', {

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -14,6 +14,9 @@ import classnames from 'classnames';
 import layoutConfig from './layout.config.js';
 import SiteSearchAPIConnector from '@elastic/search-ui-site-search-connector';
 
+/* prevent flex-child from overflowing on IE 11 */
+const ie11FlexChild = { width: '100%' };
+
 export default class PageLayout extends React.Component {
   // render the page's sidebar
   renderSidebar = (config, switchedNavigation, parentPath) => {
@@ -21,7 +24,7 @@ export default class PageLayout extends React.Component {
     return (
       <div
         className={`flex-child flex-child--no-shrink w-full w180-mm w240-ml mr36-mm ${config.sidebarTheme}`}
-        style={{ width: '100%' /* for ie 11 support */ }}
+        style={ie11FlexChild}
       >
         <Sidebar
           {...this.props}
@@ -71,10 +74,7 @@ export default class PageLayout extends React.Component {
       }
     ]);
     return (
-      <div
-        className="flex-child flex-child--grow"
-        style={{ width: '100%' /* for ie 11 support */ }}
-      >
+      <div className="flex-child flex-child--grow" style={ie11FlexChild}>
         {!frontMatter.hideBreadcrumbs && (
           <Breadcrumb
             themeWrapper={classnames('py12', {

--- a/src/helpers/batfish/__tests__/fixtures/data.json
+++ b/src/helpers/batfish/__tests__/fixtures/data.json
@@ -261,6 +261,12 @@
       "filePath": "./docs/src/pages/index.js",
       "path": "/dr-ui/",
       "frontMatter": {}
+    },
+    {
+      "filePath": "./node_modules/@mapbox/batfish/dist/webpack/default-not-found.js",
+      "path": "/dr-ui/404/",
+      "is404": true,
+      "frontMatter": {}
     }
   ]
 }

--- a/src/helpers/batfish/__tests__/fixtures/data.json
+++ b/src/helpers/batfish/__tests__/fixtures/data.json
@@ -261,12 +261,6 @@
       "filePath": "./docs/src/pages/index.js",
       "path": "/dr-ui/",
       "frontMatter": {}
-    },
-    {
-      "filePath": "./node_modules/@mapbox/batfish/dist/webpack/default-not-found.js",
-      "path": "/dr-ui/404/",
-      "is404": true,
-      "frontMatter": {}
     }
   ]
 }


### PR DESCRIPTION
This PR;

- Replaces find with reduce (IE 11 does not support the find array method)
- Adds `width: 100%` to PageLayout `flex-child` elements to fix an IE 11 bug where content overflows.
- Fixes catalog site build in IE11 by adding `devBrowserslist: false,` to batfish.config.js

## How to test

Run catalog site `npm run start-docs` on IE 11 without errors.

## QA checklist

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] IE11, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.
