### PR TITLE
Handle `Video` play as a promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.2
+
+- Fix `Video` to use a promise when handling `play()`. [#459](https://github.com/mapbox/dr-ui/pull/459)
+
 ## 4.0.1
 
 - In `Search` component, fix logic to prevent queries with results from being sent to Sentry.

--- a/src/components/video/video.js
+++ b/src/components/video/video.js
@@ -2,6 +2,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { VimeoPlayImage } from '../related-page/vimeo';
+import * as Sentry from '@sentry/browser';
+
 /*
  * The state defines the user's preferences for the video settings (autoplay and loop).
  * The props for Video will only be taken into account if the user does not prefer reduced motion.
@@ -58,7 +60,12 @@ export default class Video extends React.PureComponent {
 
   // play the video
   playVideo = () => {
-    this.video.current.play();
+    const playPromise = this.video.current.play();
+    if (playPromise !== undefined) {
+      playPromise
+        .then(() => this.setState({ isPlaying: true }))
+        .catch((error) => Sentry.captureException(error));
+    }
   };
 
   render() {


### PR DESCRIPTION
This PR fixes a bug with the Video component, where `play` should be handled as a promise.

Fixes #458 

## How to test

1. npm start
2. visit /Video test case
3. interact with the videos to make sure you can click the video to pause/play it

## QA checklist

<!-- Complete this checklist when adding a new component or package. -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.

## Before merge

- [x] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
