### PR TITLE
Make `filename` required for `CodeSnippetTitle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Update prismjs, rehype-prism. [#411](https://github.com/mapbox/dr-ui/pull/411)
 - 🚨 Deprecates `HelpPage`, `NavigationDropdown`, `SectionedNavigation`, `TopbarSticker`, and `Topbar` components. [#407](https://github.com/mapbox/dr-ui/pull/407)
 - Make `css` optional in `Edit` and `CodeSnippet` components. [#293](https://github.com/mapbox/dr-ui/pull/293)
+- Make `filename` required for `CodeSnippetTitle`. [#413](https://github.com/mapbox/dr-ui/pull/413)
 
 ## 3.0.1
 

--- a/src/components/code-snippet-title/code-snippet-title.js
+++ b/src/components/code-snippet-title/code-snippet-title.js
@@ -42,7 +42,7 @@ export default class CodeSnippetTitle extends React.Component {
 CodeSnippetTitle.propTypes = {
   /* Filename to be displayed as a kind of title. Can be a specific filename like
   `RuntimeStylingActivity.java` or a general filename like `Activity`. */
-  filename: PropTypes.string,
+  filename: PropTypes.string.isRequired,
   /* Optional `link` to a GitHub file. If this is set, the rendered component
   will include a "View on Github" link. */
   link: function (props, propName, componentName) {


### PR DESCRIPTION
This PR makes `filename` required for `CodeSnippetTitle` since the prop puts the `Title` in `CodeSnippetTitle`.

Fixes https://github.com/mapbox/dr-ui/issues/286