### PR TITLE
Add Lazy component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Lazy
+
 ## 2.3.0
 
 - Update `GlWrapper` component to check for Internet Explorer and provide reason for when the issue is not Internet Explorer or WebGL support. [#387](https://github.com/mapbox/dr-ui/pull/387)

--- a/docs/src/categories.json
+++ b/docs/src/categories.json
@@ -9,6 +9,7 @@
     "Browser",
     "DemoIframe",
     "GLWrapper",
+    "Lazy",
     "Phone",
     "Video"
   ],

--- a/docs/src/pages/guides/lazy.md
+++ b/docs/src/pages/guides/lazy.md
@@ -1,0 +1,13 @@
+---
+title: Lazy loading
+description: Learn when to use lazy loading.
+order: 5
+layout: page
+contentType: guide
+products:
+  - Documentation
+prependJs:
+  - "import Lazy from '../../../../src/components/lazy/lazy';"
+---
+
+{{<Lazy lazyClasses="h30-mm h36" lazyComponent={() => import('../../../../src/components/search/examples/basic.js')} />}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8066,14 +8066,15 @@
       }
     },
     "@mapbox/remark-lint-mapbox": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/remark-lint-mapbox/-/remark-lint-mapbox-2.2.0.tgz",
-      "integrity": "sha512-jDzilXe/7g2puoTEQhvks739k5gpOmlf4geaQBULLkpci/VkKt9Ep16DKVdfGE1OBF7ygkQZ4IiCB7w6b9Mkcw==",
+      "version": "2.4.0-perf.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/remark-lint-mapbox/-/remark-lint-mapbox-2.4.0-perf.0.tgz",
+      "integrity": "sha512-nOchfpjEoZALw+JOARySndKVM7ZR5VallYKHOVW9rwhEX8V4PmczzObekfwq4UAzK4SKjDOb/ek0DTpfd1ihsg==",
       "dev": true,
       "requires": {
         "@mapbox/jsxtreme-markdown": "^1.0.0",
+        "babel-eslint": "^10.1.0",
         "check-links": "^1.1.8",
-        "js-yaml": "^3.14.0",
+        "js-yaml": "^3.14.1",
         "unified-lint-rule": "^1.0.6",
         "unist-util-generated": "^1.1.6",
         "unist-util-visit": "^2.0.3",
@@ -8082,9 +8083,9 @@
       },
       "dependencies": {
         "js-yaml": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-          "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -8098,9 +8099,9 @@
           "dev": true
         },
         "unist-util-is": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.3.tgz",
-          "integrity": "sha512-bTofCFVx0iQM8Jqb1TBDVRIQW03YkD3p66JOd/aCWuqzlLyUtx1ZAGw/u+Zw+SttKvSVcvTiKYbfrtLoLefykw==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.4.tgz",
+          "integrity": "sha512-3dF39j/u423v4BBQrk1AQ2Ve1FxY5W3JKwXxVFzBODQ6WEvccguhgp802qQLKSnxPODE6WuRZtV+ohlUg4meBA==",
           "dev": true
         },
         "unist-util-visit-parents": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5012,6 +5012,36 @@
         }
       }
     },
+    "@loadable/component": {
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/@loadable/component/-/component-5.14.1.tgz",
+      "integrity": "sha512-UQBZfZrp1FLTf8RNhljXNHFNY4QhAA1L2+GOEeABBFre9TD0aFyQh3Sai5QxcOfy+FTbjIfti5iHaNRR7yUzEQ==",
+      "requires": {
+        "@babel/runtime": "^7.7.7",
+        "hoist-non-react-statics": "^3.3.1",
+        "react-is": "^16.12.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        }
+      }
+    },
     "@mapbox/appropriate-images-get-url": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@mapbox/appropriate-images-get-url/-/appropriate-images-get-url-0.1.1.tgz",
@@ -17598,6 +17628,14 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "homedir-polyfill": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@mapbox/rehype-prism": "^0.5.0",
     "@mapbox/remark-config-docs": "^0.9.0",
     "@mapbox/remark-lint-link-text": "^0.5.0",
-    "@mapbox/remark-lint-mapbox": "^2.2.0",
+    "@mapbox/remark-lint-mapbox": "^2.4.0-perf.0",
     "babel-eslint": "^10.1.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "babelify": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "@elastic/react-search-ui": "1.3.2",
     "@elastic/react-search-ui-views": "1.3.2",
     "@elastic/search-ui-site-search-connector": "1.3.2",
+    "@loadable/component": "^5.14.1",
     "@mapbox/mapbox-gl-supported": "^2.0.0",
     "@mapbox/mr-ui": "^0.9.1",
     "@sentry/browser": "^5.27.4",

--- a/src/components/lazy/__tests__/__snapshots__/lazy.test.js.snap
+++ b/src/components/lazy/__tests__/__snapshots__/lazy.test.js.snap
@@ -5,7 +5,7 @@ exports[`Lazy Basic renders as expected 1`] = `
   className="relative"
   style={
     Object {
-      "height": 500,
+      "height": 30,
     }
   }
 >

--- a/src/components/lazy/__tests__/__snapshots__/lazy.test.js.snap
+++ b/src/components/lazy/__tests__/__snapshots__/lazy.test.js.snap
@@ -1,5 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Lazy A larger example renders as expected 1`] = `
+<div
+  className="relative"
+  style={
+    Object {
+      "height": 850,
+    }
+  }
+>
+  <div
+    className="flex-parent flex-parent--center-cross flex-parent--center-main absolute top right bottom left bg-darken10 z5 round"
+  >
+    <div
+      className="flex-child loading"
+    />
+  </div>
+</div>
+`;
+
 exports[`Lazy Basic renders as expected 1`] = `
 <div
   className="relative"
@@ -13,7 +32,7 @@ exports[`Lazy Basic renders as expected 1`] = `
     className="flex-parent flex-parent--center-cross flex-parent--center-main absolute top right bottom left bg-darken10 z5 round"
   >
     <div
-      className="flex-child loading"
+      className="flex-child loading loading--s"
     />
   </div>
 </div>

--- a/src/components/lazy/__tests__/__snapshots__/lazy.test.js.snap
+++ b/src/components/lazy/__tests__/__snapshots__/lazy.test.js.snap
@@ -13,7 +13,7 @@ exports[`Lazy A larger example renders as expected 1`] = `
     className="flex-parent flex-parent--center-cross flex-parent--center-main absolute top right bottom left bg-darken10 z5 round"
   >
     <div
-      className="flex-child loading"
+      className="flex-child loading loading--s"
     />
   </div>
 </div>
@@ -21,12 +21,8 @@ exports[`Lazy A larger example renders as expected 1`] = `
 
 exports[`Lazy Basic renders as expected 1`] = `
 <div
-  className="relative"
-  style={
-    Object {
-      "height": 30,
-    }
-  }
+  className="relative h30-mm h36"
+  style={Object {}}
 >
   <div
     className="flex-parent flex-parent--center-cross flex-parent--center-main absolute top right bottom left bg-darken10 z5 round"

--- a/src/components/lazy/__tests__/__snapshots__/lazy.test.js.snap
+++ b/src/components/lazy/__tests__/__snapshots__/lazy.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Lazy Basic renders as expected 1`] = `
+<div
+  className="relative"
+  style={
+    Object {
+      "height": 500,
+    }
+  }
+>
+  <div
+    className="flex-parent flex-parent--center-cross flex-parent--center-main absolute top right bottom left bg-darken10 z5 round"
+  >
+    <div
+      className="flex-child loading"
+    />
+  </div>
+</div>
+`;

--- a/src/components/lazy/__tests__/lazy-test-cases.js
+++ b/src/components/lazy/__tests__/lazy-test-cases.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import Basic from '../examples/basic';
+
+const testCases = {};
+const noRenderCases = {};
+
+testCases.basic = {
+  description: 'Basic',
+  element: <Basic />
+};
+
+export { testCases, noRenderCases };

--- a/src/components/lazy/__tests__/lazy-test-cases.js
+++ b/src/components/lazy/__tests__/lazy-test-cases.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Basic from '../examples/basic';
+import Lazy from '../../lazy/lazy';
 
 const testCases = {};
 const noRenderCases = {};
@@ -7,6 +8,16 @@ const noRenderCases = {};
 testCases.basic = {
   description: 'Basic',
   element: <Basic />
+};
+
+testCases.larger = {
+  description: 'A larger example',
+  element: (
+    <Lazy
+      lazyHeight={850}
+      lazyComponent={() => import('../../video/examples/basic.js')}
+    />
+  )
 };
 
 export { testCases, noRenderCases };

--- a/src/components/lazy/__tests__/lazy.test.js
+++ b/src/components/lazy/__tests__/lazy.test.js
@@ -1,0 +1,20 @@
+import renderer from 'react-test-renderer';
+import { testCases } from './lazy-test-cases.js';
+
+describe('Lazy', () => {
+  describe(testCases.basic.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.basic;
+      wrapper = renderer.create(testCase.element);
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/lazy/__tests__/lazy.test.js
+++ b/src/components/lazy/__tests__/lazy.test.js
@@ -17,4 +17,20 @@ describe('Lazy', () => {
       expect(tree).toMatchSnapshot();
     });
   });
+
+  describe(testCases.larger.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.larger;
+      wrapper = renderer.create(testCase.element);
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
 });

--- a/src/components/lazy/examples/basic.js
+++ b/src/components/lazy/examples/basic.js
@@ -8,7 +8,7 @@ export default class Basic extends React.PureComponent {
   render() {
     return (
       <Lazy
-        lazyHeight={30}
+        lazyClasses="h30-mm h36"
         lazyComponent={() => import('../../search/examples/basic.js')}
       />
     );

--- a/src/components/lazy/examples/basic.js
+++ b/src/components/lazy/examples/basic.js
@@ -9,7 +9,7 @@ export default class Basic extends React.PureComponent {
     return (
       <Lazy
         lazyHeight={30}
-        component={() => import('../../search/examples/basic.js')}
+        lazyComponent={() => import('../../search/examples/basic.js')}
       />
     );
   }

--- a/src/components/lazy/examples/basic.js
+++ b/src/components/lazy/examples/basic.js
@@ -1,5 +1,5 @@
 /*
-Lazy load a video
+Lazy load the Search component
 */
 import React from 'react';
 import Lazy from '../lazy';
@@ -8,8 +8,8 @@ export default class Basic extends React.PureComponent {
   render() {
     return (
       <Lazy
-        height={500}
-        component={() => import('../../video/examples/basic.js')}
+        height={30}
+        component={() => import('../../search/examples/basic.js')}
       />
     );
   }

--- a/src/components/lazy/examples/basic.js
+++ b/src/components/lazy/examples/basic.js
@@ -1,0 +1,16 @@
+/*
+Lazy load a video
+*/
+import React from 'react';
+import Lazy from '../lazy';
+
+export default class Basic extends React.PureComponent {
+  render() {
+    return (
+      <Lazy
+        height={500}
+        component={() => import('../../video/examples/basic.js')}
+      />
+    );
+  }
+}

--- a/src/components/lazy/examples/basic.js
+++ b/src/components/lazy/examples/basic.js
@@ -8,7 +8,7 @@ export default class Basic extends React.PureComponent {
   render() {
     return (
       <Lazy
-        height={30}
+        lazyHeight={30}
         component={() => import('../../search/examples/basic.js')}
       />
     );

--- a/src/components/lazy/index.js
+++ b/src/components/lazy/index.js
@@ -1,0 +1,3 @@
+import main from './lazy';
+
+export default main;

--- a/src/components/lazy/lazy.js
+++ b/src/components/lazy/lazy.js
@@ -5,19 +5,23 @@ import loadable from '@loadable/component';
 
 export default class Lazy extends React.Component {
   render() {
-    const { lazyHeight, lazyComponent } = this.props;
+    const { lazyHeight, lazyComponent, lazyClasses } = this.props;
     const LazyLoadComponent = loadable(lazyComponent);
-    const Loader = () => (
-      <div style={{ height: lazyHeight }} className="relative">
-        <div className="flex-parent flex-parent--center-cross flex-parent--center-main absolute top right bottom left bg-darken10 z5 round">
-          <div
-            className={`flex-child loading${
-              lazyHeight < 60 ? ' loading--s' : ''
-            }`}
-          ></div>
+    const Loader = () => {
+      const loaderClasses = `relative${lazyClasses ? ` ${lazyClasses}` : ''}`;
+      return (
+        <div
+          style={{
+            ...(lazyHeight && { height: lazyHeight })
+          }}
+          className={loaderClasses}
+        >
+          <div className="flex-parent flex-parent--center-cross flex-parent--center-main absolute top right bottom left bg-darken10 z5 round">
+            <div className="flex-child loading loading--s" />
+          </div>
         </div>
-      </div>
-    );
+      );
+    };
     return (
       <ErrorBoundary>
         <LazyLoadComponent fallback={<Loader />} {...this.props} />
@@ -32,5 +36,7 @@ Lazy.propTypes = {
   Example: `lazyComponent={() => import('../components/example.js')}`*/
   lazyComponent: PropTypes.func.isRequired,
   /** Height of the component. This is needed to set the height of the loader to prevent content shift when the component loads. */
-  lazyHeight: PropTypes.number.isRequired
+  lazyHeight: PropTypes.number,
+  /** Classes to describe the height of the component, when `lazyHeight` will not suffice. */
+  lazyClasses: PropTypes.string
 };

--- a/src/components/lazy/lazy.js
+++ b/src/components/lazy/lazy.js
@@ -1,0 +1,34 @@
+import React, { Suspense } from 'react';
+import PropTypes from 'prop-types';
+import ErrorBoundary from '../error-boundary/error-boundary';
+
+export default class Lazy extends React.PureComponent {
+  render() {
+    const { height, component } = this.props;
+    const LazyLoadComponent = React.lazy(component);
+    return (
+      <ErrorBoundary>
+        <Suspense
+          fallback={
+            <div style={{ height: height }} className="relative">
+              <div className="flex-parent flex-parent--center-cross flex-parent--center-main absolute top right bottom left bg-darken10 z5 round">
+                <div className="flex-child loading"></div>
+              </div>
+            </div>
+          }
+        >
+          <LazyLoadComponent {...this.props} />
+        </Suspense>
+      </ErrorBoundary>
+    );
+  }
+}
+
+Lazy.propTypes = {
+  /** Dynamic import function with path to the component. The file containing the component must be a default export. 
+
+  Example: `component={() => import('../components/example.js')}`*/
+  component: PropTypes.func.isRequired,
+  /** Height of the component. This is needed to set the height of the loader to prevent content shift when the component loads. */
+  height: PropTypes.number.isRequired
+};

--- a/src/components/lazy/lazy.js
+++ b/src/components/lazy/lazy.js
@@ -6,22 +6,21 @@ import loadable from '@loadable/component';
 export default class Lazy extends React.Component {
   render() {
     const { lazyHeight, lazyComponent } = this.props;
-    const LazyLoadComponent = loadable(lazyComponent, {
-      fallback: (
-        <div style={{ height: lazyHeight }} className="relative">
-          <div className="flex-parent flex-parent--center-cross flex-parent--center-main absolute top right bottom left bg-darken10 z5 round">
-            <div
-              className={`flex-child loading${
-                lazyHeight < 60 ? ' loading--s' : ''
-              }`}
-            ></div>
-          </div>
+    const LazyLoadComponent = loadable(lazyComponent);
+    const Loader = () => (
+      <div style={{ height: lazyHeight }} className="relative">
+        <div className="flex-parent flex-parent--center-cross flex-parent--center-main absolute top right bottom left bg-darken10 z5 round">
+          <div
+            className={`flex-child loading${
+              lazyHeight < 60 ? ' loading--s' : ''
+            }`}
+          ></div>
         </div>
-      )
-    });
+      </div>
+    );
     return (
       <ErrorBoundary>
-        <LazyLoadComponent {...this.props} />
+        <LazyLoadComponent fallback={<Loader />} {...this.props} />
       </ErrorBoundary>
     );
   }

--- a/src/components/lazy/lazy.js
+++ b/src/components/lazy/lazy.js
@@ -5,8 +5,8 @@ import loadable from '@loadable/component';
 
 export default class Lazy extends React.Component {
   render() {
-    const { lazyHeight, component } = this.props;
-    const LazyLoadComponent = loadable(component, {
+    const { lazyHeight, lazyComponent } = this.props;
+    const LazyLoadComponent = loadable(lazyComponent, {
       fallback: (
         <div style={{ height: lazyHeight }} className="relative">
           <div className="flex-parent flex-parent--center-cross flex-parent--center-main absolute top right bottom left bg-darken10 z5 round">
@@ -30,8 +30,8 @@ export default class Lazy extends React.Component {
 Lazy.propTypes = {
   /** Dynamic import function with path to the component. The file containing the component must be a default export. 
 
-  Example: `component={() => import('../components/example.js')}`*/
-  component: PropTypes.func.isRequired,
+  Example: `lazyComponent={() => import('../components/example.js')}`*/
+  lazyComponent: PropTypes.func.isRequired,
   /** Height of the component. This is needed to set the height of the loader to prevent content shift when the component loads. */
   lazyHeight: PropTypes.number.isRequired
 };

--- a/src/components/lazy/lazy.js
+++ b/src/components/lazy/lazy.js
@@ -1,24 +1,27 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import ErrorBoundary from '../error-boundary/error-boundary';
+import loadable from '@loadable/component';
 
-export default class Lazy extends React.PureComponent {
+export default class Lazy extends React.Component {
   render() {
     const { lazyHeight, component } = this.props;
-    const LazyLoadComponent = React.lazy(component);
+    const LazyLoadComponent = loadable(component, {
+      fallback: (
+        <div style={{ height: lazyHeight }} className="relative">
+          <div className="flex-parent flex-parent--center-cross flex-parent--center-main absolute top right bottom left bg-darken10 z5 round">
+            <div
+              className={`flex-child loading${
+                lazyHeight < 60 ? ' loading--s' : ''
+              }`}
+            ></div>
+          </div>
+        </div>
+      )
+    });
     return (
       <ErrorBoundary>
-        <Suspense
-          fallback={
-            <div style={{ height: lazyHeight }} className="relative">
-              <div className="flex-parent flex-parent--center-cross flex-parent--center-main absolute top right bottom left bg-darken10 z5 round">
-                <div className="flex-child loading"></div>
-              </div>
-            </div>
-          }
-        >
-          <LazyLoadComponent {...this.props} />
-        </Suspense>
+        <LazyLoadComponent {...this.props} />
       </ErrorBoundary>
     );
   }

--- a/src/components/lazy/lazy.js
+++ b/src/components/lazy/lazy.js
@@ -30,13 +30,42 @@ export default class Lazy extends React.Component {
   }
 }
 
+/* prop function to assert that lazyHeight or lazyClasses is defined and is the right type */
+const heightOrClasses = (props, propName, componentName) => {
+  if (!props.lazyClasses && !props.lazyHeight) {
+    return new Error(
+      `You must define \`lazyClasses\` or \`lazyHeight\` in ${componentName}`
+    );
+  }
+  if (
+    propName === 'lazyClasses' &&
+    props.lazyClasses &&
+    typeof props.lazyClasses !== 'string'
+  ) {
+    return new Error(
+      `\`lazyClasses\` must be a string, received ${typeof props.lazyClasses}`
+    );
+  }
+  if (
+    propName === 'lazyHeight' &&
+    props.lazyHeight &&
+    typeof props.lazyHeight !== 'number'
+  ) {
+    return new Error(
+      `\`lazyClasses\` must be a number, received ${typeof props.lazyHeight}`
+    );
+  }
+};
+
 Lazy.propTypes = {
   /** Dynamic import function with path to the component. The file containing the component must be a default export. 
 
   Example: `lazyComponent={() => import('../components/example.js')}`*/
   lazyComponent: PropTypes.func.isRequired,
   /** Height of the component. This is needed to set the height of the loader to prevent content shift when the component loads. */
-  lazyHeight: PropTypes.number,
+  lazyHeight: (props, propName, componentName) =>
+    heightOrClasses(props, propName, componentName),
   /** Classes to describe the height of the component, when `lazyHeight` will not suffice. */
-  lazyClasses: PropTypes.string
+  lazyClasses: (props, propName, componentName) =>
+    heightOrClasses(props, propName, componentName)
 };

--- a/src/components/lazy/lazy.js
+++ b/src/components/lazy/lazy.js
@@ -52,7 +52,7 @@ const heightOrClasses = (props, propName, componentName) => {
     typeof props.lazyHeight !== 'number'
   ) {
     return new Error(
-      `\`lazyClasses\` must be a number, received ${typeof props.lazyHeight}`
+      `\`lazyHeight\` must be a number, received ${typeof props.lazyHeight}`
     );
   }
 };

--- a/src/components/lazy/lazy.js
+++ b/src/components/lazy/lazy.js
@@ -62,10 +62,10 @@ Lazy.propTypes = {
 
   Example: `lazyComponent={() => import('../components/example.js')}`*/
   lazyComponent: PropTypes.func.isRequired,
-  /** Height of the component. This is needed to set the height of the loader to prevent content shift when the component loads. */
+  /** Height of the component. This is needed to set the height of the loader to prevent content shift when the component loads. Accepts a number. Required if `lazyClasses` is not defined. */
   lazyHeight: (props, propName, componentName) =>
     heightOrClasses(props, propName, componentName),
-  /** Classes to describe the height of the component, when `lazyHeight` will not suffice. */
+  /** Classes to describe the height of the component, when `lazyHeight` will not suffice.  Accepts a string. Required if `lazyHeight` is not defined. */
   lazyClasses: (props, propName, componentName) =>
     heightOrClasses(props, propName, componentName)
 };

--- a/src/components/lazy/lazy.js
+++ b/src/components/lazy/lazy.js
@@ -4,13 +4,13 @@ import ErrorBoundary from '../error-boundary/error-boundary';
 
 export default class Lazy extends React.PureComponent {
   render() {
-    const { height, component } = this.props;
+    const { lazyHeight, component } = this.props;
     const LazyLoadComponent = React.lazy(component);
     return (
       <ErrorBoundary>
         <Suspense
           fallback={
-            <div style={{ height: height }} className="relative">
+            <div style={{ height: lazyHeight }} className="relative">
               <div className="flex-parent flex-parent--center-cross flex-parent--center-main absolute top right bottom left bg-darken10 z5 round">
                 <div className="flex-child loading"></div>
               </div>
@@ -30,5 +30,5 @@ Lazy.propTypes = {
   Example: `component={() => import('../components/example.js')}`*/
   component: PropTypes.func.isRequired,
   /** Height of the component. This is needed to set the height of the loader to prevent content shift when the component loads. */
-  height: PropTypes.number.isRequired
+  lazyHeight: PropTypes.number.isRequired
 };

--- a/src/helpers/batfish/__tests__/fixtures/data.json
+++ b/src/helpers/batfish/__tests__/fixtures/data.json
@@ -261,6 +261,12 @@
       "filePath": "./docs/src/pages/index.js",
       "path": "/dr-ui/",
       "frontMatter": {}
+    },
+    {
+      "filePath": "./node_modules/@mapbox/batfish/dist/webpack/default-not-found.js",
+      "path": "/dr-ui/404/",
+      "is404": true,
+      "frontMatter": {}
     }
   ]
 }

--- a/src/helpers/batfish/__tests__/fixtures/data.json
+++ b/src/helpers/batfish/__tests__/fixtures/data.json
@@ -261,12 +261,6 @@
       "filePath": "./docs/src/pages/index.js",
       "path": "/dr-ui/",
       "frontMatter": {}
-    },
-    {
-      "filePath": "./node_modules/@mapbox/batfish/dist/webpack/default-not-found.js",
-      "path": "/dr-ui/404/",
-      "is404": true,
-      "frontMatter": {}
     }
   ]
 }


### PR DESCRIPTION
_This PR merges in to the `perf` branch #393 ._

This PR adds a new component, `Lazy`. It's a wrapper for https://loadable-components.com/ which is the React team's recommended alternative for lazy loading components server side (`React.lazy` is not supported on the server side by React, yet). 

`Lazy` accepts two props:

- `lazyComponent` a function to import the desired component
- `lazyHeight` the height of the imported component to reduce content layout shift during load.
- `lazyClasses` is an alternative to `lazyHeight` in case the height of the component is variable, you can define classes to best describe the height of the component.

You must define `lazyHeight` or `lazyClasses`.

You can also pass props to `Lazy` that will be passed along to the import component. The lazy props are named distinctly to avoid prop name collisions.

The component will display a loader while the `lazyComponent` loads. 

Fixes #388 

## How to test

- [ ] Open test cases app (`npm start`) at /Lazy. The example is lazy loading the Search component. Confirm that the Search component loads as expect.

## QA checklist

<!-- complete this checklist when adding a new component or package -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `6.4.0`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] IE11, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.
