### PR TITLE
Replace `id` with aria-label in VimeoPlayImage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ hideFromSearchEngines: true
 ---*/
 ```
 
+- Replace `id` with `aria-label` in `VimeoPlayImage` to prevent duplicated `id`s when more than one instance is on the same page. [#438](https://github.com/mapbox/dr-ui/pull/438)
+
 ## 3.3.1
 
 - The `edit.css` prop is optional when displaying `Edit` in `CodeSnippet`. [#421](https://github.com/mapbox/dr-ui/pull/421)

--- a/src/components/related-page/__tests__/__snapshots__/related-page.test.js.snap
+++ b/src/components/related-page/__tests__/__snapshots__/related-page.test.js.snap
@@ -856,18 +856,13 @@ exports[`related-page video renders as expected 1`] = `
             }
           >
             <svg
-              aria-labelledby="play-icon-title"
+              aria-label="Play"
               fill="#fff"
               focusable="false"
               role="img"
               viewBox="0 0 20 20"
               width="100%"
             >
-              <title
-                id="play-icon-title"
-              >
-                Play
-              </title>
               <polygon
                 points="1,0 20,10 1,20"
               />
@@ -942,18 +937,13 @@ exports[`related-page video with svg image fallback renders as expected 1`] = `
             }
           >
             <svg
-              aria-labelledby="play-icon-title"
+              aria-label="Play"
               fill="#7753eb"
               focusable="false"
               role="img"
               viewBox="0 0 20 20"
               width="100%"
             >
-              <title
-                id="play-icon-title"
-              >
-                Play
-              </title>
               <polygon
                 points="1,0 20,10 1,20"
               />

--- a/src/components/related-page/vimeo.js
+++ b/src/components/related-page/vimeo.js
@@ -92,11 +92,10 @@ export class VimeoPlayImage extends React.PureComponent {
           viewBox="0 0 20 20"
           width="100%"
           focusable="false"
-          aria-labelledby="play-icon-title"
+          aria-label="Play"
           role="img"
           fill={this.props.fallbackIcon ? '#7753eb' : '#fff'}
         >
-          <title id="play-icon-title">Play</title>
           <polygon points="1,0 20,10 1,20" />
         </svg>
       </IconWrapper>


### PR DESCRIPTION
**This branch merges into #431** 

This PR replaces the `id` in `VimeoPlayImage` with an `aria-label` to prevent duplicated `id`s when more than one instance is on the page.



## QA checklist


- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `7.0.0`.




## Before merge

- [x] Add entry to CHANGELOG.md to describe changes.

