### PR TITLE
Make sortVersions a common JS module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Update devDependencies. [#468](https://github.com/mapbox/dr-ui/pull/468)
 - Add `babel-plugin-transform-react-remove-prop-types` to babel.config.js and use ES6 modules. [#456](https://github.com/mapbox/dr-ui/pull/456)
 - Add Sentry tracing to the `AnalyticsShell` with added `sentryPerformance` prop. [#469](https://github.com/mapbox/dr-ui/pull/469)
+- Make `sortVersions` a common JS module. [#470](https://github.com/mapbox/dr-ui/pull/470)
 
 ## 4.0.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dr-ui",
-  "version": "4.1.0-alpha.2",
+  "version": "4.1.0-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dr-ui",
-  "version": "4.1.0-alpha.2",
+  "version": "4.1.0-alpha.3",
   "description": "Mapbox frontend tools for documentation websites.",
   "main": "index.js",
   "scripts": {

--- a/src/helpers/version-sort.js
+++ b/src/helpers/version-sort.js
@@ -1,6 +1,6 @@
 const compareVersions = require('compare-versions');
 
-export function sortVersions(versions) {
+function sortVersions(versions) {
   // make sure versions are in order
   const allVersionsOrdered = versions.sort(compareVersions).reverse();
   // get the latest stable version
@@ -61,3 +61,7 @@ export function sortVersions(versions) {
     versionsToDisplay
   };
 }
+
+module.exports = {
+  sortVersions
+};


### PR DESCRIPTION
This PR switches the sortVersions function to a common JS module. Before #457, babel was converting the module, but since this module is used by Batfish (and only accepts CJS at this time), we'll want this module to be CJS.