### PR TITLE
Fix `sortVersions` for prerelease versions greater than 10.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix `sortVersions` for prerelease versions greater than 10. [#464](https://github.com/mapbox/dr-ui/pull/464)
+
 ## 4.0.1
 
 - In `Search` component, fix logic to prevent queries with results from being sent to Sentry.

--- a/src/helpers/version-sort.js
+++ b/src/helpers/version-sort.js
@@ -1,8 +1,5 @@
 const compareVersions = require('compare-versions');
 
-const sortBy = (key) => (a, b) =>
-  a[key] > b[key] ? 1 : b[key] > a[key] ? -1 : 0;
-
 export function sortVersions(versions) {
   // make sure versions are in order
   const allVersionsOrdered = versions.sort(compareVersions).reverse();
@@ -40,7 +37,7 @@ export function sortVersions(versions) {
   const newestPreRelease =
     sortPreReleases &&
     sortPreReleases
-      .sort(sortBy('version'))
+      .sort((a, b) => { return compareVersions(a.version, b.version); })
       .reverse()
       .reduce((arr, v) => {
         // do not push pre releases of lastest stable

--- a/tests/version-sort.test.js
+++ b/tests/version-sort.test.js
@@ -5,6 +5,8 @@ const allIosVersions = require('./sample/ios.json');
 
 describe('pre-release', () => {
   const arr = [
+    '4.9.0-beta.2',
+    '4.9.0-beta.10',
     '4.9.0-beta.1',
     '4.9.0-alpha.2',
     '4.9.0-alpha.1',
@@ -17,6 +19,8 @@ describe('pre-release', () => {
 
   test(`allVersionsOrdered`, () => {
     expect(sortVersions(arr).allVersionsOrdered).toEqual([
+      '4.9.0-beta.10',
+      '4.9.0-beta.2',
       '4.9.0-beta.1',
       '4.9.0-alpha.2',
       '4.9.0-alpha.1',
@@ -38,6 +42,8 @@ describe('pre-release', () => {
 
   test(`newestPreRelease`, () => {
     expect(sortVersions(arr).newestPreRelease).toEqual([
+      '4.9.0-beta.10',
+      '4.9.0-beta.2',
       '4.9.0-beta.1',
       '4.9.0-alpha.2',
       '4.9.0-alpha.1'


### PR DESCRIPTION
<!-- List what changes this PR introduces. -->
Fixes #463.

## How to test

I tested this solution by rebuilding NavSDK "API Reference" page https://docs.mapbox.com/ios/navigation/api-reference/ with these changes.

**Before:** 
<img width="712" alt="image" src="https://user-images.githubusercontent.com/1976216/123634503-3041b680-d823-11eb-9e69-fc913bd226e3.png">

**After:** 
<img width="708" alt="image" src="https://user-images.githubusercontent.com/1976216/123634553-4485b380-d823-11eb-990c-a83ad999f6ee.png">

## QA checklist

<!-- Complete this checklist when adding a new component or package. -->

- [ ] No errors logged to console.
- [ ] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [ ] Component is accessible at mobile-size viewport.
- [ ] Component is accessible at tablet-size viewport.
- [ ] Component is accessible at laptop-size viewport.
- [ ] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [ ] Chrome, no errors logged to console.
- [ ] Firefox, no errors logged to console.
- [ ] Safari, no errors logged to console.
- [ ] Edge, no errors logged to console.
- [ ] Mobile Safari, no errors logged to console.
- [ ] Android Chrome, no errors logged to console.

## Before merge

- [x] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
