### PR TITLE
Enforces where React component static properties should be positioned

### DIFF
--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": ["../conf/eslint-config-base.json", "@mapbox/eslint-config-docs"],
   "rules": {
-    "es/no-object-assign": "off"
+    "es/no-object-assign": "off",
+    "react/static-property-placement": ["error", "property assignment"]
   }
 }

--- a/src/components/contextless-ios-view-controller-toggle/contextless-ios-view-controller-toggle.js
+++ b/src/components/contextless-ios-view-controller-toggle/contextless-ios-view-controller-toggle.js
@@ -5,10 +5,6 @@ import { highlightSwift } from '../highlight/swift';
 import { highlightObjectivec } from '../highlight/objectivec';
 
 export default class ContextlessIosViewControllerToggle extends React.Component {
-  static defaultProps = {
-    limitHeight: true
-  };
-
   render() {
     const { id, context, objectiveC, swift, limitHeight } = this.props;
 
@@ -62,6 +58,10 @@ export default class ContextlessIosViewControllerToggle extends React.Component 
     );
   }
 }
+
+ContextlessIosViewControllerToggle.defaultProps = {
+  limitHeight: true
+};
 
 ContextlessIosViewControllerToggle.propTypes = {
   /* Intended to be hooked up to `context` in the format

--- a/src/components/numbered-code-snippet/numbered-code-snippet.js
+++ b/src/components/numbered-code-snippet/numbered-code-snippet.js
@@ -16,55 +16,6 @@ function getWindow() {
 const injectedThemes = [];
 
 export default class NumberedCodeSnippet extends React.PureComponent {
-  static propTypes = {
-    /**
-     * Raw (unhighlighted) code. When the user clicks a copy button, this is what they'll get.
-     * If no `highlightedCode` is provided, `code` is displayed.
-     */
-    code: PropTypes.string.isRequired,
-    /**
-     * The HTML output of running code through a syntax highlighter. If this is not provided,
-     * `code` is displayed, instead.
-     */
-    highlightedCode: PropTypes.string,
-    /**
-     * Specific line ranges that should be independently copiable. Each range is a two-value array,
-     * consisting of the starting and ending line. If this is not provided, the entire snippet is copiable.
-     */
-    copyRanges: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
-    /**
-     * A maximum height for the snippet. If the code exceeds this height, the snippet will scroll internally.
-     */
-    maxHeight: PropTypes.number,
-    /**
-     * A callback that is invoked when the snippet (or a chunk of the snippet) is copied. If `copyRanges`
-     * are provided, the callback is passed the index (0-based) of the chunk that was copied.
-     */
-    onCopy: PropTypes.func,
-    /**
-     * CSS that styles the highlighted code.
-     */
-    highlightThemeCss: PropTypes.string.isRequired,
-    /**
-     * The width of a character in the theme's monospace font, used for indentation. If you use a font or
-     * font-size different than the default theme, you may need to change this value.
-     */
-    characterWidth: PropTypes.number,
-    /**
-     * Determines if non-copiable lines (when using `copyRanges`) should be collapsed. Default is true.
-     *
-     * If false, a `maxHeight` is defined, and the first live chunk (from the `copyRanges` prop) is not
-     * visible in the snippet given the `maxHeight`, the component will autoscroll to make sure the live
-     * chunk is in view when the page loads.
-     */
-    collapseLines: PropTypes.bool
-  };
-
-  static defaultProps = {
-    characterWidth: 7.225, // Will need to change this if we change font size
-    collapseLines: true
-  };
-
   constructor(props) {
     super(props);
     this.state = {
@@ -484,3 +435,52 @@ export default class NumberedCodeSnippet extends React.PureComponent {
     );
   }
 }
+
+NumberedCodeSnippet.defaultProps = {
+  characterWidth: 7.225, // Will need to change this if we change font size
+  collapseLines: true
+};
+
+NumberedCodeSnippet.propTypes = {
+  /**
+   * Raw (unhighlighted) code. When the user clicks a copy button, this is what they'll get.
+   * If no `highlightedCode` is provided, `code` is displayed.
+   */
+  code: PropTypes.string.isRequired,
+  /**
+   * The HTML output of running code through a syntax highlighter. If this is not provided,
+   * `code` is displayed, instead.
+   */
+  highlightedCode: PropTypes.string,
+  /**
+   * Specific line ranges that should be independently copiable. Each range is a two-value array,
+   * consisting of the starting and ending line. If this is not provided, the entire snippet is copiable.
+   */
+  copyRanges: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
+  /**
+   * A maximum height for the snippet. If the code exceeds this height, the snippet will scroll internally.
+   */
+  maxHeight: PropTypes.number,
+  /**
+   * A callback that is invoked when the snippet (or a chunk of the snippet) is copied. If `copyRanges`
+   * are provided, the callback is passed the index (0-based) of the chunk that was copied.
+   */
+  onCopy: PropTypes.func,
+  /**
+   * CSS that styles the highlighted code.
+   */
+  highlightThemeCss: PropTypes.string.isRequired,
+  /**
+   * The width of a character in the theme's monospace font, used for indentation. If you use a font or
+   * font-size different than the default theme, you may need to change this value.
+   */
+  characterWidth: PropTypes.number,
+  /**
+   * Determines if non-copiable lines (when using `copyRanges`) should be collapsed. Default is true.
+   *
+   * If false, a `maxHeight` is defined, and the first live chunk (from the `copyRanges` prop) is not
+   * visible in the snippet given the `maxHeight`, the component will autoscroll to make sure the live
+   * chunk is in view when the page loads.
+   */
+  collapseLines: PropTypes.bool
+};

--- a/src/components/numbered-code-snippet/show-hide-lines.js
+++ b/src/components/numbered-code-snippet/show-hide-lines.js
@@ -6,12 +6,6 @@ const containerClasses =
   'wfull bg-gray-faint color-gray-dark color-gray-on-hover pl12 py6 cursor-pointer txt-s';
 
 class HideLines extends React.PureComponent {
-  static propTypes = {
-    /** The content that should be hidden on click. */
-    children: PropTypes.node.isRequired,
-    /** A callback that is invoked when the line is clicked. */
-    onClick: PropTypes.func.isRequired
-  };
   render() {
     return (
       <div>
@@ -33,11 +27,14 @@ class HideLines extends React.PureComponent {
   }
 }
 
+HideLines.propTypes = {
+  /** The content that should be hidden on click. */
+  children: PropTypes.node.isRequired,
+  /** A callback that is invoked when the line is clicked. */
+  onClick: PropTypes.func.isRequired
+};
+
 class ShowLines extends React.PureComponent {
-  static propTypes = {
-    /** A callback that is invoked when the line is clicked. */
-    onClick: PropTypes.func.isRequired
-  };
   render() {
     return (
       <div
@@ -59,5 +56,10 @@ class ShowLines extends React.PureComponent {
     );
   }
 }
+
+ShowLines.propTypes = {
+  /** A callback that is invoked when the line is clicked. */
+  onClick: PropTypes.func.isRequired
+};
 
 export { HideLines, ShowLines };

--- a/src/components/toggleable-code-block/toggleable-code-block.js
+++ b/src/components/toggleable-code-block/toggleable-code-block.js
@@ -7,10 +7,6 @@ import CodeToggle from '../code-toggle/code-toggle';
 import { highlightThemeCss } from '../highlight/theme-css.js';
 
 export default class ToggleableCodeBlock extends React.Component {
-  static defaultProps = {
-    limitHeight: true
-  };
-
   renderSnippet = (code) => {
     const {
       highlightedCode,
@@ -72,6 +68,10 @@ export default class ToggleableCodeBlock extends React.Component {
     );
   }
 }
+
+ToggleableCodeBlock.defaultProps = {
+  limitHeight: true
+};
 
 ToggleableCodeBlock.propTypes = {
   /* A unique `id` is required for the language toggle. */


### PR DESCRIPTION
Enforces where React component static properties should be positioned: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/static-property-placement.md

I had noticed that a few (four) components do not use the same patterns as the others, this PR will help keep us consistent.