### PR TITLE
[Info arch] Adjust showfilters proptypes validation

### DIFF
--- a/src/components/page-layout/components/example-index.js
+++ b/src/components/page-layout/components/example-index.js
@@ -350,7 +350,7 @@ ExampleIndex.propTypes = {
     hideCardDescription: PropTypes.bool,
     hideCardLanguage: PropTypes.bool,
     cardColSize: PropTypes.number,
-    showFilters: PropTypes.arrayOf(filterOptions)
+    showFilters: PropTypes.arrayOf(PropTypes.oneOf(filterOptions))
   }).isRequired,
   AppropriateImage: PropTypes.func
 };

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -193,7 +193,7 @@ PageLayout.propTypes = {
     hideBreadcrumbs: PropTypes.bool,
     hideSidebar: PropTypes.bool,
     title: PropTypes.string,
-    showFilters: PropTypes.arrayOf(filterOptions),
+    showFilters: PropTypes.arrayOf(PropTypes.oneOf(filterOptions)),
     onThisPage: PropTypes.bool
   }).isRequired,
   /**


### PR DESCRIPTION
Fixes a small `propTypes` validation issue with `showFilters` frontmatter.

## How to test

Run the docs catalog site and check for console errors related to prop validation. Filters should also still work!

## QA checklist

- [x] No errors logged to console.
