### PR TITLE
[info arch] Add "search" filter to ExampleIndex

### DIFF
--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -281,6 +281,42 @@ Array [
                       >
                         <div>
                           <label
+                            className="inline-block txt-s txt-bold color-darken75"
+                            htmlFor="search"
+                          >
+                            Search
+                             
+                          </label>
+                        </div>
+                        <input
+                          aria-required={true}
+                          className="input input--s relative wmax180"
+                          data-test="search-input"
+                          id="search"
+                          name="search"
+                          onChange={[Function]}
+                          placeholder="Search title and description…"
+                          style={
+                            Object {
+                              "top": "2px",
+                            }
+                          }
+                          type="text"
+                          value=""
+                        />
+                        <div
+                          role="alert"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      className="col col--6 col--4-ml col--12-mxl mb6"
+                    >
+                      <div
+                        className="relative "
+                      >
+                        <div>
+                          <label
                             className="inline-block txt-s txt-bold color-darken75 w70"
                             htmlFor="topic"
                           >
@@ -379,12 +415,12 @@ Array [
                         <div
                           className="mb6"
                         >
-                          Example 1
+                          Display a map
                         </div>
                         <div
                           className="color-gray color-gray-on-hover"
                         >
-                          Replace me.
+                          Initialize a map in an HTML element with Mapbox GL JS.
                         </div>
                       </div>
                     </a>
@@ -432,12 +468,12 @@ Array [
                         <div
                           className="mb6"
                         >
-                          Example 2
+                          Add a default marker
                         </div>
                         <div
                           className="color-gray color-gray-on-hover"
                         >
-                          Replace me.
+                          Add a default Marker to the map.
                         </div>
                       </div>
                     </a>
@@ -485,12 +521,12 @@ Array [
                         <div
                           className="mb6"
                         >
-                          Example 3
+                          Extrude polygons for 3D indoor mapping
                         </div>
                         <div
                           className="color-gray color-gray-on-hover"
                         >
-                          Replace me.
+                          Create a 3D indoor map with the fill-extrude-height paint property.
                         </div>
                       </div>
                     </a>

--- a/src/components/page-layout/components/example-index.js
+++ b/src/components/page-layout/components/example-index.js
@@ -7,6 +7,7 @@ import { levels } from '../../level-indicator/level-indicator';
 import classnames from 'classnames';
 import ControlSwitch from '@mapbox/mr-ui/control-switch';
 import ControlSelect from '@mapbox/mr-ui/control-select';
+import ControlText from '@mapbox/mr-ui/control-text';
 import { ContentWrapper } from './content';
 
 // options of frontMatter.showFilters
@@ -14,8 +15,9 @@ export const filterOptions = [
   'products',
   'topics',
   'languages',
-  'levels',
-  'videos'
+  'level',
+  'videos',
+  'search'
 ];
 
 export default class ExampleIndex extends React.PureComponent {
@@ -26,7 +28,8 @@ export default class ExampleIndex extends React.PureComponent {
       language: undefined,
       level: undefined,
       videos: false,
-      product: undefined
+      product: undefined,
+      search: undefined
     };
   }
 
@@ -62,6 +65,9 @@ export default class ExampleIndex extends React.PureComponent {
           filters.levels,
           'level'
         );
+      }
+      if (query.get('search')) {
+        this.setState({ search: `${query.get('search')}` });
       }
       if (query.get('videos')) {
         this.setStateIfValid(query.get('videos') === 'true', [true], 'videos');
@@ -109,7 +115,8 @@ export default class ExampleIndex extends React.PureComponent {
         language: undefined,
         level: undefined,
         videos: false,
-        product: undefined
+        product: undefined,
+        search: undefined
       },
       () => {
         // remove all query params
@@ -121,12 +128,22 @@ export default class ExampleIndex extends React.PureComponent {
   // build filters
   renderFilters = () => {
     const { filters, frontMatter } = this.props;
-    const { topic, language, level, videos, product } = this.state;
+    const { topic, language, level, videos, product, search } = this.state;
 
     return frontMatter.showFilters.length > 0 ? (
       <div className="mb18 mb0-mxl">
         <AsideHeading>Filters</AsideHeading>
         <div className="grid grid--gut6">
+          {frontMatter.showFilters.indexOf('search') > -1 && (
+            <FilterSection
+              title="Search"
+              id="search"
+              activeItem={search}
+              handleInput={this.handleInput}
+              isText={true}
+              placeholder="Search title and description&hellip;"
+            />
+          )}
           {filters.products &&
             filters.products.length > 1 &&
             frontMatter.showFilters.indexOf('products') > -1 && (
@@ -222,7 +239,7 @@ export default class ExampleIndex extends React.PureComponent {
   // filter available pages based on active filters
   filterPages = () => {
     const { filters } = this.props;
-    const { topic, language, level, videos, product } = this.state;
+    const { topic, language, level, videos, product, search } = this.state;
 
     let filteredPages = filters.pages;
 
@@ -253,6 +270,16 @@ export default class ExampleIndex extends React.PureComponent {
     if (videos) {
       filteredPages = filteredPages.filter((f) => f.video);
     }
+
+    if (search) {
+      const trimmedSearch = search.toLowerCase().trim();
+      filteredPages = filteredPages.filter(
+        (f) =>
+          (f.title && f.title.toLowerCase().indexOf(trimmedSearch) > -1) ||
+          (f.description &&
+            f.description.toLowerCase().indexOf(trimmedSearch) > -1)
+      );
+    }
     return filteredPages;
   };
 
@@ -269,8 +296,9 @@ export default class ExampleIndex extends React.PureComponent {
     } = frontMatter;
 
     const filteredPages = this.filterPages();
-    const { topic, language, level, videos, product } = this.state;
-    const showResultIndicator = topic || language || level || videos || product;
+    const { topic, language, level, videos, product, search } = this.state;
+    const showResultIndicator =
+      topic || language || level || videos || product || search;
     const resultsLength = filteredPages.length;
     return (
       <ContentWrapper {...this.props} customAside={this.renderFilters()}>
@@ -359,9 +387,73 @@ ExampleIndex.propTypes = {
 };
 
 class FilterSection extends React.PureComponent {
-  render() {
-    const { title, data, activeItem, isSwitch, id, handleInput } = this.props;
+  renderInput = () => {
+    const {
+      title,
+      data,
+      activeItem,
+      isSwitch,
+      id,
+      handleInput,
+      isText,
+      placeholder
+    } = this.props;
     const themeLabel = 'txt-s txt-bold color-darken75';
+
+    if (isText)
+      return (
+        <ControlText
+          placeholder={placeholder}
+          id={id}
+          value={activeItem}
+          onChange={(value, id) => handleInput(value, id)}
+          themeControlInput="input input--s relative wmax180"
+          themeLabel={themeLabel}
+          label={title}
+          style={{
+            top: '2px'
+          }} /* make input align with select on smaller screens */
+        />
+      );
+    else if (isSwitch)
+      return (
+        <ControlSwitch
+          id={id}
+          value={activeItem}
+          label={title}
+          themeLabel={`${themeLabel} ml6`}
+          themeControlSwitch="switch--s-label switch--gray"
+          onChange={(value, id) => handleInput(value, id)}
+        />
+      );
+    else
+      return (
+        <ControlSelect
+          id={id}
+          label={title}
+          value={activeItem}
+          themeLabel={`${themeLabel} w70`}
+          themeControlSelect="select select--s"
+          onChange={(value, id) => {
+            handleInput(value, id);
+          }}
+          options={[
+            {
+              label: `All ${title.toLowerCase()}`,
+              value: ''
+            }
+          ].concat(
+            data.map((datum) => ({
+              label: title === 'Levels' ? levels[datum].label : datum,
+              value: datum
+            }))
+          )}
+        />
+      );
+  };
+
+  render() {
+    const { isSwitch } = this.props;
     return (
       <div
         className={classnames('col col--6 col--4-ml col--12-mxl', {
@@ -369,38 +461,7 @@ class FilterSection extends React.PureComponent {
           mb6: !isSwitch
         })}
       >
-        {isSwitch ? (
-          <ControlSwitch
-            id={id}
-            value={activeItem}
-            label={title}
-            themeLabel={`${themeLabel} ml6`}
-            themeControlSwitch="switch--s-label switch--gray"
-            onChange={(value, id) => handleInput(value, id)}
-          />
-        ) : (
-          <ControlSelect
-            id={id}
-            label={title}
-            value={activeItem}
-            themeLabel={`${themeLabel} w70`}
-            themeControlSelect="select select--s"
-            onChange={(value, id) => {
-              handleInput(value, id);
-            }}
-            options={[
-              {
-                label: `All ${title.toLowerCase()}`,
-                value: ''
-              }
-            ].concat(
-              data.map((datum) => ({
-                label: title === 'Levels' ? levels[datum].label : datum,
-                value: datum
-              }))
-            )}
-          />
-        )}
+        {this.renderInput()}
       </div>
     );
   }
@@ -412,5 +473,7 @@ FilterSection.propTypes = {
   handleInput: PropTypes.func.isRequired,
   data: PropTypes.array,
   activeItem: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-  isSwitch: PropTypes.bool
+  isSwitch: PropTypes.bool,
+  isText: PropTypes.bool,
+  placeholder: PropTypes.string
 };

--- a/src/components/page-layout/examples/example.js
+++ b/src/components/page-layout/examples/example.js
@@ -93,37 +93,36 @@ export default class Basic extends React.Component {
             pages: [
               {
                 contentType: 'example',
-                description: 'Replace me.',
+                description:
+                  'Initialize a map in an HTML element with Mapbox GL JS.',
                 language: ['JavaScript'],
                 layout: 'example',
                 path: '/PageLayout/example-1/',
-                text: 'Example 1',
                 thumbnail: 'header-image',
-                title: 'Example 1',
+                title: 'Display a map',
                 topics: ['Cool'],
                 url: '/PageLayout/example-1/'
               },
               {
                 contentType: 'example',
-                description: 'Replace me.',
+                description: 'Add a default Marker to the map.',
                 language: ['JavaScript'],
                 layout: 'example',
                 path: '/PageLayout/example-2/',
-                text: 'Example 2',
                 thumbnail: 'header-image',
-                title: 'Example 2',
+                title: 'Add a default marker',
                 topics: ['Cool'],
                 url: '/PageLayout/example-2/'
               },
               {
                 contentType: 'example',
-                description: 'Replace me.',
+                description:
+                  'Create a 3D indoor map with the fill-extrude-height paint property.',
                 language: ['JavaScript'],
                 layout: 'example',
                 path: '/PageLayout/example-3/',
-                text: 'Example 3',
                 thumbnail: 'header-image',
-                title: 'Example 3',
+                title: 'Extrude polygons for 3D indoor mapping',
                 topics: ['Cool', 'Awesome'],
                 url: '/PageLayout/example-3/'
               }


### PR DESCRIPTION
This PR introduces a search to the filters in ExampleIndex that will allow the user to only display cards that have their text query in the title or description of the collection of cards.

> ![2020-11-18 at 4 24 PM](https://user-images.githubusercontent.com/2180540/99589925-abeca280-29ba-11eb-91eb-f6ebebe91e22.gif)

## How to test

- Try out /PageLayout test case: `Example (index) layout.` 
- Try searching for different words in the title and the description of the cards, try lowercase and uppercase (search should be case insensitive).
- Do you have better naming suggestions for the label and placeholder? I'm not sure if I love it right now, but couldn't think of other ideas 🤔 

## QA checklist

<!-- complete this checklist when adding a new component or package -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.
- [ ] Create a PR in a site repo, copy the component, and test it. Push to staging and let the reviewer know they can also test the component there.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] IE11, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.
