### PR TITLE
Improve contrast on syntax highlighting

### DIFF
--- a/docs/src/pages/guides/a11y.md
+++ b/docs/src/pages/guides/a11y.md
@@ -1,0 +1,42 @@
+---
+title: Accessibility test page
+description: Page for testing accessibility of components.
+layout: page
+order: 6
+contentType: guide
+products:
+  - Documentation
+prependJs:
+  - "import Note from '../../../../src/components/note/note';"
+---
+
+Use this test page to check color contrast and other accessibility considerations.
+
+## Test cases
+
+Use [`map.addLayer()`](https://docs.mapbox.com/mapbox-gl-js/api/map/#map#addlayer) in Mapbox GL JS.
+
+```xml
+<uses-permission android:name="android.permission.INTERNET" />
+<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+<uses-permission android:name="android.permission.CAMERA" />
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+```
+
+{{ <Note> }}
+Use [`map.addLayer()`](https://docs.mapbox.com/mapbox-gl-js/api/map/#map#addlayer) in Mapbox GL JS.
+
+A `code` element. A [link](#) element.
+
+```xml
+<uses-permission android:name="android.permission.INTERNET" />
+<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+<uses-permission android:name="android.permission.CAMERA" />
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+```
+
+{{</Note>}}

--- a/src/css/docs-prose.css
+++ b/src/css/docs-prose.css
@@ -38,6 +38,11 @@
   color: #3151df !important;
 }
 
+/* set code links to slightly darker blue */
+.prose a code {
+  color: #2b50f0;
+}
+
 /* set max-height for code examples */
 .prose pre[class*='language-'] {
   max-height: 300px;

--- a/src/css/prism.css
+++ b/src/css/prism.css
@@ -52,7 +52,8 @@ pre[class*='language-'] {
 }
 
 .namespace {
-  opacity: 0.7;
+  opacity: 1 !important;
+  color: #b43b71; /* bg-dark-pink */
 }
 
 .token.property,

--- a/src/helpers/batfish/__tests__/__snapshots__/navigation.test.js.snap
+++ b/src/helpers/batfish/__tests__/__snapshots__/navigation.test.js.snap
@@ -1901,6 +1901,10 @@ Object {
       "parent": "/dr-ui/guides/",
       "title": "Guides",
     },
+    "/dr-ui/guides/a11y/": Object {
+      "parent": "/dr-ui/guides/",
+      "title": "Guides",
+    },
     "/dr-ui/guides/batfish-helpers/": Object {
       "parent": "/dr-ui/guides/",
       "title": "Guides",
@@ -1954,6 +1958,12 @@ Object {
           "order": 4,
           "path": "/dr-ui/guides/multi-structured/",
           "title": "Multi-structured sites",
+        },
+        Object {
+          "layout": "page",
+          "order": 6,
+          "path": "/dr-ui/guides/a11y/",
+          "title": "Accessibility test page",
         },
       ],
       "path": "/dr-ui/guides/",

--- a/src/helpers/batfish/__tests__/fixtures/data.json
+++ b/src/helpers/batfish/__tests__/fixtures/data.json
@@ -121,6 +121,21 @@
       }
     },
     {
+      "filePath": "./docs/src/pages/guides/a11y.md",
+      "path": "/dr-ui/guides/a11y/",
+      "frontMatter": {
+        "title": "Accessibility test page",
+        "description": "Page for testing accessibility of components.",
+        "layout": "page",
+        "order": 6,
+        "contentType": "guide",
+        "products": ["Documentation"],
+        "prependJs": [
+          "import Note from '../../../../src/components/note/note';"
+        ]
+      }
+    },
+    {
       "filePath": "./docs/src/pages/guides/batfish-helpers.md",
       "path": "/dr-ui/guides/batfish-helpers/",
       "frontMatter": {
@@ -260,6 +275,12 @@
     {
       "filePath": "./docs/src/pages/index.js",
       "path": "/dr-ui/",
+      "frontMatter": {}
+    },
+    {
+      "filePath": "./node_modules/@mapbox/batfish/dist/webpack/default-not-found.js",
+      "path": "/dr-ui/404/",
+      "is404": true,
       "frontMatter": {}
     }
   ]


### PR DESCRIPTION
This PR improves contrast on a couple elements: 
- adds a new style to set `.prose a code` at a darker blue color
- sets `.namespace` to remove opacity and set a darker color.

## How to test

1. Run `npm run start-docs`
2. Visit http://localhost:8080/dr-ui/guides/a11y/
3. Run Chrome DevTools Accessibility audit to confirm that there are no color contrast issues.

## QA checklist

<!-- complete this checklist when adding a new component or package -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.
- [x] Create a PR in a site repo, copy the component, and test it. Push to staging and let the reviewer know they can also test the component there.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] IE11, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.


Fixes https://github.com/mapbox/dr-ui/issues/391