### PR TITLE
Send search results with no queries to Sentry

### DIFF
--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -8,6 +8,7 @@ import SearchResult from './search-result';
 import { getFilterValueDisplay } from '@elastic/react-search-ui-views/lib/view-helpers';
 import { Facet } from '@elastic/react-search-ui';
 import classnames from 'classnames';
+import * as Sentry from '@sentry/browser';
 
 export class SearchBox extends React.PureComponent {
   constructor(props) {
@@ -21,6 +22,7 @@ export class SearchBox extends React.PureComponent {
     this.renderModal = this.renderModal.bind(this);
     this.renderSearchBar = this.renderSearchBar.bind(this);
     this.singleLinksFacet = this.singleLinksFacet.bind(this);
+    this.renderNoResult = this.renderNoResult.bind(this);
     // if resultsOnly and overrideSearchTerm, set the search term
     if (this.props.resultsOnly && this.props.overrideSearchTerm) {
       props.setSearchTerm(this.props.overrideSearchTerm);
@@ -99,6 +101,31 @@ export class SearchBox extends React.PureComponent {
     );
   };
 
+  renderNoResult() {
+    const { themeCompact, emptyResultMessage, searchTerm } = this.props;
+    // Track query in Sentry
+    Sentry.init({
+      dsn:
+        'https://cbf0479a2c93421db53d4dd20df6dc52@o5937.ingest.sentry.io/5736949',
+      environment: 'dr-ui'
+    });
+    Sentry.configureScope((scope) => {
+      scope.setFingerprint(searchTerm);
+      Sentry.captureMessage(searchTerm);
+    });
+    // Return message
+    return (
+      <div
+        className={classnames('px12', {
+          'py6 txt-s': themeCompact,
+          'py12 prose': !themeCompact
+        })}
+      >
+        {emptyResultMessage}
+      </div>
+    );
+  }
+
   renderSearchBar() {
     const {
       inputId,
@@ -110,7 +137,6 @@ export class SearchBox extends React.PureComponent {
       isLoading,
       wasSearched,
       themeCompact,
-      emptyResultMessage,
       placeholder,
       useModal
     } = this.props;
@@ -208,14 +234,7 @@ export class SearchBox extends React.PureComponent {
                             ))}
                           </ul>
                         ) : (
-                          <div
-                            className={classnames('px12', {
-                              'py6 txt-s': themeCompact,
-                              'py12 prose': !themeCompact
-                            })}
-                          >
-                            {emptyResultMessage}
-                          </div>
+                          this.renderNoResult()
                         ))}
                     </React.Fragment>
                   </div>


### PR DESCRIPTION
This PR will send a Sentry event if the Search component returns no results. This will allow us to better track the number of users who encounter this message and provide us realtime data.

## How to test

1. `npm ci && npm start`
2. Visit http://192.168.7.223:9966/Search
3. Open Search component and smash your hands upon your keyboard
4. Wait for no result message and then close search
5. Visit the Sentry project docs-swiftype to check that your query came through (give it 1-2 minutes) - let me know if you need the link!

## QA checklist


- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.

## Before merge

- [ ] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
