### PR TITLE
[info arch] Add unprose class to OverviewHeader ul

### DIFF
--- a/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
+++ b/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
@@ -34,12 +34,7 @@ exports[`overview-header Adds Contact Us button renders as expected 1`] = `
         </a>
       </p>
       <ul
-        className="mb24"
-        style={
-          Object {
-            "listStyle": "none",
-          }
-        }
+        className="unprose mb24 ml24"
       >
         <li
           className="ml-neg24 flex-parent"
@@ -189,12 +184,7 @@ exports[`overview-header All, plus Contact Us button renders as expected 1`] = `
         </a>
       </p>
       <ul
-        className="mb24"
-        style={
-          Object {
-            "listStyle": "none",
-          }
-        }
+        className="unprose mb24 ml24"
       >
         <li
           className="ml-neg24 flex-parent"
@@ -384,12 +374,7 @@ exports[`overview-header Basic renders as expected 1`] = `
         </a>
       </p>
       <ul
-        className="mb24"
-        style={
-          Object {
-            "listStyle": "none",
-          }
-        }
+        className="unprose mb24 ml24"
       >
         <li
           className="ml-neg24 flex-parent"
@@ -596,12 +581,7 @@ exports[`overview-header Beta product renders as expected 1`] = `
         </span>
       </h1>
       <ul
-        className="mb24"
-        style={
-          Object {
-            "listStyle": "none",
-          }
-        }
+        className="unprose mb24 ml24"
       >
         <li
           className="ml-neg24 flex-parent"
@@ -723,12 +703,7 @@ exports[`overview-header No optional props renders as expected 1`] = `
         Mapbox SDK that You've Never Heard Of
       </h1>
       <ul
-        className="mb24"
-        style={
-          Object {
-            "listStyle": "none",
-          }
-        }
+        className="unprose mb24 ml24"
       >
         <li
           className="ml-neg24 flex-parent"
@@ -920,12 +895,7 @@ exports[`overview-header Some optional props renders as expected 1`] = `
         </span>
       </p>
       <ul
-        className="mb24"
-        style={
-          Object {
-            "listStyle": "none",
-          }
-        }
+        className="unprose mb24 ml24"
       >
         <li
           className="ml-neg24 flex-parent"

--- a/src/components/overview-header/overview-header.js
+++ b/src/components/overview-header/overview-header.js
@@ -136,9 +136,7 @@ class OverviewHeader extends React.PureComponent {
             {this.renderVersion()}
 
             {featuresList && (
-              <ul className="mb24" style={{ listStyle: 'none' }}>
-                {featuresList}
-              </ul>
+              <ul className="unprose mb24 ml24">{featuresList}</ul>
             )}
             {this.renderFooter()}
           </div>


### PR DESCRIPTION
This PR adds the `unprose` class to the OverviewHeader component's ul to allow us to better exclude this specific list from local list styles, Ref https://github.com/mapbox/studio-manual/pull/132

