### PR TITLE
Make code toggles in test cases interactive or label if they are not

### DIFF
--- a/src/components/code-snippet-title/examples/custom.js
+++ b/src/components/code-snippet-title/examples/custom.js
@@ -6,6 +6,14 @@ import CodeSnippetTitle from '../code-snippet-title';
 import CodeToggle from '../../code-toggle';
 
 export default class Custom extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      language: 'swift'
+    };
+  }
+
+  changeLanguage = (language) => this.setState({ language });
   render() {
     return (
       <CodeSnippetTitle
@@ -14,17 +22,17 @@ export default class Custom extends React.Component {
         toggle={
           <CodeToggle
             id="some-id"
-            onChange={() => {}}
+            onChange={this.changeLanguage}
             options={[
               {
                 label: 'Swift',
                 language: 'swift',
-                preferredLanguage: true
+                preferredLanguage: this.state.language === 'swift'
               },
               {
                 label: 'Objective-C',
                 language: 'objectiveC',
-                preferredLanguage: false
+                preferredLanguage: this.state.language === 'objectiveC'
               }
             ]}
           />

--- a/src/components/code-toggle/__tests__/__snapshots__/code-toggle.test.js.snap
+++ b/src/components/code-toggle/__tests__/__snapshots__/code-toggle.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`code-toggle Java preferred renders as expected 1`] = `
+exports[`code-toggle Java preferred (not interactive) renders as expected 1`] = `
 <div
   className="relative "
 >
@@ -88,7 +88,7 @@ exports[`code-toggle Java preferred renders as expected 1`] = `
 </div>
 `;
 
-exports[`code-toggle Objective C preferred renders as expected 1`] = `
+exports[`code-toggle Objective C preferred (not interactive) renders as expected 1`] = `
 <div
   className="relative "
 >
@@ -142,7 +142,7 @@ exports[`code-toggle Objective C preferred renders as expected 1`] = `
 </div>
 `;
 
-exports[`code-toggle Swift preferred renders as expected 1`] = `
+exports[`code-toggle Swift preferred (interactive) renders as expected 1`] = `
 <div
   className="relative "
 >

--- a/src/components/code-toggle/__tests__/code-toggle-test-cases.js
+++ b/src/components/code-toggle/__tests__/code-toggle-test-cases.js
@@ -6,13 +6,13 @@ const testCases = {};
 const noRenderCases = {};
 
 testCases.basic = {
-  description: 'Swift preferred',
+  description: 'Swift preferred (interactive)',
   element: <Basic />
 };
 
 testCases.objectiveC = {
   component: CodeToggle,
-  description: 'Objective C preferred',
+  description: 'Objective C preferred (not interactive)',
   props: {
     id: 'two',
     onChange: () => {},
@@ -33,7 +33,7 @@ testCases.objectiveC = {
 
 testCases.objectiveC2 = {
   component: CodeToggle,
-  description: 'Java preferred',
+  description: 'Java preferred (not interactive)',
   props: {
     id: 'three',
     onChange: () => {},

--- a/src/components/code-toggle/examples/basic.js
+++ b/src/components/code-toggle/examples/basic.js
@@ -5,21 +5,30 @@ import React from 'react';
 import CodeToggle from '../code-toggle';
 
 export default class Basic extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      language: 'swift'
+    };
+  }
+
+  changeLanguage = (language) => this.setState({ language });
+
   render() {
     return (
       <CodeToggle
         id="one"
-        onChange={() => {}}
+        onChange={this.changeLanguage}
         options={[
           {
             label: 'Swift',
             language: 'swift',
-            preferredLanguage: true
+            preferredLanguage: this.state.language === 'swift'
           },
           {
             label: 'Objective-C',
             language: 'objectiveC',
-            preferredLanguage: false
+            preferredLanguage: this.state.language === 'objectiveC'
           }
         ]}
       />

--- a/src/components/contextless-android-activity-toggle/__tests__/__snapshots__/contextless-android-activity-toggle.test.js.snap
+++ b/src/components/contextless-android-activity-toggle/__tests__/__snapshots__/contextless-android-activity-toggle.test.js.snap
@@ -400,7 +400,7 @@ exports[`contextless-android-activity-toggle Kotlin only renders as expected 1`]
 </div>
 `;
 
-exports[`contextless-android-activity-toggle Two languages renders as expected 1`] = `
+exports[`contextless-android-activity-toggle Two languages (code toggle not interactive) renders as expected 1`] = `
 <div
   className="my24 prose"
 >

--- a/src/components/contextless-android-activity-toggle/__tests__/contextless-android-activity-toggle-test-cases.js
+++ b/src/components/contextless-android-activity-toggle/__tests__/contextless-android-activity-toggle-test-cases.js
@@ -70,7 +70,7 @@ testCases.basic = {
 
 testCases.twoLang = {
   component: ContextlessAndroidActivityToggle,
-  description: 'Two languages',
+  description: 'Two languages (code toggle not interactive)',
   props: {
     context: contextJava,
     id: 'test-java-kotlin',
@@ -95,7 +95,7 @@ testCases.kotlinOnly = {
 
 testCases.filename = {
   component: ContextlessAndroidActivityToggle,
-  description: 'Two languages with filename',
+  description: 'Two languages with filename  (code toggle not interactive)',
   props: {
     context: contextKotlin,
     id: 'test-java-kotlin-filename',
@@ -110,7 +110,7 @@ testCases.filename = {
 
 testCases.copyRange = {
   component: ContextlessAndroidActivityToggle,
-  description: 'Two languages with copy ranges',
+  description: 'Two languages with copy ranges (code toggle not interactive)',
   props: {
     context: contextKotlin,
     id: 'test-java-kotlin-copy-range',

--- a/src/components/contextless-ios-view-controller-toggle/__tests__/__snapshots__/contextless-ios-view-controller-toggle.test.js.snap
+++ b/src/components/contextless-ios-view-controller-toggle/__tests__/__snapshots__/contextless-ios-view-controller-toggle.test.js.snap
@@ -123,7 +123,7 @@ exports[`contextless-ios-view-controller-toggle Basic renders as expected 1`] = 
 </div>
 `;
 
-exports[`contextless-ios-view-controller-toggle Two languages renders as expected 1`] = `
+exports[`contextless-ios-view-controller-toggle Two languages (code toggle is not interactive) renders as expected 1`] = `
 <div
   className="my24 prose"
 >

--- a/src/components/contextless-ios-view-controller-toggle/__tests__/contextless-ios-view-controller-toggle-test-cases.js
+++ b/src/components/contextless-ios-view-controller-toggle/__tests__/contextless-ios-view-controller-toggle-test-cases.js
@@ -63,7 +63,7 @@ testCases.basic = {
 
 testCases.twoLang = {
   component: ContextlessIosViewControllerToggle,
-  description: 'Two languages',
+  description: 'Two languages (code toggle is not interactive)',
   props: {
     context: contextSwift,
     id: 'test-java-kotlin',
@@ -75,7 +75,7 @@ testCases.twoLang = {
 
 testCases.filename = {
   component: ContextlessIosViewControllerToggle,
-  description: 'Two languages with filename',
+  description: 'Two languages with filename (code toggle is not interactive)',
   props: {
     context: contextObjectiveC,
     id: 'test-java-kotlin-filename',
@@ -89,7 +89,8 @@ testCases.filename = {
 
 testCases.copyRange = {
   component: ContextlessIosViewControllerToggle,
-  description: 'Two languages with copy ranges',
+  description:
+    'Two languages with copy ranges (code toggle is not interactive)',
   props: {
     context: contextObjectiveC,
     id: 'test-java-kotlin-copy-range',

--- a/src/components/toggleable-code-block/examples/basic.js
+++ b/src/components/toggleable-code-block/examples/basic.js
@@ -6,6 +6,15 @@ import ToggleableCodeBlock from '../toggleable-code-block';
 import { highlightJava } from '../../highlight/java';
 
 export default class Basic extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      language: 'java'
+    };
+  }
+
+  changeLanguage = (language) => this.setState({ language });
+
   render() {
     const javaCodeSnippet = `
     public class MainActivity extends AppCompatActivity {
@@ -33,7 +42,7 @@ export default class Basic extends React.Component {
             [5, 8]
           ]
         }}
-        changeLanguage={() => {}}
+        changeLanguage={this.changeLanguage}
         filename="ThisIsAFile.extension"
         link="https://github.com/mapbox/"
         limitHeight={true}
@@ -41,27 +50,27 @@ export default class Basic extends React.Component {
           {
             label: 'JavaScript',
             language: 'javascript',
-            preferredLanguage: false
+            preferredLanguage: this.state.language === 'javascript'
           },
           {
             label: 'Swift',
             language: 'swift',
-            preferredLanguage: false
+            preferredLanguage: this.state.language === 'swift'
           },
           {
             label: 'Objective-C',
             language: 'objectiveC',
-            preferredLanguage: false
+            preferredLanguage: this.state.language === 'objectiveC'
           },
           {
             label: 'Java',
             language: 'java',
-            preferredLanguage: true
+            preferredLanguage: this.state.language === 'java'
           },
           {
             label: 'Kotlin',
             language: 'kotlin',
-            preferredLanguage: false
+            preferredLanguage: this.state.language === 'kotlin'
           }
         ]}
       />


### PR DESCRIPTION
**Merges into #431**

This PR makes test case toggles interactive, where possible, and adds labels to test cases that are not interactive. This will help make it clear if a change affected the interactivity of these components, especially ahead of reviewing #414 .

## How to test

<!-- List steps on how the reviewer can test this change. Make sure the user can test the component properly by creating a test case or adding an example to the catalog site. -->

## QA checklist

Not applicable for this change

