### PR TITLE
@mapbox/rehype-prism@0.7.0 and prismjs@1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Update prismjs, rehype-prism. [#466](https://github.com/mapbox/dr-ui/pull/466)
+
 ## 4.0.2
 
 - Fix `sortVersions` for prerelease versions greater than 10. [#464](https://github.com/mapbox/dr-ui/pull/464)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8107,13 +8107,13 @@
       }
     },
     "@mapbox/rehype-prism": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/rehype-prism/-/rehype-prism-0.6.0.tgz",
-      "integrity": "sha512-/0Ev/PB4fXdKPT6VDzVpnAPxGpWFIc4Yz3mf/DzLEMxlpIPZpZlCzaFk4V4NGFofQXPc41+GpEcZtWP3VuFWVA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/rehype-prism/-/rehype-prism-0.7.0.tgz",
+      "integrity": "sha512-zSG46selA6v+3THhCatTyOt9DuTzxTIVTxTbcj15kFmxPDtjzZ5VoFVCLZfjWFouYa9PiXxcbMLLhJoVzCxh9w==",
       "dev": true,
       "requires": {
         "hast-util-to-string": "^1.0.4",
-        "refractor": "^3.3.1",
+        "refractor": "^3.4.0",
         "unist-util-visit": "^2.0.3"
       }
     },
@@ -25844,28 +25844,21 @@
       "dev": true
     },
     "refractor": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.3.1.tgz",
-      "integrity": "sha512-vaN6R56kLMuBszHSWlwTpcZ8KTMG6aUCok4GrxYDT20UIOXxOc5o6oDc8tNTzSlH3m2sI+Eu9Jo2kVdDcUTWYw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.4.0.tgz",
+      "integrity": "sha512-dBeD02lC5eytm9Gld2Mx0cMcnR+zhSnsTfPpWqFaMgUMJfC9A6bcN3Br/NaXrnBJcuxnLFR90k1jrkaSyV8umg==",
       "dev": true,
       "requires": {
         "hastscript": "^6.0.0",
         "parse-entities": "^2.0.0",
-        "prismjs": "~1.23.0"
+        "prismjs": "~1.24.0"
       },
       "dependencies": {
-        "hastscript": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
-          "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
-          "dev": true,
-          "requires": {
-            "@types/hast": "^2.0.0",
-            "comma-separated-tokens": "^1.0.0",
-            "hast-util-parse-selector": "^2.0.0",
-            "property-information": "^5.0.0",
-            "space-separated-tokens": "^1.0.0"
-          }
+        "prismjs": {
+          "version": "1.24.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
+          "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ==",
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -25166,12 +25166,9 @@
       }
     },
     "prismjs": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
-      "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
-      "requires": {
-        "clipboard": "^2.0.0"
-      }
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
+      "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ=="
     },
     "private": {
       "version": "0.1.8",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "downshift": "^6.1.3",
     "github-slugger": "^1.3.0",
     "hastscript": "^6.0.0",
-    "prismjs": "^1.23.0",
+    "prismjs": "^1.24.0",
     "react-aria-modal": "^4.0.0",
     "react-html-parser": "^2.0.2",
     "remark-frontmatter": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@mapbox/mbx-assembly": "^0.31.0",
     "@mapbox/prettier-config-docs": "^0.2.1",
     "@mapbox/react-test-kitchen": "^0.3.0",
-    "@mapbox/rehype-prism": "^0.6.0",
+    "@mapbox/rehype-prism": "^0.7.0",
     "@mapbox/remark-config-docs": "^0.14.0",
     "@mapbox/remark-lint-link-text": "^0.6.0",
     "@mapbox/remark-lint-mapbox": "^2.9.0",


### PR DESCRIPTION
This PR will bump @mapbox/rehype-prism@0.7.0 and prismjs@1.24.0 to fix a security issue with prismjs (ref #465)