### PR TITLE
Sort まず始めに (Getting started) to front of topic list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Main
+
+- Update the filter Batfish helper to sort "まず始めに" (Getting started) to start of the topic list. [#381](https://github.com/mapbox/dr-ui/pull/381).
+
 ## 2.0.0
 
 - Add `Breadcrumb` component. This component is included as a feature in `PageLayout`. [#331](https://github.com/mapbox/dr-ui/pull/331).

--- a/src/helpers/batfish/__tests__/filters.test.js
+++ b/src/helpers/batfish/__tests__/filters.test.js
@@ -123,6 +123,25 @@ describe('generateTopics', () => {
       ])
     ).toEqual(['Carrot', 'Cucumber', 'Radish']);
   });
+
+  it('sorted and unique, jp', () => {
+    expect(
+      generateTopics([
+        {
+          topic: 'データの可視化'
+        },
+        {
+          topics: ['データの可視化', 'Webアプリ']
+        },
+        {
+          topics: ['まず始めに', 'カメラ']
+        },
+        {
+          topic: 'まず始めに'
+        }
+      ])
+    ).toEqual(['まず始めに', 'Webアプリ', 'カメラ', 'データの可視化']);
+  });
 });
 
 describe('pageSorter', () => {

--- a/src/helpers/batfish/filters.js
+++ b/src/helpers/batfish/filters.js
@@ -64,10 +64,15 @@ function generateTopics(pages) {
       }, [])
     )
   ].sort();
-  // check if "Getting started" topic exists
-  const index = topics.indexOf('Getting started');
-  // if "Getting started" exists, splice the array, and move "Getting started" to the front of the list
-  return index > -1 ? [...topics.splice(index, 1), ...topics] : topics;
+  // check if "Getting started" topic exists (en and jp)
+  const indexEn = topics.indexOf('Getting started');
+  const indexJp = topics.indexOf('まず始めに');
+  // if exists, splice the array, and move "Getting started/まず始めに" to the front of the list
+  return [
+    ...(indexEn > -1 ? [...topics.splice(indexEn, 1)] : []),
+    ...(indexJp > -1 ? [...topics.splice(indexJp, 1)] : []),
+    ...topics
+  ];
 }
 
 function hasTopic(page, topic) {


### PR DESCRIPTION
This PR updates the filter Batfish helper to sort まず始めに (Getting started) to front of the topic list. 

## How to test

- Review the new test (with out the intervention `Webアプリ` would come before `まず始めに`)

@danswick for review

Ref https://github.com/mapbox/docs-jp/pull/55

