### PR TITLE
[info arch] Set height to prevent content shift as Search component loads

### DIFF
--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -47,7 +47,7 @@ Array [
               </div>
             </div>
             <div
-              className="pb6"
+              className="mb6 h36"
             >
               <div
                 className="h36 relative"
@@ -678,7 +678,7 @@ Array [
               </div>
             </div>
             <div
-              className="pb6"
+              className="mb6 h36"
             >
               <div
                 className="h36 relative"
@@ -1348,7 +1348,7 @@ Array [
               </div>
             </div>
             <div
-              className="pb6"
+              className="mb6 h36"
             >
               <div
                 className="h36 relative"
@@ -1875,7 +1875,7 @@ Array [
               </div>
             </div>
             <div
-              className="pb6"
+              className="mb6 h36"
             >
               <div
                 className="h36 relative"

--- a/src/components/page-layout/components/sidebar.js
+++ b/src/components/page-layout/components/sidebar.js
@@ -40,7 +40,8 @@ export default class Sidebar extends React.Component {
             />
           </div>
           {!hideSearch && (
-            <div className="pb6">
+            /* set height to prevent content shift as Search component loads */
+            <div className="mb6 h36">
               <Search {...this.props} site={SITE} />
             </div>
           )}


### PR DESCRIPTION
This PR adds `h36` class to the div that wraps the Search component in PageLayout component. This will prevent the page from shifting while the search component loads.

## How to test

This may be tricky to test effectiveness locally as I've only been able to reproduce on staging. But I think checking the /PageLayout tests cases app page to make sure the Search component loads as expected is a good thing to check.

@danswick for review