### PR TITLE
Add Sentry tracing with new `sentryPerformance` prop on AnalyticsShell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update search-ui dependencies. [#467](https://github.com/mapbox/dr-ui/pull/467)
 - Update devDependencies. [#468](https://github.com/mapbox/dr-ui/pull/468)
 - Add `babel-plugin-transform-react-remove-prop-types` to babel.config.js and use ES6 modules. [#456](https://github.com/mapbox/dr-ui/pull/456)
+- Add Sentry tracing to the `AnalyticsShell` with added `sentryPerformance` prop. [#469](https://github.com/mapbox/dr-ui/pull/469)
 
 ## 4.0.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dr-ui",
-  "version": "4.1.0-alpha.1",
+  "version": "4.1.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8261,6 +8261,54 @@
         "tslib": "^1.9.3"
       }
     },
+    "@sentry/tracing": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.10.0.tgz",
+      "integrity": "sha512-jZj6Aaf8kU5wgyNXbAJHosHn8OOFdK14lgwYPb/AIDsY35g9a9ncTOqIOBp8X3KkmSR8lcBzAEyiUzCxAis2jA==",
+      "requires": {
+        "@sentry/hub": "6.10.0",
+        "@sentry/minimal": "6.10.0",
+        "@sentry/types": "6.10.0",
+        "@sentry/utils": "6.10.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/hub": {
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.10.0.tgz",
+          "integrity": "sha512-MV8wjhWiFAXZAhmj7Ef5QdBr2IF93u8xXiIo2J+dRZ7eVa4/ZszoUiDbhUcl/TPxczaw4oW2a6tINBNFLzXiig==",
+          "requires": {
+            "@sentry/types": "6.10.0",
+            "@sentry/utils": "6.10.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/minimal": {
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.10.0.tgz",
+          "integrity": "sha512-yarm046UgUFIBoxqnBan2+BEgaO9KZCrLzsIsmALiQvpfW92K1lHurSawl5W6SR7wCYBnNn7CPvPE/BHFdy4YA==",
+          "requires": {
+            "@sentry/hub": "6.10.0",
+            "@sentry/types": "6.10.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.10.0.tgz",
+          "integrity": "sha512-M7s0JFgG7/6/yNVYoPUbxzaXDhnzyIQYRRJJKRaTD77YO4MHvi4Ke8alBWqD5fer0cPIfcSkBqa9BLdqRqcMWw=="
+        },
+        "@sentry/utils": {
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.10.0.tgz",
+          "integrity": "sha512-F9OczOcZMFtazYVZ6LfRIe65/eOfQbiAedIKS0li4npuMz0jKYRbxrjd/U7oLiNQkPAp4/BujU4m1ZIwq6a+tg==",
+          "requires": {
+            "@sentry/types": "6.10.0",
+            "tslib": "^1.9.3"
+          }
+        }
+      }
+    },
     "@sentry/types": {
       "version": "6.3.6",
       "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.6.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8219,45 +8219,45 @@
       }
     },
     "@sentry/browser": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.3.6.tgz",
-      "integrity": "sha512-l4323jxuBOArki6Wf+EHes39IEyJ2Zj/CIUaTY7GWh7CntpfHQAfFmZWQw3Ozq+ka1u8lVp25RPhb4Wng3azNA==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.10.0.tgz",
+      "integrity": "sha512-H0Blgp8f8bomebkkGWIgxHVjabtQAlsKJDiFXBg7gIc75YcarRxwH0R3hMog1/h8mmv4CGGUsy5ljYW6jsNnvA==",
       "requires": {
-        "@sentry/core": "6.3.6",
-        "@sentry/types": "6.3.6",
-        "@sentry/utils": "6.3.6",
+        "@sentry/core": "6.10.0",
+        "@sentry/types": "6.10.0",
+        "@sentry/utils": "6.10.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.3.6.tgz",
-      "integrity": "sha512-w6BRizAqh7BaiM9oeKzO6aACXwRijUPacYaVLX/OfhqCSueF9uDxpMRT7+4D/eCeDVqgJYhBJ4Vsu2NSstkk4A==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.10.0.tgz",
+      "integrity": "sha512-5KlxHJlbD7AMo+b9pMGkjxUOfMILtsqCtGgI7DMvZNfEkdohO8QgUY+hPqr540kmwArFS91ipQYWhqzGaOhM3Q==",
       "requires": {
-        "@sentry/hub": "6.3.6",
-        "@sentry/minimal": "6.3.6",
-        "@sentry/types": "6.3.6",
-        "@sentry/utils": "6.3.6",
+        "@sentry/hub": "6.10.0",
+        "@sentry/minimal": "6.10.0",
+        "@sentry/types": "6.10.0",
+        "@sentry/utils": "6.10.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.3.6.tgz",
-      "integrity": "sha512-foBZ3ilMnm9Gf9OolrAxYHK8jrA6IF72faDdJ3Al+1H27qcpnBaMdrdEp2/jzwu/dgmwuLmbBaMjEPXaGH/0JQ==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.10.0.tgz",
+      "integrity": "sha512-MV8wjhWiFAXZAhmj7Ef5QdBr2IF93u8xXiIo2J+dRZ7eVa4/ZszoUiDbhUcl/TPxczaw4oW2a6tINBNFLzXiig==",
       "requires": {
-        "@sentry/types": "6.3.6",
-        "@sentry/utils": "6.3.6",
+        "@sentry/types": "6.10.0",
+        "@sentry/utils": "6.10.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.3.6.tgz",
-      "integrity": "sha512-uM2/dH0a6zfvI5f+vg+/mST+uTBdN6Jgpm585ipH84ckCYQwIIDRg6daqsen4S1sy/xgg1P1YyC3zdEC4G6b1Q==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.10.0.tgz",
+      "integrity": "sha512-yarm046UgUFIBoxqnBan2+BEgaO9KZCrLzsIsmALiQvpfW92K1lHurSawl5W6SR7wCYBnNn7CPvPE/BHFdy4YA==",
       "requires": {
-        "@sentry/hub": "6.3.6",
-        "@sentry/types": "6.3.6",
+        "@sentry/hub": "6.10.0",
+        "@sentry/types": "6.10.0",
         "tslib": "^1.9.3"
       }
     },
@@ -8310,16 +8310,16 @@
       }
     },
     "@sentry/types": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.6.tgz",
-      "integrity": "sha512-93cFJdJkWyCfyZeWFARSU11qnoHVOS/R2h5WIsEf+jbQmkqG2C+TXVz/19s6nHVsfDrwpvYpwALPv4/nrxfU7g=="
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.10.0.tgz",
+      "integrity": "sha512-M7s0JFgG7/6/yNVYoPUbxzaXDhnzyIQYRRJJKRaTD77YO4MHvi4Ke8alBWqD5fer0cPIfcSkBqa9BLdqRqcMWw=="
     },
     "@sentry/utils": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.3.6.tgz",
-      "integrity": "sha512-HnYlDBf8Dq8MEv7AulH7B6R1D/2LAooVclGdjg48tSrr9g+31kmtj+SAj2WWVHP9+bp29BWaC7i5nkfKrOibWw==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.10.0.tgz",
+      "integrity": "sha512-F9OczOcZMFtazYVZ6LfRIe65/eOfQbiAedIKS0li4npuMz0jKYRbxrjd/U7oLiNQkPAp4/BujU4m1ZIwq6a+tg==",
       "requires": {
-        "@sentry/types": "6.3.6",
+        "@sentry/types": "6.10.0",
         "tslib": "^1.9.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dr-ui",
-  "version": "4.1.0-alpha.1",
+  "version": "4.1.0-alpha.2",
   "description": "Mapbox frontend tools for documentation websites.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -105,8 +105,8 @@
     "@elastic/search-ui-site-search-connector": "^1.7.0",
     "@mapbox/mapbox-gl-supported": "^2.0.0",
     "@mapbox/mr-ui": "^0.10.0",
-    "@sentry/browser": "6.3.6",
-    "@sentry/tracing": "^6.10.0",
+    "@sentry/browser": "6.10.0",
+    "@sentry/tracing": "6.10.0",
     "classnames": "^2.3.1",
     "compare-versions": "^3.6.0",
     "debounce": "^1.2.1",
@@ -126,7 +126,7 @@
   "peerDependencies": {
     "@mapbox/mr-ui": "^0.10.0",
     "@mapbox/mbx-assembly": "^0.31.0",
-    "@sentry/browser": "6.3.6",
+    "@sentry/browser": "6.10.0",
     "react": "^16.14.0",
     "react-dom": "^16.14.0"
   },

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@mapbox/mapbox-gl-supported": "^2.0.0",
     "@mapbox/mr-ui": "^0.10.0",
     "@sentry/browser": "6.3.6",
+    "@sentry/tracing": "^6.10.0",
     "classnames": "^2.3.1",
     "compare-versions": "^3.6.0",
     "debounce": "^1.2.1",

--- a/src/components/analytics-shell/__tests__/analytics-shell.test.js
+++ b/src/components/analytics-shell/__tests__/analytics-shell.test.js
@@ -3,6 +3,7 @@ import renderer from 'react-test-renderer';
 import AnalyticsShell from '../analytics-shell';
 import { testCases } from './analytics-shell-test-cases.js';
 import * as Sentry from '@sentry/browser';
+import { Integrations as TracingIntegrations } from '@sentry/tracing';
 import { mount } from 'enzyme';
 
 jest.mock('@sentry/browser');
@@ -27,7 +28,9 @@ describe('AnalyticsShell', () => {
       mount(testCase.element);
       expect(Sentry.init).toHaveBeenCalledWith({
         dsn: 'https://6ba8cfeeedad4fb7acb8576f0fd6e266@sentry.io/1384508',
-        environment: 'staging'
+        environment: 'staging',
+        integrations: [new TracingIntegrations.BrowserTracing()],
+        tracesSampleRate: 0.2
       });
     });
 
@@ -64,6 +67,7 @@ describe('AnalyticsShell', () => {
     mount(
       <AnalyticsShell
         sentry={{ dsn: 'abcd!' }}
+        sentryPerformance={{}} // disable performance
         location={{ pathname: '/dr-ui/' }}
       >
         Hello world!

--- a/src/components/analytics-shell/analytics-shell.js
+++ b/src/components/analytics-shell/analytics-shell.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import PropTypes from 'prop-types';
 import * as Sentry from '@sentry/browser';
+import { Integrations as TracingIntegrations } from '@sentry/tracing';
 import env from './env';
 
 export default class AnalyticsShell extends React.PureComponent {
@@ -11,6 +12,7 @@ export default class AnalyticsShell extends React.PureComponent {
       disableSentry,
       webAnalytics,
       sentry,
+      sentryPerformance,
       mbxMetadata
     } = this.props;
     // set mapbox metadata before initializing analytics
@@ -25,7 +27,8 @@ export default class AnalyticsShell extends React.PureComponent {
     if (!disableSentry) {
       Sentry.init({
         ...sentry,
-        environment: env()
+        environment: env(),
+        ...sentryPerformance
       });
     }
   }
@@ -59,6 +62,12 @@ AnalyticsShell.defaultProps = {
   sentry: {
     dsn: 'https://6ba8cfeeedad4fb7acb8576f0fd6e266@sentry.io/1384508'
   },
+  sentryPerformance: {
+    // This enables automatic instrumentation (highly recommended)
+    integrations: [new TracingIntegrations.BrowserTracing()],
+    // To set a uniform sample rate
+    tracesSampleRate: 0.2
+  },
   // do not disable web-analytics by default
   disableWebAnalytics: false,
   // default web-analytics options, disable Drift by default
@@ -81,6 +90,11 @@ AnalyticsShell.propTypes = {
   /** Customize [Sentry options](https://docs.sentry.io/error-reporting/configuration/?platform=browser). */
   sentry: PropTypes.shape({
     dsn: PropTypes.string
+  }),
+  /** Customize [Sentry performance monitoring options](https://docs.sentry.io/platforms/javascript/performance/). To disable tracing, set this value as an empty object: `sentryPerformance={{}}`*/
+  sentryPerformance: PropTypes.shape({
+    integrations: PropTypes.array,
+    tracesSampleRate: PropTypes.number
   }),
   /** Customize [web-analytics options](https://github.com/mapbox/web-analytics). */
   webAnalytics: PropTypes.object,

--- a/src/components/analytics-shell/analytics-shell.js
+++ b/src/components/analytics-shell/analytics-shell.js
@@ -87,19 +87,19 @@ AnalyticsShell.propTypes = {
   }).isRequired,
   /** Production website domain. */
   domain: PropTypes.string,
+  /** If `true`, Sentry will not initialize. */
+  disableSentry: PropTypes.bool,
   /** Customize [Sentry options](https://docs.sentry.io/error-reporting/configuration/?platform=browser). */
   sentry: PropTypes.shape({
     dsn: PropTypes.string
   }),
-  /** Customize [Sentry performance monitoring options](https://docs.sentry.io/platforms/javascript/performance/). To disable tracing, set this value as an empty object: `sentryPerformance={{}}`*/
+  /** Customize [Sentry performance monitoring options](https://docs.sentry.io/platforms/javascript/performance/). To disable performance, set this value as an empty object: `sentryPerformance={{}}`*/
   sentryPerformance: PropTypes.shape({
     integrations: PropTypes.array,
     tracesSampleRate: PropTypes.number
   }),
   /** Customize [web-analytics options](https://github.com/mapbox/web-analytics). */
   webAnalytics: PropTypes.object,
-  /** If `true`, Sentry will not initialize. */
-  disableSentry: PropTypes.bool,
   /** If `true`, Mapbox analytics (`initializeMapboxAnalytics`) will not initialize. */
   disableWebAnalytics: PropTypes.bool,
   /** Object of properties to send to Segment */


### PR DESCRIPTION
This PR will automatically add Sentry's tracing integration to the AnalyticsShell Sentry initialization via a new prop `sentryPerformance`. You can disable tracking with an empty object `<AnalyticsShell sentryPerformance={{}} />`.

When we are ready to enable Sentry performance trial, all sites will be ready to launch. 

## How to test

This will be difficult to test since we don't have the trial yet, but since tracing is automatic I think it should be ok!

https://docs.sentry.io/platforms/javascript/performance/



## QA checklist

<!-- Complete this checklist when adding a new component or package. -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [ ] Firefox, no errors logged to console.
- [ ] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [ ] Mobile Safari, no errors logged to console.
- [ ] Android Chrome, no errors logged to console.

## Before merge

- [x] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
