### PR TITLE
[info arch] Add Search to PageLayout sidebar

### DIFF
--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -30,17 +30,56 @@ Array [
           }
         >
           <div
-            className="mb12 border-b border--darken10 pb12"
+            className="mb6 border-b border--darken10"
           >
             <div
-              className="dr-ui--product-menu"
+              className="mb6"
             >
-              <a
-                className="txt-fancy txt-l block color-blue-on-hover"
-                href="/dr-ui/"
+              <div
+                className="dr-ui--product-menu"
               >
-                dr-ui
-              </a>
+                <a
+                  className="txt-fancy txt-l block color-blue-on-hover"
+                  href="/dr-ui/"
+                >
+                  dr-ui
+                </a>
+              </div>
+            </div>
+            <div
+              className="pb6"
+            >
+              <div
+                className="h36 relative"
+              >
+                <div>
+                  <div>
+                    <button
+                      className="flex-parent flex-parent--center-cross btn--gray color-gray-light btn btn--stroke py3 pl6 pr12 round w-full"
+                      onClick={[Function]}
+                      style={Object {}}
+                    >
+                      <span
+                        className="mr6 color-gray"
+                      >
+                        <svg
+                          className="icon w18 h18"
+                        >
+                          <use
+                            xlinkHref="#icon-search"
+                          />
+                        </svg>
+                      </span>
+                       
+                      <span
+                        className="color-gray"
+                      >
+                        Search
+                      </span>
+                    </button>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
           <div
@@ -622,17 +661,56 @@ Array [
           }
         >
           <div
-            className="mb12 border-b border--darken10 pb12"
+            className="mb6 border-b border--darken10"
           >
             <div
-              className="dr-ui--product-menu"
+              className="mb6"
             >
-              <a
-                className="txt-fancy txt-l block color-blue-on-hover"
-                href="/dr-ui/"
+              <div
+                className="dr-ui--product-menu"
               >
-                dr-ui
-              </a>
+                <a
+                  className="txt-fancy txt-l block color-blue-on-hover"
+                  href="/dr-ui/"
+                >
+                  dr-ui
+                </a>
+              </div>
+            </div>
+            <div
+              className="pb6"
+            >
+              <div
+                className="h36 relative"
+              >
+                <div>
+                  <div>
+                    <button
+                      className="flex-parent flex-parent--center-cross btn--gray color-gray-light btn btn--stroke py3 pl6 pr12 round w-full"
+                      onClick={[Function]}
+                      style={Object {}}
+                    >
+                      <span
+                        className="mr6 color-gray"
+                      >
+                        <svg
+                          className="icon w18 h18"
+                        >
+                          <use
+                            xlinkHref="#icon-search"
+                          />
+                        </svg>
+                      </span>
+                       
+                      <span
+                        className="color-gray"
+                      >
+                        Search
+                      </span>
+                    </button>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
           <div
@@ -1253,17 +1331,56 @@ Array [
           }
         >
           <div
-            className="mb12 border-b border--darken10 pb12"
+            className="mb6 border-b border--darken10"
           >
             <div
-              className="dr-ui--product-menu"
+              className="mb6"
             >
-              <a
-                className="txt-fancy txt-l block color-blue-on-hover"
-                href="/dr-ui/"
+              <div
+                className="dr-ui--product-menu"
               >
-                dr-ui
-              </a>
+                <a
+                  className="txt-fancy txt-l block color-blue-on-hover"
+                  href="/dr-ui/"
+                >
+                  dr-ui
+                </a>
+              </div>
+            </div>
+            <div
+              className="pb6"
+            >
+              <div
+                className="h36 relative"
+              >
+                <div>
+                  <div>
+                    <button
+                      className="flex-parent flex-parent--center-cross btn--gray color-gray-light btn btn--stroke py3 pl6 pr12 round w-full"
+                      onClick={[Function]}
+                      style={Object {}}
+                    >
+                      <span
+                        className="mr6 color-gray"
+                      >
+                        <svg
+                          className="icon w18 h18"
+                        >
+                          <use
+                            xlinkHref="#icon-search"
+                          />
+                        </svg>
+                      </span>
+                       
+                      <span
+                        className="color-gray"
+                      >
+                        Search
+                      </span>
+                    </button>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
           <div
@@ -1705,53 +1822,92 @@ Array [
           }
         >
           <div
-            className="mb12 border-b border--darken10 pb12"
+            className="mb6 border-b border--darken10"
           >
             <div
-              className="dr-ui--product-menu"
+              className="mb6"
             >
               <div
-                className="ml-neg3"
+                className="dr-ui--product-menu"
               >
                 <div
-                  className="inline-block"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
+                  className="ml-neg3"
                 >
                   <div
-                    aria-describedby="tooltip-1"
-                    className="txt-bold round inline-block cursor-default txt-xs px6"
-                    style={
-                      Object {
-                        "background": "#f1f3fd",
-                        "borderColor": "#0428c8",
-                        "color": "#0c248d",
-                      }
-                    }
-                  >
-                    Beta
-                  </div>
-                  <div
-                    className="hide-visually"
-                    id="tooltip-1"
-                    role="tooltip"
+                    className="inline-block"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
                   >
                     <div
-                      className="txt-s wmax120"
+                      aria-describedby="tooltip-1"
+                      className="txt-bold round inline-block cursor-default txt-xs px6"
+                      style={
+                        Object {
+                          "background": "#f1f3fd",
+                          "borderColor": "#0428c8",
+                          "color": "#0c248d",
+                        }
+                      }
                     >
-                      This feature is in public beta and is subject to changes.
+                      Beta
+                    </div>
+                    <div
+                      className="hide-visually"
+                      id="tooltip-1"
+                      role="tooltip"
+                    >
+                      <div
+                        className="txt-s wmax120"
+                      >
+                        This feature is in public beta and is subject to changes.
+                      </div>
                     </div>
                   </div>
                 </div>
+                <a
+                  className="txt-fancy txt-l block color-blue-on-hover"
+                  href="/dr-ui/"
+                >
+                  Mapbox Tiling Service
+                </a>
               </div>
-              <a
-                className="txt-fancy txt-l block color-blue-on-hover"
-                href="/dr-ui/"
+            </div>
+            <div
+              className="pb6"
+            >
+              <div
+                className="h36 relative"
               >
-                Mapbox Tiling Service
-              </a>
+                <div>
+                  <div>
+                    <button
+                      className="flex-parent flex-parent--center-cross btn--gray color-gray-light btn btn--stroke py3 pl6 pr12 round w-full"
+                      onClick={[Function]}
+                      style={Object {}}
+                    >
+                      <span
+                        className="mr6 color-gray"
+                      >
+                        <svg
+                          className="icon w18 h18"
+                        >
+                          <use
+                            xlinkHref="#icon-search"
+                          />
+                        </svg>
+                      </span>
+                       
+                      <span
+                        className="color-gray"
+                      >
+                        Search
+                      </span>
+                    </button>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
           <div

--- a/src/components/page-layout/components/sidebar.js
+++ b/src/components/page-layout/components/sidebar.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import NavigationAccordion from '../../navigation-accordion';
 import ProductMenu from '../../product-menu/product-menu';
+import Search from '../../search/search';
 import classnames from 'classnames';
 
 export default class Sidebar extends React.Component {
@@ -11,7 +12,8 @@ export default class Sidebar extends React.Component {
       navigation,
       location,
       children,
-      parentPath
+      parentPath,
+      hideSearch
     } = this.props;
     const { SITE, BASEURL } = constants;
     const { title, tag, path, navTabs } = navigation;
@@ -29,12 +31,19 @@ export default class Sidebar extends React.Component {
         className="sticky-mm scroll-auto-mm scroll-styled viewport-almost-mm px12-mm"
         style={{ top: '10px' }}
       >
-        <div className="mb12 border-b border--darken10 pb12">
-          <ProductMenu
-            productName={title || SITE}
-            tag={tag || undefined}
-            homePage={`${BASEURL}/${path || ''}`}
-          />
+        <div className="mb6 border-b border--darken10">
+          <div className="mb6">
+            <ProductMenu
+              productName={title || SITE}
+              tag={tag || undefined}
+              homePage={`${BASEURL}/${path || ''}`}
+            />
+          </div>
+          {!hideSearch && (
+            <div className="pb6">
+              <Search {...this.props} site={SITE} />
+            </div>
+          )}
         </div>
         <div
           className={classnames('', {
@@ -75,5 +84,6 @@ Sidebar.propTypes = {
   constants: PropTypes.shape({
     SITE: PropTypes.string.isRequired,
     BASEURL: PropTypes.string.isRequired
-  }).isRequired
+  }).isRequired,
+  hideSearch: PropTypes.bool
 };

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -150,7 +150,8 @@ PageLayout.defaultProps = {
   domain: {
     title: 'All docs',
     path: 'https://docs.mapbox.com'
-  }
+  },
+  hideSearch: false
 };
 
 PageLayout.propTypes = {
@@ -248,5 +249,7 @@ PageLayout.propTypes = {
   domain: PropTypes.shape({
     title: PropTypes.string.isRequired,
     path: PropTypes.string.isRequired
-  })
+  }),
+  /** Hide Search component from the sidebar */
+  hideSearch: PropTypes.bool
 };

--- a/src/components/search/__tests__/__snapshots__/search.test.js.snap
+++ b/src/components/search/__tests__/__snapshots__/search.test.js.snap
@@ -7,12 +7,12 @@ exports[`search Basic search with \`site\` set to show filter toggle. Open https
   <div>
     <div>
       <button
-        className="flex-parent flex-parent--center-cross flex-parent--center-main btn btn--stroke"
+        className="flex-parent flex-parent--center-cross btn--gray color-gray-light btn btn--stroke py3 pl6 pr12 round w-full"
         onClick={[Function]}
         style={Object {}}
       >
         <span
-          className="mr6"
+          className="mr6 color-gray"
         >
           <svg
             className="icon w18 h18"
@@ -23,7 +23,11 @@ exports[`search Basic search with \`site\` set to show filter toggle. Open https
           </svg>
         </span>
          
-        Search
+        <span
+          className="color-gray"
+        >
+          Search
+        </span>
       </button>
     </div>
   </div>
@@ -37,12 +41,12 @@ exports[`search Basic search. Open https://app.swiftype.com/engines/docs/analyti
   <div>
     <div>
       <button
-        className="flex-parent flex-parent--center-cross flex-parent--center-main btn btn--stroke"
+        className="flex-parent flex-parent--center-cross btn--gray color-gray-light btn btn--stroke py3 pl6 pr12 round w-full"
         onClick={[Function]}
         style={Object {}}
       >
         <span
-          className="mr6"
+          className="mr6 color-gray"
         >
           <svg
             className="icon w18 h18"
@@ -53,7 +57,11 @@ exports[`search Basic search. Open https://app.swiftype.com/engines/docs/analyti
           </svg>
         </span>
          
-        Search
+        <span
+          className="color-gray"
+        >
+          Search
+        </span>
       </button>
     </div>
   </div>
@@ -84,7 +92,7 @@ exports[`search Search with \`disableModal\` option set. Open https://app.swifty
             className="absolute flex-parent flex-parent--center-cross flex-parent--center-main w36 h36"
           >
             <svg
-              className="icon color-gray"
+              className="icon color-gray w18 h18"
             >
               <title>
                 Search
@@ -123,7 +131,7 @@ exports[`search Search with \`narrow\` option set. Open https://app.swiftype.com
   <div>
     <div>
       <button
-        className="flex-parent flex-parent--center-cross flex-parent--center-main btn btn--stroke"
+        className="flex-parent flex-parent--center-cross btn--gray color-gray-light btn btn--stroke py3 pl6 pr12 round"
         onClick={[Function]}
         style={
           Object {
@@ -133,7 +141,7 @@ exports[`search Search with \`narrow\` option set. Open https://app.swiftype.com
         }
       >
         <span
-          className=""
+          className="color-gray"
         >
           <svg
             className="icon w18 h18"
@@ -160,12 +168,12 @@ exports[`search Search with custom connector. Open https://app.swiftype.com/engi
   <div>
     <div>
       <button
-        className="flex-parent flex-parent--center-cross flex-parent--center-main btn btn--stroke"
+        className="flex-parent flex-parent--center-cross btn--gray color-gray-light btn btn--stroke py3 pl6 pr12 round w-full"
         onClick={[Function]}
         style={Object {}}
       >
         <span
-          className="mr6"
+          className="mr6 color-gray"
         >
           <svg
             className="icon w18 h18"
@@ -176,7 +184,11 @@ exports[`search Search with custom connector. Open https://app.swiftype.com/engi
           </svg>
         </span>
          
-        Search
+        <span
+          className="color-gray"
+        >
+          Search
+        </span>
       </button>
     </div>
   </div>
@@ -196,7 +208,7 @@ exports[`search Search with dark background, custom placeholder. Open https://ap
       <div>
         <div>
           <button
-            className="flex-parent flex-parent--center-cross flex-parent--center-main btn btn--stroke btn--white"
+            className="flex-parent flex-parent--center-cross btn--gray color-gray-light btn btn--stroke py3 pl6 pr12 round btn--white w-full"
             onClick={[Function]}
             style={Object {}}
           >
@@ -212,7 +224,11 @@ exports[`search Search with dark background, custom placeholder. Open https://ap
               </svg>
             </span>
              
-            Search
+            <span
+              className=""
+            >
+              Search
+            </span>
           </button>
         </div>
       </div>

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -161,7 +161,8 @@ class SearchBox extends React.Component {
                     >
                       <svg
                         className={classnames('icon color-gray', {
-                          'w24 h24': this.state.useModal
+                          'w24 h24': this.state.useModal,
+                          'w18 h18': !this.state.useModal
                         })}
                       >
                         <title>Search</title>
@@ -284,9 +285,10 @@ class SearchBox extends React.Component {
           <div>
             <button
               className={classnames(
-                'flex-parent flex-parent--center-cross flex-parent--center-main btn btn--stroke',
+                'flex-parent flex-parent--center-cross btn--gray color-gray-light btn btn--stroke py3 pl6 pr12 round',
                 {
-                  'btn--white': this.props.background !== 'light'
+                  'btn--white': this.props.background !== 'light',
+                  'w-full': !this.props.narrow
                 }
               )}
               style={
@@ -298,7 +300,8 @@ class SearchBox extends React.Component {
             >
               <span
                 className={classnames('', {
-                  mr6: !this.props.narrow
+                  mr6: !this.props.narrow,
+                  'color-gray': this.props.background === 'light'
                 })}
               >
                 <svg className="icon w18 h18">
@@ -306,7 +309,15 @@ class SearchBox extends React.Component {
                   <use xlinkHref="#icon-search" />
                 </svg>
               </span>{' '}
-              {!this.props.narrow && 'Search'}
+              {!this.props.narrow && (
+                <span
+                  className={classnames('', {
+                    'color-gray': this.props.background === 'light'
+                  })}
+                >
+                  Search
+                </span>
+              )}
             </button>
             {this.renderModal()}
           </div>

--- a/src/components/search/title-generator.js
+++ b/src/components/search/title-generator.js
@@ -1,11 +1,12 @@
+const contextlessTitles = ['Introduction', 'Overview', 'Guides'];
+
 export function titleGenerator(title, subsite, site) {
   // create array for formatted title: {title} | {subsite} | {site}
   const titleArr = [];
   // do not push a title that is "Introduction" or "Overview"
   if (
     title &&
-    title !== 'Introduction' &&
-    title !== 'Overview' &&
+    contextlessTitles.indexOf(title) === -1 && // do not push a title that lacks context
     (subsite || site)
   )
     titleArr.push(title);

--- a/src/components/topbar-sticker/__tests__/__snapshots__/topbar-sticker.test.js.snap
+++ b/src/components/topbar-sticker/__tests__/__snapshots__/topbar-sticker.test.js.snap
@@ -68,12 +68,12 @@ exports[`topbar-sticker For display only renders as expected 1`] = `
                   <div>
                     <div>
                       <button
-                        className="flex-parent flex-parent--center-cross flex-parent--center-main btn btn--stroke"
+                        className="flex-parent flex-parent--center-cross btn--gray color-gray-light btn btn--stroke py3 pl6 pr12 round w-full"
                         onClick={[Function]}
                         style={Object {}}
                       >
                         <span
-                          className="mr6"
+                          className="mr6 color-gray"
                         >
                           <svg
                             className="icon w18 h18"
@@ -84,7 +84,11 @@ exports[`topbar-sticker For display only renders as expected 1`] = `
                           </svg>
                         </span>
                          
-                        Search
+                        <span
+                          className="color-gray"
+                        >
+                          Search
+                        </span>
                       </button>
                     </div>
                   </div>

--- a/src/components/topbar/__tests__/__snapshots__/topbar.test.js.snap
+++ b/src/components/topbar/__tests__/__snapshots__/topbar.test.js.snap
@@ -46,12 +46,12 @@ exports[`topbar-sticker Basic renders as expected 1`] = `
             <div>
               <div>
                 <button
-                  className="flex-parent flex-parent--center-cross flex-parent--center-main btn btn--stroke"
+                  className="flex-parent flex-parent--center-cross btn--gray color-gray-light btn btn--stroke py3 pl6 pr12 round w-full"
                   onClick={[Function]}
                   style={Object {}}
                 >
                   <span
-                    className="mr6"
+                    className="mr6 color-gray"
                   >
                     <svg
                       className="icon w18 h18"
@@ -62,7 +62,11 @@ exports[`topbar-sticker Basic renders as expected 1`] = `
                     </svg>
                   </span>
                    
-                  Search
+                  <span
+                    className="color-gray"
+                  >
+                    Search
+                  </span>
                 </button>
               </div>
             </div>

--- a/tests/title-generator.test.js
+++ b/tests/title-generator.test.js
@@ -36,4 +36,10 @@ describe('titleGenerator', () => {
   it('no "Introduction" as title', () => {
     expect(tagger.titleGenerator('Introduction', 'iOS')).toEqual(['iOS']);
   });
+
+  it('no "Guides" as title', () => {
+    expect(tagger.titleGenerator('Guides', 'Mapbox Tiling Service')).toEqual([
+      'Mapbox Tiling Service'
+    ]);
+  });
 });


### PR DESCRIPTION
This PR adds back Search to the PageLayout component, by adding it to the sidebar under ProductMenu:
- Adds back `hideSearch` PageLayout prop to disable the feature for a given site (for example, /documentation, /jp)
- Updates the style of the Search button to complement the new layout
- Search component has the same behavior has before (show button that opens an input modal for larger screens and then on smaller screens replace button with input)
- Leaves titleGenerator intact (I mentioned removing it here, but to reduce scope I think we should leave Swiftype title tag alone for now in docs-page-shell -- I'll follow up in docs-page-shell while remove Swiftype from it.)

![image](https://user-images.githubusercontent.com/2180540/100275682-52422600-2f2e-11eb-8883-934b0b416cd6.png)


cc @danswick 


## How to test

- Check the Search component in the /PageLayout and /Search test cases app pages
- Check the Search component in the catalog site

## QA checklist

<!-- complete this checklist when adding a new component or package -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.
- [ ] Create a PR in a site repo, copy the component, and test it. Push to staging and let the reviewer know they can also test the component there.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] IE11, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.
