### PR TITLE
Add editClasses and editStyles props to CodeSnippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## Main
+
+- Add `editClasses` and `editStyles` props to `CodeSnippet`. [#420](https://github.com/mapbox/dr-ui/pull/420)
+
 ## 3.2.0
 
-- - Add `pricing` theme to `Note`. [#416](https://github.com/mapbox/dr-ui/pull/416)
+- Add `pricing` theme to `Note`. [#416](https://github.com/mapbox/dr-ui/pull/416)
 
 ## 3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Main
 
-- Add `editClasses` and `editStyles` props to `CodeSnippet`. [#420](https://github.com/mapbox/dr-ui/pull/420)
+- Add `editClasses` and `editStyles` props to `CodeSnippet` and automatically move the `Edit` buttons in `CodeSnippet` above the code when `maxHeight` is set. [#420](https://github.com/mapbox/dr-ui/pull/420)
 
 ## 3.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Main
 
-- Add `editClasses` and `editStyles` props to `CodeSnippet` and automatically move the `Edit` buttons in `CodeSnippet` above the code when `maxHeight` is set. [#420](https://github.com/mapbox/dr-ui/pull/420)
+- When `maxHeight` is set, move `Edit` buttons in `CodeSnippet` above the code. [#420](https://github.com/mapbox/dr-ui/pull/420)
 
 ## 3.2.0
 

--- a/src/components/code-snippet/__tests__/__snapshots__/code-snippet.test.js.snap
+++ b/src/components/code-snippet/__tests__/__snapshots__/code-snippet.test.js.snap
@@ -970,7 +970,7 @@ exports[`CodeSnippet CodeSnippet with edit buttons with maxHeight. renders as ex
     className="relative prose"
   >
     <div
-      className="absolute-mm right mb3 mt-neg36-mm"
+      className="absolute-mm right mb6 mb0-mm mt-neg36-mm"
       style={Object {}}
     >
       <form

--- a/src/components/code-snippet/__tests__/__snapshots__/code-snippet.test.js.snap
+++ b/src/components/code-snippet/__tests__/__snapshots__/code-snippet.test.js.snap
@@ -949,7 +949,7 @@ See the example: https://docs.mapbox.com//mapbox-gl-js/example/simple-map/"
 </div>
 `;
 
-exports[`CodeSnippet CodeSnippet with edit buttons, maxHeight, editClasses, and editStyles. renders as expected 1`] = `
+exports[`CodeSnippet CodeSnippet with edit buttons with maxHeight. renders as expected 1`] = `
 <div
   data-swiftype-index="false"
 >

--- a/src/components/code-snippet/__tests__/__snapshots__/code-snippet.test.js.snap
+++ b/src/components/code-snippet/__tests__/__snapshots__/code-snippet.test.js.snap
@@ -21,7 +21,7 @@ exports[`CodeSnippet A CodeSnippet with every feature (edit buttons, title) rend
     className="relative prose"
   >
     <div
-      className="absolute-mm mb6 mb0-mm top right mr36-mm z2"
+      className="absolute-mm right mb6 mb0-mm top mr36-mm z2"
       style={
         Object {
           "marginTop": "4px",
@@ -226,7 +226,7 @@ exports[`CodeSnippet CodeSnippet with edit buttons and extractor renders as expe
     className="relative prose"
   >
     <div
-      className="absolute-mm mb6 mb0-mm top right mr36-mm z2"
+      className="absolute-mm right mb6 mb0-mm top mr36-mm z2"
       style={
         Object {
           "marginTop": "4px",

--- a/src/components/code-snippet/__tests__/__snapshots__/code-snippet.test.js.snap
+++ b/src/components/code-snippet/__tests__/__snapshots__/code-snippet.test.js.snap
@@ -949,7 +949,7 @@ See the example: https://docs.mapbox.com//mapbox-gl-js/example/simple-map/"
 </div>
 `;
 
-exports[`CodeSnippet CodeSnippet with edit buttons and maxHeight renders as expected 1`] = `
+exports[`CodeSnippet CodeSnippet with edit buttons, maxHeight, editClasses, and editStyles. renders as expected 1`] = `
 <div
   data-swiftype-index="false"
 >
@@ -1076,7 +1076,7 @@ See the example: https://docs.mapbox.com//mapbox-gl-js/example/simple-map/"
       className="relative round z0 scroll-styled scroll-auto"
       style={
         Object {
-          "maxHeight": 100,
+          "maxHeight": 150,
         }
       }
     >

--- a/src/components/code-snippet/__tests__/__snapshots__/code-snippet.test.js.snap
+++ b/src/components/code-snippet/__tests__/__snapshots__/code-snippet.test.js.snap
@@ -949,6 +949,750 @@ See the example: https://docs.mapbox.com//mapbox-gl-js/example/simple-map/"
 </div>
 `;
 
+exports[`CodeSnippet CodeSnippet with edit buttons and maxHeight renders as expected 1`] = `
+<div
+  data-swiftype-index="false"
+>
+  <div
+    className="flex-parent-mm flex-parent--space-between-main-mm mb6"
+  >
+    <div
+      className="flex-child"
+    >
+      <div
+        className="inline-block txt-bold mb6 color-gray-dark"
+      >
+        index.html
+      </div>
+    </div>
+  </div>
+  <div
+    className="relative prose"
+  >
+    <div
+      className="absolute-mm right mb3 mt-neg36-mm"
+      style={Object {}}
+    >
+      <form
+        action="https://jsfiddle.net/api/post/library/pure/"
+        className="inline-block"
+        method="POST"
+        target="_blank"
+      >
+        <input
+          className="btn btn--s cursor-pointer round"
+          onClick={[Function]}
+          style={
+            Object {
+              "border": 0,
+            }
+          }
+          type="submit"
+          value="Edit in JSFiddle"
+        />
+        <input
+          name="wrap"
+          type="hidden"
+          value="b"
+        />
+        <input
+          name="css"
+          type="hidden"
+          value="
+    body { margin: 0; padding: 0; }
+        #map { position: absolute; top: 0; bottom: 0; width: 100%; };
+"
+        />
+        <input
+          name="html"
+          type="hidden"
+          value="
+<div id='map'></div>
+
+
+"
+        />
+        <input
+          name="js"
+          type="hidden"
+          value="
+mapboxgl.accessToken = '<your access token here>';
+var map = new mapboxgl.Map({
+    container: 'map', // container id
+    style: 'mapbox://styles/mapbox/streets-v11', // stylesheet location
+    center: [-74.50, 40], // starting position [lng, lat]
+    zoom: 9 // starting zoom
+});
+"
+        />
+        <input
+          name="title"
+          type="hidden"
+          value="Display a map"
+        />
+        <input
+          name="resources"
+          type="hidden"
+          value={
+            Array [
+              "https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.js",
+              "https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css",
+            ]
+          }
+        />
+        <input
+          name="description"
+          type="hidden"
+          value="Initialize a map in an HTML element with Mapbox GL JS.
+
+See the example: https://docs.mapbox.com//mapbox-gl-js/example/simple-map/"
+        />
+      </form>
+      <form
+        action="https://codepen.io/pen/define"
+        className="inline-block ml6"
+        method="POST"
+        target="_blank"
+      >
+        <input
+          name="data"
+          type="hidden"
+          value="{\\"title\\":\\"Display a map\\",\\"html\\":\\"\\\\n<div id='map'></div>\\\\n\\\\n\\\\n\\",\\"html_pre_processor\\":\\"none\\",\\"description\\":\\"Initialize a map in an HTML element with Mapbox GL JS.\\\\n\\\\nSee the example: [https://docs.mapbox.com//mapbox-gl-js/example/simple-map/](https://docs.mapbox.com//mapbox-gl-js/example/simple-map/)\\",\\"tags\\":[\\"mapbox\\",\\"maps\\"],\\"css\\":\\"\\\\n    body { margin: 0; padding: 0; }\\\\n        #map { position: absolute; top: 0; bottom: 0; width: 100%; };\\\\n\\",\\"css_pre_processor\\":\\"none\\",\\"js\\":\\"\\\\nmapboxgl.accessToken = '<your access token here>';\\\\nvar map = new mapboxgl.Map({\\\\n    container: 'map', // container id\\\\n    style: 'mapbox://styles/mapbox/streets-v11', // stylesheet location\\\\n    center: [-74.50, 40], // starting position [lng, lat]\\\\n    zoom: 9 // starting zoom\\\\n});\\\\n\\",\\"js_pre_processor\\":\\"none\\",\\"css_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css\\",\\"js_external\\":\\"https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.js\\"}"
+        />
+        <input
+          className="btn btn--s cursor-pointer round"
+          onClick={[Function]}
+          style={
+            Object {
+              "border": 0,
+            }
+          }
+          type="submit"
+          value="Edit in CodePen"
+        />
+      </form>
+    </div>
+    <div
+      className="relative round z0 scroll-styled scroll-auto"
+      style={
+        Object {
+          "maxHeight": 100,
+        }
+      }
+    >
+      <pre>
+        <code
+          className="px0 hljs"
+        >
+          <div
+            className="relative z2"
+            data-chunk-code="chunk-0"
+          >
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<span class=\\"token doctype\\"><span class=\\"token punctuation\\">&lt;!</span><span class=\\"token doctype-tag\\">DOCTYPE</span> <span class=\\"token name\\">html</span><span class=\\"token punctuation\\">></span></span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>html</span><span class=\\"token punctuation\\">></span></span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>head</span><span class=\\"token punctuation\\">></span></span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>meta</span> <span class=\\"token attr-name\\">charset</span><span class=\\"token attr-value\\"><span class=\\"token punctuation attr-equals\\">=</span><span class=\\"token punctuation\\">'</span>utf-8<span class=\\"token punctuation\\">'</span></span> <span class=\\"token punctuation\\">/></span></span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>title</span><span class=\\"token punctuation\\">></span></span>Display a map<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;/</span>title</span><span class=\\"token punctuation\\">></span></span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>meta</span> <span class=\\"token attr-name\\">name</span><span class=\\"token attr-value\\"><span class=\\"token punctuation attr-equals\\">=</span><span class=\\"token punctuation\\">'</span>viewport<span class=\\"token punctuation\\">'</span></span> <span class=\\"token attr-name\\">content</span><span class=\\"token attr-value\\"><span class=\\"token punctuation attr-equals\\">=</span><span class=\\"token punctuation\\">'</span>initial-scale=1,maximum-scale=1,user-scalable=no<span class=\\"token punctuation\\">'</span></span> <span class=\\"token punctuation\\">/></span></span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>script</span> <span class=\\"token attr-name\\">src</span><span class=\\"token attr-value\\"><span class=\\"token punctuation attr-equals\\">=</span><span class=\\"token punctuation\\">'</span>https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.js<span class=\\"token punctuation\\">'</span></span><span class=\\"token punctuation\\">></span></span><span class=\\"token script\\"></span><span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;/</span>script</span><span class=\\"token punctuation\\">></span></span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>link</span> <span class=\\"token attr-name\\">href</span><span class=\\"token attr-value\\"><span class=\\"token punctuation attr-equals\\">=</span><span class=\\"token punctuation\\">'</span>https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css<span class=\\"token punctuation\\">'</span></span> <span class=\\"token attr-name\\">rel</span><span class=\\"token attr-value\\"><span class=\\"token punctuation attr-equals\\">=</span><span class=\\"token punctuation\\">'</span>stylesheet<span class=\\"token punctuation\\">'</span></span> <span class=\\"token punctuation\\">/></span></span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>style</span><span class=\\"token punctuation\\">></span></span><span class=\\"token style\\"><span class=\\"token language-css\\">",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 40.9,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<span class=\\"token selector\\">body</span> <span class=\\"token punctuation\\">{</span> <span class=\\"token property\\">margin</span><span class=\\"token punctuation\\">:</span> 0<span class=\\"token punctuation\\">;</span> <span class=\\"token property\\">padding</span><span class=\\"token punctuation\\">:</span> 0<span class=\\"token punctuation\\">;</span> <span class=\\"token punctuation\\">}</span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 69.8,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<span class=\\"token selector\\">#map</span> <span class=\\"token punctuation\\">{</span> <span class=\\"token property\\">position</span><span class=\\"token punctuation\\">:</span> absolute<span class=\\"token punctuation\\">;</span> <span class=\\"token property\\">top</span><span class=\\"token punctuation\\">:</span> 0<span class=\\"token punctuation\\">;</span> <span class=\\"token property\\">bottom</span><span class=\\"token punctuation\\">:</span> 0<span class=\\"token punctuation\\">;</span> <span class=\\"token property\\">width</span><span class=\\"token punctuation\\">:</span> 100%<span class=\\"token punctuation\\">;</span> <span class=\\"token punctuation\\">}</span><span class=\\"token punctuation\\">;</span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "</span></span><span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;/</span>style</span><span class=\\"token punctuation\\">></span></span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;/</span>head</span><span class=\\"token punctuation\\">></span></span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>body</span><span class=\\"token punctuation\\">></span></span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>div</span> <span class=\\"token attr-name\\">id</span><span class=\\"token attr-value\\"><span class=\\"token punctuation attr-equals\\">=</span><span class=\\"token punctuation\\">'</span>map<span class=\\"token punctuation\\">'</span></span><span class=\\"token punctuation\\">></span></span><span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;/</span>div</span><span class=\\"token punctuation\\">></span></span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>script</span><span class=\\"token punctuation\\">></span></span><span class=\\"token script\\"><span class=\\"token language-javascript\\">",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "mapboxgl<span class=\\"token punctuation\\">.</span>accessToken <span class=\\"token operator\\">=</span> <span class=\\"token string\\">'&lt;your access token here>'</span><span class=\\"token punctuation\\">;</span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<span class=\\"token keyword\\">var</span> map <span class=\\"token operator\\">=</span> <span class=\\"token keyword\\">new</span> <span class=\\"token class-name\\">mapboxgl<span class=\\"token punctuation\\">.</span>Map</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">{</span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 40.9,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "container<span class=\\"token operator\\">:</span> <span class=\\"token string\\">'map'</span><span class=\\"token punctuation\\">,</span> <span class=\\"token comment\\">// container id</span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 40.9,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "style<span class=\\"token operator\\">:</span> <span class=\\"token string\\">'mapbox://styles/mapbox/streets-v11'</span><span class=\\"token punctuation\\">,</span> <span class=\\"token comment\\">// stylesheet location</span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 40.9,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "center<span class=\\"token operator\\">:</span> <span class=\\"token punctuation\\">[</span><span class=\\"token operator\\">-</span><span class=\\"token number\\">74.50</span><span class=\\"token punctuation\\">,</span> <span class=\\"token number\\">40</span><span class=\\"token punctuation\\">]</span><span class=\\"token punctuation\\">,</span> <span class=\\"token comment\\">// starting position [lng, lat]</span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 40.9,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "zoom<span class=\\"token operator\\">:</span> <span class=\\"token number\\">9</span> <span class=\\"token comment\\">// starting zoom</span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<span class=\\"token punctuation\\">}</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">;</span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "</span></span><span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;/</span>script</span><span class=\\"token punctuation\\">></span></span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": " ",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;/</span>body</span><span class=\\"token punctuation\\">></span></span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="pr12"
+              style={
+                Object {
+                  "paddingLeft": 12,
+                }
+              }
+            >
+              <div
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;/</span>html</span><span class=\\"token punctuation\\">></span></span>",
+                  }
+                }
+                style={
+                  Object {
+                    "marginLeft": 14.45,
+                    "textIndent": -14.45,
+                  }
+                }
+              />
+            </div>
+          </div>
+        </code>
+      </pre>
+      <div
+        className="absolute z2 top right mr6 mt6 color-white"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`CodeSnippet CodeSnippet without edit buttons renders as expected 1`] = `
 <div
   data-swiftype-index="false"

--- a/src/components/code-snippet/__tests__/code-snippet-test-cases.js
+++ b/src/components/code-snippet/__tests__/code-snippet-test-cases.js
@@ -64,4 +64,25 @@ testCases.withHelpers = {
   }
 };
 
+testCases.maxHeight = {
+  component: CodeSnippet,
+  description: 'CodeSnippet with edit buttons and maxHeight',
+  props: {
+    code: fullHtml,
+    maxHeight: 100,
+    editClasses: 'absolute-mm right mb3 mt-neg36-mm',
+    editStyles: {},
+    edit: {
+      ...code,
+      frontMatter: {
+        description: 'Initialize a map in an HTML element with Mapbox GL JS.',
+        pathname: '/mapbox-gl-js/example/simple-map/',
+        title: 'Display a map'
+      }
+    },
+    highlighter: () => highlightHtml,
+    filename: 'index.html'
+  }
+};
+
 export { testCases, noRenderCases };

--- a/src/components/code-snippet/__tests__/code-snippet-test-cases.js
+++ b/src/components/code-snippet/__tests__/code-snippet-test-cases.js
@@ -66,10 +66,11 @@ testCases.withHelpers = {
 
 testCases.maxHeight = {
   component: CodeSnippet,
-  description: 'CodeSnippet with edit buttons and maxHeight',
+  description:
+    'CodeSnippet with edit buttons, maxHeight, editClasses, and editStyles.',
   props: {
     code: fullHtml,
-    maxHeight: 100,
+    maxHeight: 150,
     editClasses: 'absolute-mm right mb3 mt-neg36-mm',
     editStyles: {},
     edit: {

--- a/src/components/code-snippet/__tests__/code-snippet-test-cases.js
+++ b/src/components/code-snippet/__tests__/code-snippet-test-cases.js
@@ -66,13 +66,10 @@ testCases.withHelpers = {
 
 testCases.maxHeight = {
   component: CodeSnippet,
-  description:
-    'CodeSnippet with edit buttons, maxHeight, editClasses, and editStyles.',
+  description: 'CodeSnippet with edit buttons with maxHeight.',
   props: {
     code: fullHtml,
     maxHeight: 150,
-    editClasses: 'absolute-mm right mb3 mt-neg36-mm',
-    editStyles: {},
     edit: {
       ...code,
       frontMatter: {

--- a/src/components/code-snippet/__tests__/code-snippet.test.js
+++ b/src/components/code-snippet/__tests__/code-snippet.test.js
@@ -88,4 +88,22 @@ describe('CodeSnippet', () => {
       expect(tree).toMatchSnapshot();
     });
   });
+
+  describe(testCases.maxHeight.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.maxHeight;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
 });

--- a/src/components/code-snippet/code-snippet.js
+++ b/src/components/code-snippet/code-snippet.js
@@ -10,17 +10,14 @@ import { highlightThemeCss } from '../highlight/theme-css.js';
 class CodeSnippet extends React.Component {
   editButtons = () => {
     // show edit buttons if edit object and all required props are present
-    const edit = this.props.edit;
+    const { edit, editClasses, editStyles } = this.props;
     return edit &&
       edit.css &&
       edit.html &&
       edit.js &&
       edit.frontMatter.title &&
       edit.frontMatter.description ? (
-      <div
-        className="absolute-mm mb6 mb0-mm top right mr36-mm z2"
-        style={{ marginTop: '4px' }}
-      >
+      <div className={editClasses} style={editStyles}>
         <Edit
           css={edit.css}
           html={edit.html}
@@ -66,23 +63,41 @@ class CodeSnippet extends React.Component {
   }
 }
 
+CodeSnippet.defaultProps = {
+  editClasses: 'absolute-mm mb6 mb0-mm top right mr36-mm z2',
+  editStyles: { marginTop: '4px' }
+};
+
 CodeSnippet.propTypes = {
-  code: PropTypes.string.isRequired, // raw code
-  highlighter: PropTypes.func.isRequired, // the dr-ui/highlight function, example: highlighter={() => highlightJson}. You must also import the function in your frontmatter.
-  filename: PropTypes.string, // (optional) name of the file to add context to the code block
-  maxHeight: PropTypes.number, // (optional) maximum height of the code block, default is set at 300
+  /** The raw code. */
+  code: PropTypes.string.isRequired,
+  /** The dr-ui/highlight function, example: "highlighter={() => highlightJson}". You must also import the function in your frontmatter. */
+  highlighter: PropTypes.func.isRequired,
+  /** Name of the file to add context to the code block. */
+  filename: PropTypes.string,
+  /** The maximum height of the code block. */
+  maxHeight: PropTypes.number,
+  /** Classes to add to the Edit component container */
+  editClasses: PropTypes.string,
+  /** Styles to add to the Edit component container */
+  editStyles: PropTypes.object,
+  /** Enables the Edit in CodePen/JSFiddle buttons */
   edit: PropTypes.shape({
-    css: PropTypes.string, // CSS panel contents
-    js: PropTypes.string.isRequired, // JS panel contents
-    html: PropTypes.string.isRequired, // HTML panel contents
-    head: PropTypes.string, // extra html to add to the head of the document (CodePen)
+    /** Contents for the CSS panel. */
+    css: PropTypes.string,
+    /** Contents for the JavaScript panel. */
+    js: PropTypes.string.isRequired,
+    /** Contents for the HTML panel. */
+    html: PropTypes.string.isRequired,
+    /* Extra HTML to add to the head of the document, used by CodePen. */
+    head: PropTypes.string,
     frontMatter: PropTypes.shape({
       title: PropTypes.string.isRequired,
       description: PropTypes.string.isRequired,
       pathname: PropTypes.string.isRequired
     }),
+    /** Absolute URLs to CDNs that are required by the code. */
     resources: PropTypes.shape({
-      // absolute URLs to CDNs
       js: PropTypes.array,
       css: PropTypes.array
     })

--- a/src/components/code-snippet/code-snippet.js
+++ b/src/components/code-snippet/code-snippet.js
@@ -19,9 +19,9 @@ class CodeSnippet extends React.Component {
       edit.frontMatter.title &&
       edit.frontMatter.description ? (
       <div
-        className={classnames('absolute-mm right', {
-          'mb6 mb0-mm top mr36-mm z2': !maxHeight,
-          'mb3 mt-neg36-mm': maxHeight // if maxHeight is set, move the Edit buttons above the CodeSnippet
+        className={classnames('absolute-mm right mb6 mb0-mm', {
+          'top mr36-mm z2': !maxHeight, // set Edit next to CopyButton
+          'mt-neg36-mm': maxHeight // set Edit above CodeSnippet
         })}
         style={maxHeight ? {} : { marginTop: '4px' }}
       >

--- a/src/components/code-snippet/code-snippet.js
+++ b/src/components/code-snippet/code-snippet.js
@@ -10,7 +10,14 @@ import { highlightThemeCss } from '../highlight/theme-css.js';
 class CodeSnippet extends React.Component {
   editButtons = () => {
     // show edit buttons if edit object and all required props are present
-    const { edit, editClasses, editStyles } = this.props;
+    const { edit, maxHeight } = this.props;
+    let { editClasses, editStyles } = this.props;
+
+    // if maxHeight is set, move the Edit buttons above the CodeSnippet
+    if (maxHeight) {
+      (editClasses = 'absolute-mm right mb3 mt-neg36-mm'), (editStyles = {});
+    }
+
     return edit &&
       edit.css &&
       edit.html &&
@@ -75,7 +82,7 @@ CodeSnippet.propTypes = {
   highlighter: PropTypes.func.isRequired,
   /** Name of the file to add context to the code block. */
   filename: PropTypes.string,
-  /** The maximum height of the code block. */
+  /** The maximum height of the code block. If set, the Edit buttons (if enabled) will move above the CodeSnippet. */
   maxHeight: PropTypes.number,
   /** Classes to add to the Edit component container */
   editClasses: PropTypes.string,

--- a/src/components/code-snippet/code-snippet.js
+++ b/src/components/code-snippet/code-snippet.js
@@ -15,7 +15,8 @@ class CodeSnippet extends React.Component {
 
     // if maxHeight is set, move the Edit buttons above the CodeSnippet
     if (maxHeight) {
-      (editClasses = 'absolute-mm right mb3 mt-neg36-mm'), (editStyles = {});
+      editClasses = 'absolute-mm right mb3 mt-neg36-mm';
+      editStyles = {};
     }
 
     return edit &&

--- a/src/components/code-snippet/code-snippet.js
+++ b/src/components/code-snippet/code-snippet.js
@@ -6,26 +6,25 @@ import MrCodeSnippet from '@mapbox/mr-ui/code-snippet';
 import CodeSnippetTitle from '../code-snippet-title';
 import Edit from '../edit';
 import { highlightThemeCss } from '../highlight/theme-css.js';
+import classnames from 'classnames';
 
 class CodeSnippet extends React.Component {
   editButtons = () => {
     // show edit buttons if edit object and all required props are present
     const { edit, maxHeight } = this.props;
-    let { editClasses, editStyles } = this.props;
-
-    // if maxHeight is set, move the Edit buttons above the CodeSnippet
-    if (maxHeight) {
-      editClasses = 'absolute-mm right mb3 mt-neg36-mm';
-      editStyles = {};
-    }
-
     return edit &&
       edit.css &&
       edit.html &&
       edit.js &&
       edit.frontMatter.title &&
       edit.frontMatter.description ? (
-      <div className={editClasses} style={editStyles}>
+      <div
+        className={classnames('absolute-mm right', {
+          'mb6 mb0-mm top mr36-mm z2': !maxHeight,
+          'mb3 mt-neg36-mm': maxHeight // if maxHeight is set, move the Edit buttons above the CodeSnippet
+        })}
+        style={maxHeight ? {} : { marginTop: '4px' }}
+      >
         <Edit
           css={edit.css}
           html={edit.html}
@@ -71,11 +70,6 @@ class CodeSnippet extends React.Component {
   }
 }
 
-CodeSnippet.defaultProps = {
-  editClasses: 'absolute-mm mb6 mb0-mm top right mr36-mm z2',
-  editStyles: { marginTop: '4px' }
-};
-
 CodeSnippet.propTypes = {
   /** The raw code. */
   code: PropTypes.string.isRequired,
@@ -85,10 +79,6 @@ CodeSnippet.propTypes = {
   filename: PropTypes.string,
   /** The maximum height of the code block. If set, the Edit buttons (if enabled) will move above the CodeSnippet. */
   maxHeight: PropTypes.number,
-  /** Classes to add to the Edit component container */
-  editClasses: PropTypes.string,
-  /** Styles to add to the Edit component container */
-  editStyles: PropTypes.object,
   /** Enables the Edit in CodePen/JSFiddle buttons */
   edit: PropTypes.shape({
     /** Contents for the CSS panel. */


### PR DESCRIPTION
This PR adds `editClasses` and `editStyles` props to the CodeSnippet component. These props allow us to change the styles and classes for the Edit button so we may change their position on the page.

This PR will also fix the styling of the proptType comments so they will be parsed by our catalog site.

## How to test

1. `npm ci`
2. `npm start`
3. Visit /CodeSnippet and look at the last test case: CodeSnippet with edit buttons, maxHeight, editClasses, and editStyles. This uses test case shows how we can set the editClasses and editStyles in Help.

## QA checklist

<!-- Complete this checklist when adding a new component or package. -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `6.4.0`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [ ] Chrome, no errors logged to console.
- [ ] Firefox, no errors logged to console.
- [ ] Safari, no errors logged to console.
- [ ] Edge, no errors logged to console.
- [ ] Mobile Safari, no errors logged to console.
- [ ] Android Chrome, no errors logged to console.

## Before merge

- [x] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
