### PR TITLE
[info arch] Increase limiter--wide at 800px min-width query

### DIFF
--- a/src/css/docs-prose.css
+++ b/src/css/docs-prose.css
@@ -4,6 +4,11 @@
     max-width: 1800px !important;
   }
 }
+@media screen and (min-width: 800px) {
+  .limiter--wide {
+    width: 91.666666666% !important; /* override limiter */
+  }
+}
 
 #docs-content .prose h1,
 #docs-content.prose h1 {


### PR DESCRIPTION
This PR overrides `.limiter--wide` width at the 800px min-width query to fill the page's width more. This will help give the page layout more space on smaller devices.

## How to test

Open the catalog page on a smaller monitor (1024 x 768). The `limiter-wide` class should have a width of `91.666666666%` (instead of `83.33333333%`)

## QA checklist

- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.
