### PR TITLE
Fix prepareSitemap function to append index.html to files ending in index.js

### DIFF
--- a/src/helpers/batfish/__tests__/sitemap.test.js
+++ b/src/helpers/batfish/__tests__/sitemap.test.js
@@ -64,6 +64,55 @@ describe('prepareSitemap', () => {
     ]);
   });
 
+  it('append index.html to files ending in index.js', () => {
+    const ignoreFile = prepareSitemap({
+      pages: [
+        {
+          filePath: '/android-docs/src/pages/index.js',
+          path: '/android/',
+          frontMatter: {
+            hideFromSearchEngines: true
+          }
+        },
+        {
+          filePath: '/android-docs/src/pages/core/index.js',
+          path: '/android/core/',
+          frontMatter: {
+            hideFromSearchEngines: true
+          }
+        },
+        {
+          filePath: '/android-docs/src/pages/java/index.js',
+          path: '/android/java/',
+          frontMatter: {
+            hideFromSearchEngines: true
+          }
+        },
+        {
+          filePath: '/android-docs/src/pages/core/api-reference/index.md',
+          path: '/android/core/api-reference/',
+          frontMatter: {
+            title: 'API Reference'
+          }
+        },
+        {
+          filePath: '/android-docs/src/pages/core/guides/hidden.md',
+          path: '/android/core/guides/hidden/',
+          frontMatter: {
+            hideFromSearchEngines: true
+          }
+        }
+      ],
+      siteBasePath: '/android'
+    }).map((f) => f.replace(process.cwd(), ''));
+    expect(ignoreFile).toEqual([
+      '/_site/index.html',
+      '/_site/core/index.html',
+      '/_site/java/index.html',
+      '/_site/core/guides/hidden/'
+    ]);
+  });
+
   // travis is configured to run this test file again after build
   // this test asserts the URLs in the sitemap
   if (existsSync(siteMap)) {

--- a/src/helpers/batfish/sitemap.js
+++ b/src/helpers/batfish/sitemap.js
@@ -13,13 +13,12 @@ function prepareSitemap({
       ({ frontMatter }) =>
         frontMatter.hideFromSearchEngines || frontMatter.splitPage
     )
-    .map(({ path }) => {
-      // fix root index path to return full path
-      if (path === `${siteBasePath}/`) {
-        return path.replace(
-          join(siteBasePath, '/'),
-          join(process.cwd(), docsPath, outputDirectory, 'index.html')
-        );
+    .map(({ path, filePath }) => {
+      // append index.html to files ending in index.js
+      if (filePath.endsWith('index.js')) {
+        return path
+          .replace(siteBasePath, join(process.cwd(), docsPath, outputDirectory))
+          .replace(/\/$/, '/index.html');
       } else {
         return path.replace(
           siteBasePath,


### PR DESCRIPTION
While testing #431, I noticed that in the prepareSitemap Batfish helper that all files that end in `index.js` must have `index.html` appended to the path (not just the root index.js file). This PR makes that fixes and adds a test case to support it.

Before this fix, the test case would return the following paths to ignore:

```json
["/_site/index.html", "/_site/core/", "/_site/java/", "/_site/core/guides/hidden/"]
```

This would result in the sitemap excluding everything under `/_site/core/` and `/_site/java/` since it uses globs. This is not what we want. We only want the `index.html` to be removed from the sitemap, not all pages under those directories.

With the fix, the paths are more specific:

```json
["/_site/index.html", "/_site/core/index.html", "/_site/java/index.html", "/_site/core/guides/hidden/"]
```