### PR TITLE
Fix CSS for code elements in headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.0.1
 
-- Fix docs-prose.css to not apply blue color to code elements that are descendants of elements with `anchor` class (headings).
+- Fix docs-prose.css to not apply blue color to code elements that are descendants of elements with `anchor` class (headings). [#409](https://github.com/mapbox/dr-ui/pull/409)
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.1
+
+- Fix docs-prose.css to not apply blue color to code elements that are descendants of elements with `anchor` class (headings).
+
 ## 3.0.0
 
 - 🚨 Remove support for IE 11.

--- a/docs/src/pages/guides/a11y.md
+++ b/docs/src/pages/guides/a11y.md
@@ -40,3 +40,7 @@ A `code` element. A [link](#) element.
 ```
 
 {{</Note>}}
+
+## Heading with `code` element
+
+The `code` element in the heading above should not be blue. But this [`code`](#) element should be blue.

--- a/src/css/docs-prose.css
+++ b/src/css/docs-prose.css
@@ -39,7 +39,8 @@
 }
 
 /* set code links to slightly darker blue */
-.prose a code {
+/* this rule does not apply to elements with the "anchor" class (which are headings) */
+.prose :not(.anchor) > a code {
   color: #2b50f0;
 }
 


### PR DESCRIPTION
<!-- List what changes this PR introduces. -->

## How to test

1. Run `npm ci`
2. Run `npm run start-docs`
3. Navigate to http://localhost:8080/dr-ui/guides/a11y/#heading-with-code-element - You should see that the `code` element in the heading is not colored blue.

## QA checklist

<!-- Complete this checklist when adding a new component or package. -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `6.4.0`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.

## Before merge

- [x] Add entry to CHANGELOG.md to describe changes.
- [ ] ~~If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.~~


Fixes https://github.com/mapbox/dr-ui/issues/408