### PR TITLE
Make "With token" `DemoIframe` a no render test case

### DIFF
--- a/src/components/demo-iframe/__tests__/__snapshots__/demo-iframe.test.js.snap
+++ b/src/components/demo-iframe/__tests__/__snapshots__/demo-iframe.test.js.snap
@@ -105,62 +105,42 @@ exports[`demo-iframe Basic renders as expected 1`] = `
 exports[`demo-iframe Missing token will return null component renders as expected 1`] = `null`;
 
 exports[`demo-iframe With token renders as expected 1`] = `
-<div
-  style={
-    Object {
-      "minHeight": 430,
-    }
-  }
->
-  <div
-    className="dr-ui--note py18 px18 round flex-parent flex-parent--row mb18"
-    style={
-      Object {
-        "background": "#feefe2",
-        "color": "#78471c",
-      }
-    }
+<div>
+  <iframe
+    height={400}
+    src="https://api.mapbox.com/styles/v1/examples/cjj0b5ie80ec32so5uo8ox21m.html?fresh=true&title=true&access_token=p.key10101010101010101010#15/40.751589/-73.986485/-28/60"
+    title="Static API request"
+    width="100%"
+  />
+  <a
+    className="link"
+    href="https://api.mapbox.com/styles/v1/examples/cjj0b5ie80ec32so5uo8ox21m.html?fresh=true&title=true&access_token=p.key10101010101010101010#15/40.751589/-73.986485/-28/60"
   >
-    <div
-      className="flex-child mr18 none block-mm pt3"
-    >
-      <div
-        className="bg-orange-light round-full color-orange flex-parent flex-parent--center-main flex-parent--center-cross"
-        style={
-          Object {
-            "height": 50,
-            "width": 50,
-          }
-        }
+    <span>
+      View fullscreen
+       
+      <span
+        className="txt-nowrap"
       >
+        demo
         <svg
-          className="events-none icon"
+          className="events-none icon inline-block align-t"
           focusable="false"
           role="presentation"
           style={
             Object {
-              "height": 40,
-              "width": 40,
+              "height": "1.5em",
+              "width": "1.5em",
             }
           }
         >
           <use
-            xlinkHref="#icon-alert"
+            xlinkHref="#icon-chevron-right"
             xmlnsXlink="http://www.w3.org/1999/xlink"
           />
         </svg>
-      </div>
-    </div>
-    <div
-      className="flex-child prose"
-    >
-      <div
-        className="txt-bold txt-m mb6"
-      >
-        Mapbox GL unsupported
-      </div>
-      Mapbox GL is unsupported due to insufficient worker support.
-    </div>
-  </div>
+      </span>
+    </span>
+  </a>
 </div>
 `;

--- a/src/components/demo-iframe/__tests__/__snapshots__/demo-iframe.test.js.snap
+++ b/src/components/demo-iframe/__tests__/__snapshots__/demo-iframe.test.js.snap
@@ -104,7 +104,7 @@ exports[`demo-iframe Basic renders as expected 1`] = `
 
 exports[`demo-iframe Missing token will return null component renders as expected 1`] = `null`;
 
-exports[`demo-iframe With token renders as expected 1`] = `
+exports[`demo-iframe Overrides the MapboxAccessToken with another token renders as expected 1`] = `
 <div>
   <iframe
     height={400}

--- a/src/components/demo-iframe/__tests__/demo-iframe-test-cases.js
+++ b/src/components/demo-iframe/__tests__/demo-iframe-test-cases.js
@@ -10,14 +10,15 @@ testCases.basic = {
   element: <Basic />
 };
 
-testCases.token = {
+noRenderCases.token = {
   component: DemoIframe,
   description: 'With token',
   props: {
     src:
       'https://api.mapbox.com/styles/v1/examples/cjj0b5ie80ec32so5uo8ox21m.html?fresh=true&title=true&access_token=MapboxAccessToken#15/40.751589/-73.986485/-28/60',
     title: 'Static API request',
-    MapboxAccessToken: 'p.key10101010101010101010'
+    MapboxAccessToken: 'p.key10101010101010101010',
+    gl: false
   }
 };
 

--- a/src/components/demo-iframe/__tests__/demo-iframe-test-cases.js
+++ b/src/components/demo-iframe/__tests__/demo-iframe-test-cases.js
@@ -12,7 +12,7 @@ testCases.basic = {
 
 noRenderCases.token = {
   component: DemoIframe,
-  description: 'With token',
+  description: 'Overrides the MapboxAccessToken with another token',
   props: {
     src:
       'https://api.mapbox.com/styles/v1/examples/cjj0b5ie80ec32so5uo8ox21m.html?fresh=true&title=true&access_token=MapboxAccessToken#15/40.751589/-73.986485/-28/60',

--- a/src/components/demo-iframe/__tests__/demo-iframe.test.js
+++ b/src/components/demo-iframe/__tests__/demo-iframe.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { testCases } from './demo-iframe-test-cases.js';
+import { testCases, noRenderCases } from './demo-iframe-test-cases.js';
 
 describe('demo-iframe', () => {
   describe(testCases.basic.description, () => {
@@ -19,13 +19,13 @@ describe('demo-iframe', () => {
     });
   });
 
-  describe(testCases.token.description, () => {
+  describe(noRenderCases.token.description, () => {
     let testCase;
     let wrapper;
     let tree;
 
     beforeEach(() => {
-      testCase = testCases.token;
+      testCase = noRenderCases.token;
       wrapper = renderer.create(
         React.createElement(testCase.component, testCase.props)
       );


### PR DESCRIPTION
This PR makes the "With token" `DemoIframe` test case a no render test case. The goal of the test case is to prove that the `MapboxAccessToken` prop will be properly merged into the `src` and a snapshot test will help us assert this.

Fixes https://github.com/mapbox/dr-ui/issues/436