### PR TITLE
Remove metadata when the component unmounts in AnalyticsShell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Main
+
+- Remove `mbxMetadata` when the component unmounts in `AnalyticsShell`. [#383](https://github.com/mapbox/dr-ui/pull/383).
+
 ## 2.1.1
 
 - Fix `pageSorter` function in filter Batfish helper to sort "まず始めに" (Getting started) to top of the list.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dr-ui",
-  "version": "2.1.1",
+  "version": "2.2.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dr-ui",
-  "version": "2.1.1",
+  "version": "2.2.0-beta.0",
   "description": "Mapbox frontend tools for documentation websites.",
   "main": "index.js",
   "scripts": {

--- a/src/components/analytics-shell/__tests__/analytics-shell.test.js
+++ b/src/components/analytics-shell/__tests__/analytics-shell.test.js
@@ -31,6 +31,16 @@ describe('AnalyticsShell', () => {
       });
     });
 
+    test('mbxMetadata', () => {
+      const wrapper = mount(testCase.element);
+      expect(global.mbxMetadata).toEqual({
+        product: 'Documentation',
+        service: 'Platform'
+      });
+      wrapper.unmount();
+      expect(global.mbxMetadata).toBeUndefined();
+    });
+
     test('web-analytics init', () => {
       mount(testCase.element);
       expect(window.initializeMapboxAnalytics).toHaveBeenCalledWith({

--- a/src/components/analytics-shell/analytics-shell.js
+++ b/src/components/analytics-shell/analytics-shell.js
@@ -30,6 +30,13 @@ export default class AnalyticsShell extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    // remove mapbox metadata when the component unmounts
+    // this helps prevent unwanted data from being pushed to Segment
+    // if the component doesn't mount properly
+    if (window.mbxMetadata) window.mbxMetadata = undefined;
+  }
+
   render() {
     const { location, children, domain } = this.props;
     return (

--- a/src/components/analytics-shell/examples/basic.js
+++ b/src/components/analytics-shell/examples/basic.js
@@ -7,7 +7,10 @@ import AnalyticsShell from '../analytics-shell';
 export default class Basic extends React.Component {
   render() {
     return (
-      <AnalyticsShell location={{ pathname: '/dr-ui/' }}>
+      <AnalyticsShell
+        mbxMetadata={{ product: 'Documentation', service: 'Platform' }}
+        location={{ pathname: '/dr-ui/' }}
+      >
         Hello world!
       </AnalyticsShell>
     );


### PR DESCRIPTION
This PR will remove the `mbxMetadata` object from the window when the AnalyticsShell component unmounts. This will prevent the data object from traveling to another page and writing the wrong data if the component does not load successfully.

## How to test

<!-- list steps on how the reviewer can test this change -->

## QA checklist

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] IE11, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.
