### PR TITLE
[info arch] Add `flex-parent--center-cross` to OverviewHeader to center content

### DIFF
--- a/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
+++ b/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
@@ -5,7 +5,7 @@ exports[`overview-header Adds Contact Us button renders as expected 1`] = `
   className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--darken10"
 >
   <div
-    className="flex-parent"
+    className="flex-parent flex-parent--center-cross"
   >
     <div
       className="flex-child flex-child--grow"
@@ -155,7 +155,7 @@ exports[`overview-header All, plus Contact Us button renders as expected 1`] = `
   className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--darken10"
 >
   <div
-    className="flex-parent"
+    className="flex-parent flex-parent--center-cross"
   >
     <div
       className="flex-child flex-child--grow"
@@ -345,7 +345,7 @@ exports[`overview-header Basic renders as expected 1`] = `
   className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--darken10"
 >
   <div
-    className="flex-parent"
+    className="flex-parent flex-parent--center-cross"
   >
     <div
       className="flex-child flex-child--grow"
@@ -529,7 +529,7 @@ exports[`overview-header Beta product renders as expected 1`] = `
   className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--darken10"
 >
   <div
-    className="flex-parent"
+    className="flex-parent flex-parent--center-cross"
   >
     <div
       className="flex-child flex-child--grow"
@@ -692,7 +692,7 @@ exports[`overview-header No optional props renders as expected 1`] = `
   className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--darken10"
 >
   <div
-    className="flex-parent"
+    className="flex-parent flex-parent--center-cross"
   >
     <div
       className="flex-child flex-child--grow"
@@ -872,7 +872,7 @@ exports[`overview-header Some optional props renders as expected 1`] = `
   className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--darken10"
 >
   <div
-    className="flex-parent"
+    className="flex-parent flex-parent--center-cross"
   >
     <div
       className="flex-child flex-child--grow"

--- a/src/components/overview-header/overview-header.js
+++ b/src/components/overview-header/overview-header.js
@@ -126,7 +126,7 @@ class OverviewHeader extends React.PureComponent {
           }
         )}
       >
-        <div className="flex-parent">
+        <div className="flex-parent flex-parent--center-cross">
           <div className="flex-child flex-child--grow">
             <h1 className="mb6 txt-fancy">
               {props.title}


### PR DESCRIPTION
This PR will vertically center the content in OverviewHeader to keep the left-side content (heading, features, buttons, etc) in alignment with the right-side (image).

## How to test

View the /OverviewHeader test case.