### PR TITLE
Fix siteOrigin

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -1,7 +1,7 @@
 const rc = require('@mapbox/remark-config-docs');
 const config = {
   siteBasePath: 'dr-ui',
-  siteOrigin: 'https://mapbox.github.com',
+  siteOrigin: 'https://mapbox.github.io',
   pages: 'docs/src/pages/',
   constants: 'docs/src/constants.json',
   ignoreLinks: 'conf/ignore-links.json'


### PR DESCRIPTION
This PR fixes the siteOrigin in the remark config to fix the broken tests seen in https://github.com/mapbox/dr-ui/pull/445