### PR TITLE
[info arch] Fix path to files to work for test cases app and catalog page

### DIFF
--- a/src/components/browser/__tests__/__snapshots__/browser.test.js.snap
+++ b/src/components/browser/__tests__/__snapshots__/browser.test.js.snap
@@ -200,7 +200,7 @@ exports[`browser With image renders as expected 1`] = `
   <img
     alt="Manage styles in Studio."
     className="round-b"
-    src="./files/browser-example.png"
+    src="/files/browser-example.png"
   />
 </div>
 `;
@@ -407,7 +407,7 @@ exports[`browser With video renders as expected 1`] = `
     className="block mx-auto round-b"
     loop={true}
     muted={true}
-    src="./files/browser-example.mp4"
+    src="/files/browser-example.mp4"
     title="animated GIF walking through how to filter a source layer by adding a vector source clicking Filter > Create filter > select a data field from the list provided > select a value from the list provided"
     type="video/mp4"
     width="100%"

--- a/src/components/browser/__tests__/browser-test-cases.js
+++ b/src/components/browser/__tests__/browser-test-cases.js
@@ -20,7 +20,7 @@ testCases.video = {
         muted
         width="100%"
         className="block mx-auto round-b"
-        src="./files/browser-example.mp4"
+        src="/files/browser-example.mp4"
         type="video/mp4"
         title="animated GIF walking through how to filter a source layer by adding a vector source clicking Filter > Create filter > select a data field from the list provided > select a value from the list provided"
       >

--- a/src/components/browser/examples/basic.js
+++ b/src/components/browser/examples/basic.js
@@ -9,7 +9,7 @@ export default class Basic extends React.Component {
     return (
       <Browser>
         <img
-          src="./files/browser-example.png"
+          src="/files/browser-example.png"
           className="round-b"
           alt="Manage styles in Studio."
         />

--- a/src/components/card-container/__tests__/__snapshots__/card-container.test.js.snap
+++ b/src/components/card-container/__tests__/__snapshots__/card-container.test.js.snap
@@ -38,7 +38,7 @@ exports[`card-container Basic renders as expected 1`] = `
             className="relative h120 mb12"
             style={
               Object {
-                "backgroundImage": "url('./files/simple-map.png')",
+                "backgroundImage": "url('/files/simple-map.png')",
                 "backgroundPosition": "center",
                 "backgroundSize": "100% auto",
               }
@@ -74,7 +74,7 @@ exports[`card-container Basic renders as expected 1`] = `
             className="relative h120 mb12"
             style={
               Object {
-                "backgroundImage": "url('./files/simple-map.png')",
+                "backgroundImage": "url('/files/simple-map.png')",
                 "backgroundPosition": "center",
                 "backgroundSize": "100% auto",
               }
@@ -212,7 +212,7 @@ exports[`card-container Use cardColSize renders as expected 1`] = `
             className="relative h120 mb12"
             style={
               Object {
-                "backgroundImage": "url('./files/simple-map.png')",
+                "backgroundImage": "url('/files/simple-map.png')",
                 "backgroundPosition": "center",
                 "backgroundSize": "100% auto",
               }
@@ -248,7 +248,7 @@ exports[`card-container Use cardColSize renders as expected 1`] = `
             className="relative h120 mb12"
             style={
               Object {
-                "backgroundImage": "url('./files/simple-map.png')",
+                "backgroundImage": "url('/files/simple-map.png')",
                 "backgroundPosition": "center",
                 "backgroundSize": "100% auto",
               }
@@ -284,7 +284,7 @@ exports[`card-container Use cardColSize renders as expected 1`] = `
             className="relative h120 mb12"
             style={
               Object {
-                "backgroundImage": "url('./files/simple-map.png')",
+                "backgroundImage": "url('/files/simple-map.png')",
                 "backgroundPosition": "center",
                 "backgroundSize": "100% auto",
               }
@@ -320,7 +320,7 @@ exports[`card-container Use cardColSize renders as expected 1`] = `
             className="relative h120 mb12"
             style={
               Object {
-                "backgroundImage": "url('./files/simple-map.png')",
+                "backgroundImage": "url('/files/simple-map.png')",
                 "backgroundPosition": "center",
                 "backgroundSize": "100% auto",
               }

--- a/src/components/card-container/examples/basic.js
+++ b/src/components/card-container/examples/basic.js
@@ -22,7 +22,7 @@ export default class Example extends React.Component {
               <div
                 className="relative h120 mb12"
                 style={{
-                  backgroundImage: "url('./files/simple-map.png')",
+                  backgroundImage: "url('/files/simple-map.png')",
                   backgroundSize: '100% auto',
                   backgroundPosition: 'center'
                 }}
@@ -38,7 +38,7 @@ export default class Example extends React.Component {
               <div
                 className="relative h120 mb12"
                 style={{
-                  backgroundImage: "url('./files/simple-map.png')",
+                  backgroundImage: "url('/files/simple-map.png')",
                   backgroundSize: '100% auto',
                   backgroundPosition: 'center'
                 }}

--- a/src/components/card-container/examples/cols.js
+++ b/src/components/card-container/examples/cols.js
@@ -22,7 +22,7 @@ export default class Example extends React.Component {
               <div
                 className="relative h120 mb12"
                 style={{
-                  backgroundImage: "url('./files/simple-map.png')",
+                  backgroundImage: "url('/files/simple-map.png')",
                   backgroundSize: '100% auto',
                   backgroundPosition: 'center'
                 }}
@@ -38,7 +38,7 @@ export default class Example extends React.Component {
               <div
                 className="relative h120 mb12"
                 style={{
-                  backgroundImage: "url('./files/simple-map.png')",
+                  backgroundImage: "url('/files/simple-map.png')",
                   backgroundSize: '100% auto',
                   backgroundPosition: 'center'
                 }}
@@ -54,7 +54,7 @@ export default class Example extends React.Component {
               <div
                 className="relative h120 mb12"
                 style={{
-                  backgroundImage: "url('./files/simple-map.png')",
+                  backgroundImage: "url('/files/simple-map.png')",
                   backgroundSize: '100% auto',
                   backgroundPosition: 'center'
                 }}
@@ -70,7 +70,7 @@ export default class Example extends React.Component {
               <div
                 className="relative h120 mb12"
                 style={{
-                  backgroundImage: "url('./files/simple-map.png')",
+                  backgroundImage: "url('/files/simple-map.png')",
                   backgroundSize: '100% auto',
                   backgroundPosition: 'center'
                 }}

--- a/src/components/card/__tests__/__snapshots__/card.test.js.snap
+++ b/src/components/card/__tests__/__snapshots__/card.test.js.snap
@@ -12,7 +12,7 @@ exports[`card Card with image renders as expected 1`] = `
       className="relative h120 mb12"
       style={
         Object {
-          "backgroundImage": "url('./files/simple-map.png')",
+          "backgroundImage": "url('/files/simple-map.png')",
           "backgroundPosition": "center",
           "backgroundSize": "100% auto",
         }
@@ -199,7 +199,7 @@ exports[`card Card without description renders as expected 1`] = `
       className="relative h120 mb12"
       style={
         Object {
-          "backgroundImage": "url('./files/simple-map.png')",
+          "backgroundImage": "url('/files/simple-map.png')",
           "backgroundPosition": "center",
           "backgroundSize": "100% auto",
         }

--- a/src/components/card/examples/basic.js
+++ b/src/components/card/examples/basic.js
@@ -16,7 +16,7 @@ export default class Basic extends React.Component {
           <div
             className="relative h120 mb12"
             style={{
-              backgroundImage: "url('./files/simple-map.png')",
+              backgroundImage: "url('/files/simple-map.png')",
               backgroundSize: '100% auto',
               backgroundPosition: 'center'
             }}

--- a/src/components/card/examples/no-description.js
+++ b/src/components/card/examples/no-description.js
@@ -16,7 +16,7 @@ export default class Basic extends React.Component {
           <div
             className="relative h120 mb12"
             style={{
-              backgroundImage: "url('./files/simple-map.png')",
+              backgroundImage: "url('/files/simple-map.png')",
               backgroundSize: '100% auto',
               backgroundPosition: 'center'
             }}

--- a/src/components/demo-iframe/examples/basic.js
+++ b/src/components/demo-iframe/examples/basic.js
@@ -6,6 +6,6 @@ import DemoIframe from '../demo-iframe';
 
 export default class Basic extends React.Component {
   render() {
-    return <DemoIframe src="./files/ios-horizontal.png" />;
+    return <DemoIframe src="/files/ios-horizontal.png" />;
   }
 }

--- a/src/components/phone/__tests__/__snapshots__/phone.test.js.snap
+++ b/src/components/phone/__tests__/__snapshots__/phone.test.js.snap
@@ -82,7 +82,7 @@ exports[`phone Android landscape renders as expected 1`] = `
     >
       <img
         alt="example"
-        src="./files/ios-horizontal.png"
+        src="/files/ios-horizontal.png"
       />
     </div>
   </div>
@@ -178,7 +178,7 @@ exports[`phone Android portrait renders as expected 1`] = `
     >
       <img
         alt="example"
-        src="./files/ios-vertical.png"
+        src="/files/ios-vertical.png"
       />
     </div>
   </div>
@@ -308,7 +308,7 @@ exports[`phone iOS landscape renders as expected 1`] = `
           className="block mx-auto"
           loop={true}
           muted={true}
-          src="./files/browser-example.mp4"
+          src="/files/browser-example.mp4"
           title="example"
           type="video/mp4"
           width="100%"
@@ -317,7 +317,7 @@ exports[`phone iOS landscape renders as expected 1`] = `
             Your browser doesn't support HTML5 video. Here is a
              
             <a
-              href="./files/browser-example.mp4"
+              href="/files/browser-example.mp4"
             >
               link to the video
             </a>
@@ -442,7 +442,7 @@ exports[`phone iOS portrait renders as expected 1`] = `
     >
       <img
         alt="example"
-        src="./files/ios-vertical.png"
+        src="/files/ios-vertical.png"
       />
     </div>
   </div>

--- a/src/components/phone/__tests__/phone-test-cases.js
+++ b/src/components/phone/__tests__/phone-test-cases.js
@@ -8,7 +8,7 @@ testCases.iosHori = {
   component: Phone,
   description: 'iOS landscape',
   props: {
-    children: <Video src="./files/browser-example.mp4" title="example" />,
+    children: <Video src="/files/browser-example.mp4" title="example" />,
     mode: 'landscape',
     platform: 'ios'
   }
@@ -18,7 +18,7 @@ testCases.iosVert = {
   component: Phone,
   description: 'iOS portrait',
   props: {
-    children: <img src="./files/ios-vertical.png" alt="example" />,
+    children: <img src="/files/ios-vertical.png" alt="example" />,
     mode: 'portrait',
     platform: 'ios'
   }
@@ -28,7 +28,7 @@ testCases.androidLandscape = {
   component: Phone,
   description: 'Android landscape',
   props: {
-    children: <img src="./files/ios-horizontal.png" alt="example" />,
+    children: <img src="/files/ios-horizontal.png" alt="example" />,
     mode: 'landscape',
     platform: 'android'
   }
@@ -37,7 +37,7 @@ testCases.androidVert = {
   component: Phone,
   description: 'Android portrait',
   props: {
-    children: <img src="./files/ios-vertical.png" alt="example" />,
+    children: <img src="/files/ios-vertical.png" alt="example" />,
     mode: 'portrait',
     platform: 'android'
   }

--- a/src/components/phone/examples/basic.js
+++ b/src/components/phone/examples/basic.js
@@ -9,7 +9,7 @@ export default class Basic extends React.Component {
   render() {
     return (
       <Phone mode="landscape" platform="ios">
-        <Video src="./files/browser-example.mp4" title="example" />
+        <Video src="/files/browser-example.mp4" title="example" />
       </Phone>
     );
   }

--- a/src/components/related-page/__tests__/__snapshots__/related-page.test.js.snap
+++ b/src/components/related-page/__tests__/__snapshots__/related-page.test.js.snap
@@ -876,7 +876,7 @@ exports[`related-page video renders as expected 1`] = `
           <img
             alt=""
             className="w-full block round h-full mb24 mb0-ml"
-            src="files/vimeo_thumb.jpg"
+            src="/files/vimeo_thumb.jpg"
           />
         </div>
         <div

--- a/src/components/related-page/examples/video.js
+++ b/src/components/related-page/examples/video.js
@@ -11,7 +11,7 @@ export default class Basic extends React.Component {
         contentType="video"
         title="How to eject a Style Component in Mapbox Studio"
         vimeoId="378704089"
-        vimeoThumbnail="files/vimeo_thumb.jpg"
+        vimeoThumbnail="/files/vimeo_thumb.jpg"
       >
         Style Components provide sensible defaults and quick opportunities for
         customization by optimizing the most common property changes for styles

--- a/src/components/video/__tests__/__snapshots__/video.test.js.snap
+++ b/src/components/video/__tests__/__snapshots__/video.test.js.snap
@@ -7,7 +7,7 @@ exports[`video Basic renders as expected 1`] = `
     className="block mx-auto"
     loop={true}
     muted={true}
-    src="./files/browser-example.mp4"
+    src="/files/browser-example.mp4"
     title="A video!"
     type="video/mp4"
     width="100%"
@@ -16,7 +16,7 @@ exports[`video Basic renders as expected 1`] = `
       Your browser doesn't support HTML5 video. Here is a
        
       <a
-        href="./files/browser-example.mp4"
+        href="/files/browser-example.mp4"
       >
         link to the video
       </a>
@@ -32,7 +32,7 @@ exports[`video Reduced motion renders as expected 1`] = `
     className="block mx-auto"
     controls={true}
     muted={true}
-    src="./files/browser-example.mp4"
+    src="/files/browser-example.mp4"
     title="A video!"
     type="video/mp4"
     width="100%"
@@ -41,7 +41,7 @@ exports[`video Reduced motion renders as expected 1`] = `
       Your browser doesn't support HTML5 video. Here is a
        
       <a
-        href="./files/browser-example.mp4"
+        href="/files/browser-example.mp4"
       >
         link to the video
       </a>

--- a/src/components/video/__tests__/video-test-cases.js
+++ b/src/components/video/__tests__/video-test-cases.js
@@ -14,7 +14,7 @@ noRenderCases.reducedMotion = {
   component: Video,
   description: 'Reduced motion',
   props: {
-    src: './files/browser-example.mp4',
+    src: '/files/browser-example.mp4',
     title: 'A video!'
   }
 };

--- a/src/components/video/examples/basic.js
+++ b/src/components/video/examples/basic.js
@@ -6,6 +6,6 @@ import Video from '../video';
 
 export default class Example extends React.Component {
   render() {
-    return <Video src="./files/browser-example.mp4" title="A video!" />;
+    return <Video src="/files/browser-example.mp4" title="A video!" />;
   }
 }


### PR DESCRIPTION
I noticed that some components on the catalog site have broken assets. This PR fixes the relative path to `files` so that the path will work for the test cases app and catalog page.

## How to test

- The catalog page shouldn't log to console images or videos as 404.
- The test cases app assets load as expected: /Browser, /CardContainer, /Card, /DemoIframe, /Phone, /RelatedPage, /Video