### PR TITLE
Update GLWrapper to check for IE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Main
+
+- Update `GlWrapper` component to check for Internet Explorer and provide reason for when the issue is not Internet Explorer or WebGL support. [#387](https://github.com/mapbox/dr-ui/pull/387)
+
 ## 2.2.0
 
 - Remove `mbxMetadata` when the component unmounts in `AnalyticsShell`. [#383](https://github.com/mapbox/dr-ui/pull/383).

--- a/package-lock.json
+++ b/package-lock.json
@@ -7800,9 +7800,9 @@
       "dev": true
     },
     "@mapbox/mapbox-gl-supported": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
-      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.0.tgz",
+      "integrity": "sha512-zu4udqYiBrKMQKwpKJ4hhPON7tz0QR/JZ3iGpHnNWFmH3Sv/ysxlICATUtGCFpsyJf2v1WpFhlzaZ3GhhKmPMA=="
     },
     "@mapbox/mbx-assembly": {
       "version": "0.29.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@elastic/react-search-ui": "1.3.2",
     "@elastic/react-search-ui-views": "1.3.2",
     "@elastic/search-ui-site-search-connector": "1.3.2",
-    "@mapbox/mapbox-gl-supported": "^1.5.0",
+    "@mapbox/mapbox-gl-supported": "^2.0.0",
     "@mapbox/mr-ui": "^0.9.1",
     "@sentry/browser": "^5.27.4",
     "classnames": "^2.2.6",

--- a/src/components/demo-iframe/__tests__/__snapshots__/demo-iframe.test.js.snap
+++ b/src/components/demo-iframe/__tests__/__snapshots__/demo-iframe.test.js.snap
@@ -88,23 +88,7 @@ exports[`demo-iframe Basic renders as expected 1`] = `
     >
       Mapbox GL unsupported
     </div>
-    Mapbox GL requires
-     
-    <a
-      className="link"
-      href="https://caniuse.com/#feat=webgl"
-    >
-      WebGL support
-    </a>
-    . Please check that you are using a supported browser and that
-     
-    <a
-      className="link"
-      href="https://get.webgl.org/"
-    >
-      WebGL is enabled
-    </a>
-    .
+    Mapbox GL is unsupported due to insufficient worker support.
   </div>
 </div>
 `;
@@ -159,23 +143,7 @@ exports[`demo-iframe With token renders as expected 1`] = `
     >
       Mapbox GL unsupported
     </div>
-    Mapbox GL requires
-     
-    <a
-      className="link"
-      href="https://caniuse.com/#feat=webgl"
-    >
-      WebGL support
-    </a>
-    . Please check that you are using a supported browser and that
-     
-    <a
-      className="link"
-      href="https://get.webgl.org/"
-    >
-      WebGL is enabled
-    </a>
-    .
+    Mapbox GL is unsupported due to insufficient worker support.
   </div>
 </div>
 `;

--- a/src/components/gl-wrapper/__tests__/__snapshots__/gl-wrapper.test.js.snap
+++ b/src/components/gl-wrapper/__tests__/__snapshots__/gl-wrapper.test.js.snap
@@ -52,3 +52,155 @@ exports[`gl-wrapper Basic renders as expected 1`] = `
   </div>
 </div>
 `;
+
+exports[`gl-wrapper reason='insufficient ECMAScript 6 support' renders as expected 1`] = `
+<div
+  className="dr-ui--note py18 px18 round flex-parent flex-parent--row mb18"
+  style={
+    Object {
+      "background": "#feefe2",
+      "color": "#78471c",
+    }
+  }
+>
+  <div
+    className="flex-child mr18 none block-mm pt3"
+  >
+    <div
+      className="bg-orange-light round-full color-orange flex-parent flex-parent--center-main flex-parent--center-cross"
+      style={
+        Object {
+          "height": 50,
+          "width": 50,
+        }
+      }
+    >
+      <svg
+        className="events-none icon"
+        focusable="false"
+        role="presentation"
+        style={
+          Object {
+            "height": 40,
+            "width": 40,
+          }
+        }
+      >
+        <use
+          xlinkHref="#icon-alert"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
+        />
+      </svg>
+    </div>
+  </div>
+  <div
+    className="flex-child prose"
+  >
+    <div
+      className="txt-bold txt-m mb6"
+    >
+      Mapbox GL unsupported
+    </div>
+    Starting with v2.0.0, Mapbox GL JS is no longer compatible with any version of Internet Explorer. If you need to support Internet Explorer, consider using the
+     
+    <a
+      href="https://docs.mapbox.com/api/maps/static-images/"
+    >
+      Mapbox Static Images API
+    </a>
+     
+    for non-interactive maps or using the
+     
+    <a
+      href="https://docs.mapbox.com/api/maps/static-tiles/"
+    >
+      Mapbox Static Tiles API
+    </a>
+     
+    with another library (for example,
+     
+    <a
+      href="https://docs.mapbox.com/mapbox.js/"
+    >
+      Mapbox.js
+    </a>
+     or
+     
+    <a
+      href="https://leafletjs.com/"
+    >
+      Leaflet
+    </a>
+    ) for interactive maps.
+  </div>
+</div>
+`;
+
+exports[`gl-wrapper reason='insufficient WebGL support' renders as expected 1`] = `
+<div
+  className="dr-ui--note py18 px18 round flex-parent flex-parent--row mb18"
+  style={
+    Object {
+      "background": "#feefe2",
+      "color": "#78471c",
+    }
+  }
+>
+  <div
+    className="flex-child mr18 none block-mm pt3"
+  >
+    <div
+      className="bg-orange-light round-full color-orange flex-parent flex-parent--center-main flex-parent--center-cross"
+      style={
+        Object {
+          "height": 50,
+          "width": 50,
+        }
+      }
+    >
+      <svg
+        className="events-none icon"
+        focusable="false"
+        role="presentation"
+        style={
+          Object {
+            "height": 40,
+            "width": 40,
+          }
+        }
+      >
+        <use
+          xlinkHref="#icon-alert"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
+        />
+      </svg>
+    </div>
+  </div>
+  <div
+    className="flex-child prose"
+  >
+    <div
+      className="txt-bold txt-m mb6"
+    >
+      Mapbox GL unsupported
+    </div>
+    Mapbox GL requires
+     
+    <a
+      className="link"
+      href="https://caniuse.com/#feat=webgl"
+    >
+      WebGL support
+    </a>
+    . Please check that you are using a supported browser and that
+     
+    <a
+      className="link"
+      href="https://get.webgl.org/"
+    >
+      WebGL is enabled
+    </a>
+    .
+  </div>
+</div>
+`;

--- a/src/components/gl-wrapper/__tests__/__snapshots__/gl-wrapper.test.js.snap
+++ b/src/components/gl-wrapper/__tests__/__snapshots__/gl-wrapper.test.js.snap
@@ -48,37 +48,7 @@ exports[`gl-wrapper Basic renders IE 11 message 1`] = `
     >
       Mapbox GL unsupported
     </div>
-    Starting with v2.0.0, Mapbox GL JS is no longer compatible with any version of Internet Explorer. If you need to support Internet Explorer, consider using the
-     
-    <a
-      href="https://docs.mapbox.com/api/maps/static-images/"
-    >
-      Mapbox Static Images API
-    </a>
-     
-    for non-interactive maps or using the
-     
-    <a
-      href="https://docs.mapbox.com/api/maps/static-tiles/"
-    >
-      Mapbox Static Tiles API
-    </a>
-     
-    with another library (for example,
-     
-    <a
-      href="https://docs.mapbox.com/mapbox.js/"
-    >
-      Mapbox.js
-    </a>
-     or
-     
-    <a
-      href="https://leafletjs.com/"
-    >
-      Leaflet
-    </a>
-    ) for interactive maps.
+    Mapbox GL is unsupported due to insufficient worker support.
   </div>
 </div>
 `;
@@ -131,23 +101,7 @@ exports[`gl-wrapper Basic renders as expected 1`] = `
     >
       Mapbox GL unsupported
     </div>
-    Mapbox GL requires
-     
-    <a
-      className="link"
-      href="https://caniuse.com/#feat=webgl"
-    >
-      WebGL support
-    </a>
-    . Please check that you are using a supported browser and that
-     
-    <a
-      className="link"
-      href="https://get.webgl.org/"
-    >
-      WebGL is enabled
-    </a>
-    .
+    Mapbox GL is unsupported due to insufficient worker support.
   </div>
 </div>
 `;

--- a/src/components/gl-wrapper/__tests__/__snapshots__/gl-wrapper.test.js.snap
+++ b/src/components/gl-wrapper/__tests__/__snapshots__/gl-wrapper.test.js.snap
@@ -1,58 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`gl-wrapper Basic renders IE 11 message 1`] = `
-<div
-  className="dr-ui--note py18 px18 round flex-parent flex-parent--row mb18"
-  style={
-    Object {
-      "background": "#feefe2",
-      "color": "#78471c",
-    }
-  }
->
-  <div
-    className="flex-child mr18 none block-mm pt3"
-  >
-    <div
-      className="bg-orange-light round-full color-orange flex-parent flex-parent--center-main flex-parent--center-cross"
-      style={
-        Object {
-          "height": 50,
-          "width": 50,
-        }
-      }
-    >
-      <svg
-        className="events-none icon"
-        focusable="false"
-        role="presentation"
-        style={
-          Object {
-            "height": 40,
-            "width": 40,
-          }
-        }
-      >
-        <use
-          xlinkHref="#icon-alert"
-          xmlnsXlink="http://www.w3.org/1999/xlink"
-        />
-      </svg>
-    </div>
-  </div>
-  <div
-    className="flex-child prose"
-  >
-    <div
-      className="txt-bold txt-m mb6"
-    >
-      Mapbox GL unsupported
-    </div>
-    Mapbox GL is unsupported due to insufficient worker support.
-  </div>
-</div>
-`;
-
 exports[`gl-wrapper Basic renders as expected 1`] = `
 <div
   className="dr-ui--note py18 px18 round flex-parent flex-parent--row mb18"

--- a/src/components/gl-wrapper/__tests__/__snapshots__/gl-wrapper.test.js.snap
+++ b/src/components/gl-wrapper/__tests__/__snapshots__/gl-wrapper.test.js.snap
@@ -1,5 +1,88 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gl-wrapper Basic renders IE 11 message 1`] = `
+<div
+  className="dr-ui--note py18 px18 round flex-parent flex-parent--row mb18"
+  style={
+    Object {
+      "background": "#feefe2",
+      "color": "#78471c",
+    }
+  }
+>
+  <div
+    className="flex-child mr18 none block-mm pt3"
+  >
+    <div
+      className="bg-orange-light round-full color-orange flex-parent flex-parent--center-main flex-parent--center-cross"
+      style={
+        Object {
+          "height": 50,
+          "width": 50,
+        }
+      }
+    >
+      <svg
+        className="events-none icon"
+        focusable="false"
+        role="presentation"
+        style={
+          Object {
+            "height": 40,
+            "width": 40,
+          }
+        }
+      >
+        <use
+          xlinkHref="#icon-alert"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
+        />
+      </svg>
+    </div>
+  </div>
+  <div
+    className="flex-child prose"
+  >
+    <div
+      className="txt-bold txt-m mb6"
+    >
+      Mapbox GL unsupported
+    </div>
+    Starting with v2.0.0, Mapbox GL JS is no longer compatible with any version of Internet Explorer. If you need to support Internet Explorer, consider using the
+     
+    <a
+      href="https://docs.mapbox.com/api/maps/static-images/"
+    >
+      Mapbox Static Images API
+    </a>
+     
+    for non-interactive maps or using the
+     
+    <a
+      href="https://docs.mapbox.com/api/maps/static-tiles/"
+    >
+      Mapbox Static Tiles API
+    </a>
+     
+    with another library (for example,
+     
+    <a
+      href="https://docs.mapbox.com/mapbox.js/"
+    >
+      Mapbox.js
+    </a>
+     or
+     
+    <a
+      href="https://leafletjs.com/"
+    >
+      Leaflet
+    </a>
+    ) for interactive maps.
+  </div>
+</div>
+`;
+
 exports[`gl-wrapper Basic renders as expected 1`] = `
 <div
   className="dr-ui--note py18 px18 round flex-parent flex-parent--row mb18"

--- a/src/components/gl-wrapper/__tests__/gl-wrapper-test-cases.js
+++ b/src/components/gl-wrapper/__tests__/gl-wrapper-test-cases.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Basic from '../examples/basic';
+import GLWrapper from '../../gl-wrapper';
 
 const testCases = {};
 const noRenderCases = {};
@@ -7,6 +8,24 @@ const noRenderCases = {};
 testCases.basic = {
   description: 'Basic',
   element: <Basic />
+};
+
+noRenderCases.ie = {
+  description: "reason='insufficient ECMAScript 6 support'",
+  element: (
+    <GLWrapper reason="insufficient ECMAScript 6 support">
+      Your browser supports Mapbox GL!
+    </GLWrapper>
+  )
+};
+
+noRenderCases.webgl = {
+  description: "reason='insufficient WebGL support'",
+  element: (
+    <GLWrapper reason="insufficient WebGL support">
+      Your browser supports Mapbox GL!
+    </GLWrapper>
+  )
 };
 
 export { testCases, noRenderCases };

--- a/src/components/gl-wrapper/__tests__/gl-wrapper.test.js
+++ b/src/components/gl-wrapper/__tests__/gl-wrapper.test.js
@@ -3,10 +3,17 @@ import { testCases } from './gl-wrapper-test-cases.js';
 
 describe('gl-wrapper', () => {
   describe(testCases.basic.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.basic;
+      wrapper = renderer.create(testCase.element);
+      tree = wrapper.toJSON();
+    });
+
     test('renders as expected', () => {
-      const testCase = testCases.basic;
-      const wrapper = renderer.create(testCase.element);
-      const tree = wrapper.toJSON();
       expect(tree).toMatchSnapshot();
     });
   });

--- a/src/components/gl-wrapper/__tests__/gl-wrapper.test.js
+++ b/src/components/gl-wrapper/__tests__/gl-wrapper.test.js
@@ -1,5 +1,5 @@
 import renderer from 'react-test-renderer';
-import { testCases } from './gl-wrapper-test-cases.js';
+import { testCases, noRenderCases } from './gl-wrapper-test-cases.js';
 
 describe('gl-wrapper', () => {
   describe(testCases.basic.description, () => {
@@ -9,6 +9,38 @@ describe('gl-wrapper', () => {
 
     beforeEach(() => {
       testCase = testCases.basic;
+      wrapper = renderer.create(testCase.element);
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe(noRenderCases.ie.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = noRenderCases.ie;
+      wrapper = renderer.create(testCase.element);
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe(noRenderCases.webgl.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = noRenderCases.webgl;
       wrapper = renderer.create(testCase.element);
       tree = wrapper.toJSON();
     });

--- a/src/components/gl-wrapper/__tests__/gl-wrapper.test.js
+++ b/src/components/gl-wrapper/__tests__/gl-wrapper.test.js
@@ -3,17 +3,18 @@ import { testCases } from './gl-wrapper-test-cases.js';
 
 describe('gl-wrapper', () => {
   describe(testCases.basic.description, () => {
-    let testCase;
-    let wrapper;
-    let tree;
-
-    beforeEach(() => {
-      testCase = testCases.basic;
-      wrapper = renderer.create(testCase.element);
-      tree = wrapper.toJSON();
+    test('renders as expected', () => {
+      const testCase = testCases.basic;
+      const wrapper = renderer.create(testCase.element);
+      const tree = wrapper.toJSON();
+      expect(tree).toMatchSnapshot();
     });
 
-    test('renders as expected', () => {
+    test('renders IE 11 message', () => {
+      global.document.documentMode = 11;
+      const testCase = testCases.basic;
+      const wrapper = renderer.create(testCase.element);
+      const tree = wrapper.toJSON();
       expect(tree).toMatchSnapshot();
     });
   });

--- a/src/components/gl-wrapper/__tests__/gl-wrapper.test.js
+++ b/src/components/gl-wrapper/__tests__/gl-wrapper.test.js
@@ -9,13 +9,5 @@ describe('gl-wrapper', () => {
       const tree = wrapper.toJSON();
       expect(tree).toMatchSnapshot();
     });
-
-    test('renders IE 11 message', () => {
-      global.document.documentMode = 11;
-      const testCase = testCases.basic;
-      const wrapper = renderer.create(testCase.element);
-      const tree = wrapper.toJSON();
-      expect(tree).toMatchSnapshot();
-    });
   });
 });

--- a/src/components/gl-wrapper/examples/basic.js
+++ b/src/components/gl-wrapper/examples/basic.js
@@ -6,6 +6,6 @@ import GLWrapper from '../gl-wrapper';
 
 export default class Basic extends React.Component {
   render() {
-    return <GLWrapper>Your browser has GL enabled!</GLWrapper>;
+    return <GLWrapper>Your browser supports Mapbox GL!</GLWrapper>;
   }
 }

--- a/src/components/gl-wrapper/gl-wrapper.js
+++ b/src/components/gl-wrapper/gl-wrapper.js
@@ -49,7 +49,7 @@ export default class GLWrapper extends React.Component {
   };
 
   determineReason = () => {
-    const reason = notSupportedReason();
+    const reason = this.props.reason ? this.props.reason : notSupportedReason();
     if (reason === 'insufficient ECMAScript 6 support')
       return this.renderIEMessage();
     if (reason === 'insufficient WebGL support') return this.renderGLMessage();
@@ -69,5 +69,8 @@ export default class GLWrapper extends React.Component {
 }
 
 GLWrapper.propTypes = {
-  children: PropTypes.node.isRequired
+  /* The content that should be displayed if the browser supports Mapbox GL. */
+  children: PropTypes.node.isRequired,
+  /* Override the GL supported reason (often used for testing). */
+  reason: PropTypes.string
 };

--- a/src/components/gl-wrapper/gl-wrapper.js
+++ b/src/components/gl-wrapper/gl-wrapper.js
@@ -13,13 +13,28 @@ export default class GLWrapper extends React.Component {
   componentDidMount() {
     this.setState({ supported: supported() });
   }
-  render() {
-    // wait for supported() to push to state
-    if (this.state.supported === undefined) return <div />;
-    return this.state.supported ? (
-      this.props.children
-    ) : (
-      <Note title="Mapbox GL unsupported" theme="warning">
+  renderIEMessage = () => {
+    return (
+      <React.Fragment>
+        Starting with v2.0.0, Mapbox GL JS is no longer compatible with any
+        version of Internet Explorer. If you need to support Internet Explorer,
+        consider using the{' '}
+        <a href="https://docs.mapbox.com/api/maps/static-images/">
+          Mapbox Static Images API
+        </a>{' '}
+        for non-interactive maps or using the{' '}
+        <a href="https://docs.mapbox.com/api/maps/static-tiles/">
+          Mapbox Static Tiles API
+        </a>{' '}
+        with another library (for example,{' '}
+        <a href="https://docs.mapbox.com/mapbox.js/">Mapbox.js</a> or{' '}
+        <a href="https://leafletjs.com/">Leaflet</a>) for interactive maps.
+      </React.Fragment>
+    );
+  };
+  renderGLMessage = () => {
+    return (
+      <React.Fragment>
         Mapbox GL requires{' '}
         <a className="link" href="https://caniuse.com/#feat=webgl">
           WebGL support
@@ -29,6 +44,19 @@ export default class GLWrapper extends React.Component {
           WebGL is enabled
         </a>
         .
+      </React.Fragment>
+    );
+  };
+  render() {
+    // wait for supported() to push to state
+    if (this.state.supported === undefined) return <div />;
+    const isIe11 =
+      typeof window !== 'undefined' && window.document.documentMode;
+    return this.state.supported ? (
+      this.props.children
+    ) : (
+      <Note title="Mapbox GL unsupported" theme="warning">
+        {isIe11 ? this.renderIEMessage() : this.renderGLMessage()}
       </Note>
     );
   }

--- a/src/components/gl-wrapper/gl-wrapper.js
+++ b/src/components/gl-wrapper/gl-wrapper.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import supported from '@mapbox/mapbox-gl-supported';
+import { supported, notSupportedReason } from '@mapbox/mapbox-gl-supported';
 import Note from '../note';
 
 export default class GLWrapper extends React.Component {
@@ -47,16 +47,22 @@ export default class GLWrapper extends React.Component {
       </React.Fragment>
     );
   };
+
+  determineReason = () => {
+    const reason = notSupportedReason();
+    if (reason === 'insufficient ECMAScript 6 support')
+      return this.renderIEMessage();
+    if (reason === 'insufficient WebGL support') return this.renderGLMessage();
+    else return `Mapbox GL is unsupported due to ${reason}.`;
+  };
   render() {
     // wait for supported() to push to state
     if (this.state.supported === undefined) return <div />;
-    const isIe11 =
-      typeof window !== 'undefined' && window.document.documentMode;
     return this.state.supported ? (
       this.props.children
     ) : (
       <Note title="Mapbox GL unsupported" theme="warning">
-        {isIe11 ? this.renderIEMessage() : this.renderGLMessage()}
+        {this.determineReason()}
       </Note>
     );
   }


### PR DESCRIPTION
This PR:

- Update mapbox-gl-supported to the latest.
- Reworks the message for GLWrapper to use `notSupportedReason` provided by mapbox-gl-supported:
  - If IE 11, show our message about IE 11 and Mapbox GL JS support.
  - If no WebGL support, show original GLWrapper message.
  - else let the user know the reason supplied by `notSupportedReason`. (There can be [many reasons](https://github.com/mapbox/mapbox-gl-supported/blob/214c1ed12dba316a6434469384010948354a8c69/index.js#L18-L30) why Mapbox GL is unsupported that are unrelated to WebGL or IE!)
- Adds an optional prop to GlWrapper: `reason`. This allows us to create (non-rendering) test cases for IE and no WebGL support to generate snapshot tests. This will be helpful in case future mapbox-gl-supported versions change the handling of these two reasons.

## How to test

Because Jest doesn't have WebWorker support, it makes it difficult to generate separate tests for IE 11 support, no WebGl support, and any other messages. (You'll noticed that the snapshot tests updated to state the reason for GL unsupported is due to `Mapbox GL is unsupported due to insufficient worker support.`)

You can also manually test the GlWrapper:

1. Run test-cases app and open /GlWrapper (npm start)
2. Open page in IE 11 via BrowserStack, it should look like:
![image](https://user-images.githubusercontent.com/2180540/102925717-ecc85300-4461-11eb-8fdd-56798f7da24f.png)


One way to check for WebGL support is to disable it in Firefox (temporarily):

1. In Firefox go to `about:config`
2. Search for `webgl.disable` and set it to `true.
3. Open page in Firefox, it should look like:
![image](https://user-images.githubusercontent.com/2180540/102925618-b8ed2d80-4461-11eb-9eee-7bf41bf810d1.png)



## QA checklist

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] IE11, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.


Fixes #387 