### PR TITLE
[Info arch] Make Card description optional

### DIFF
--- a/src/components/card/__tests__/__snapshots__/card.test.js.snap
+++ b/src/components/card/__tests__/__snapshots__/card.test.js.snap
@@ -186,3 +186,98 @@ exports[`card Card with no image renders as expected 1`] = `
   </div>
 </a>
 `;
+
+exports[`card Card without description renders as expected 1`] = `
+<a
+  className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
+  href="url"
+>
+  <div
+    className="relative h120 mb6"
+  >
+    <div
+      className="relative h120 mb12"
+      style={
+        Object {
+          "backgroundImage": "url('./files/simple-map.png')",
+          "backgroundPosition": "center",
+          "backgroundSize": "100% auto",
+        }
+      }
+    />
+  </div>
+  <div>
+    <div
+      className="mb6"
+    >
+      <div
+        className="inline-block mr18 txt-s txt-bold"
+      >
+        <div
+          className="flex-parent flex-parent--center-cross"
+        >
+          <div
+            className="inline-block w6 bg-orange align-middle mr3"
+            style={
+              Object {
+                "borderRadius": "1px",
+                "height": "8px",
+              }
+            }
+          />
+          <div
+            className="inline-block w6 bg-orange align-middle mr3"
+            style={
+              Object {
+                "borderRadius": "1px",
+                "height": "8px",
+              }
+            }
+          />
+          <div
+            className="inline-block w6 bg-gray-light align-middle mr3"
+            style={
+              Object {
+                "borderRadius": "1px",
+                "height": "8px",
+              }
+            }
+          />
+          <div
+            className="inline-block color-orange ml3"
+          >
+            Intermediate
+          </div>
+        </div>
+      </div>
+      <div
+        className="inline-block color-gray txt-s txt-bold"
+      >
+        <svg
+          className="events-none icon inline-block align-t"
+          focusable="false"
+          role="presentation"
+          style={
+            Object {
+              "height": 18,
+              "width": 18,
+            }
+          }
+        >
+          <use
+            xlinkHref="#icon-code"
+            xmlnsXlink="http://www.w3.org/1999/xlink"
+          />
+        </svg>
+         
+        JavaScript
+      </div>
+    </div>
+    <div
+      className="mb6"
+    >
+      My cool card without a description
+    </div>
+  </div>
+</a>
+`;

--- a/src/components/card/__tests__/card-test-cases.js
+++ b/src/components/card/__tests__/card-test-cases.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Basic from '../examples/basic';
 import Custom from '../examples/custom';
+import NoDesc from '../examples/no-description';
 
 const testCases = {};
 const noRenderCases = {};
@@ -13,6 +14,11 @@ testCases.basic = {
 testCases.noImage = {
   description: 'Card with no image',
   element: <Custom />
+};
+
+testCases.noDescription = {
+  description: 'Card without description',
+  element: <NoDesc />
 };
 
 export { testCases, noRenderCases };

--- a/src/components/card/__tests__/card.test.js
+++ b/src/components/card/__tests__/card.test.js
@@ -18,6 +18,22 @@ describe('card', () => {
     });
   });
 
+  describe(testCases.noDescription.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.noDescription;
+      wrapper = renderer.create(testCase.element);
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
   describe(testCases.noImage.description, () => {
     let testCase;
     let wrapper;

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -56,7 +56,7 @@ class Card extends React.Component {
 Card.propTypes = {
   title: PropTypes.string.isRequired,
   path: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
+  description: PropTypes.string,
   thumbnail: PropTypes.node,
   level: PropTypes.node,
   language: PropTypes.string

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -5,33 +5,31 @@ import LevelIndicator from '../level-indicator/level-indicator';
 
 class Card extends React.Component {
   render() {
-    const { props } = this;
+    const { thumbnail, level, language, description, path, title } = this.props;
     let renderedThumbnail = '';
     let renderedLevel = '';
     let renderedLanguage = '';
-    if (props.thumbnail) {
-      renderedThumbnail = (
-        <div className="relative h120 mb6">{props.thumbnail}</div>
-      );
+    if (thumbnail) {
+      renderedThumbnail = <div className="relative h120 mb6">{thumbnail}</div>;
     }
-    if (props.level) {
+    if (level) {
       renderedLevel = (
         <div className="inline-block mr18 txt-s txt-bold">
-          <LevelIndicator level={props.level} />
+          <LevelIndicator level={level} />
         </div>
       );
     }
-    if (props.language) {
+    if (language) {
       renderedLanguage = (
         <div className="inline-block color-gray txt-s txt-bold">
-          <Icon name="code" inline={true} /> {props.language}
+          <Icon name="code" inline={true} /> {language}
         </div>
       );
     }
     return (
       <a
         className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
-        href={this.props.path}
+        href={path}
       >
         {renderedThumbnail}
         <div>
@@ -43,10 +41,10 @@ class Card extends React.Component {
           ) : (
             ''
           )}
-          <div className="mb6">{this.props.title}</div>
-          <div className="color-gray color-gray-on-hover">
-            {this.props.description}
-          </div>
+          <div className="mb6">{title}</div>
+          {description && (
+            <div className="color-gray color-gray-on-hover">{description}</div>
+          )}
         </div>
       </a>
     );

--- a/src/components/card/examples/no-description.js
+++ b/src/components/card/examples/no-description.js
@@ -1,0 +1,28 @@
+/*
+Basic.
+*/
+import React from 'react';
+import Card from '../card';
+
+export default class Basic extends React.Component {
+  render() {
+    return (
+      <Card
+        title="My cool card without a description"
+        path="url"
+        level={2}
+        language="JavaScript"
+        thumbnail={
+          <div
+            className="relative h120 mb12"
+            style={{
+              backgroundImage: "url('./files/simple-map.png')",
+              backgroundSize: '100% auto',
+              backgroundPosition: 'center'
+            }}
+          />
+        }
+      />
+    );
+  }
+}

--- a/src/components/card/examples/no-description.js
+++ b/src/components/card/examples/no-description.js
@@ -1,5 +1,5 @@
 /*
-Basic.
+No description.
 */
 import React from 'react';
 import Card from '../card';


### PR DESCRIPTION
For info-arch rollout, we need to display some cards without descriptions. In order for prop validation to pass, the `description` prop needs to be optional.

