### PR TITLE
Only send feedback to Sentry if it exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.1.2
+
+- Update `Feedback` to only send an event to Sentry if feedback exists. [#475](https://github.com/mapbox/dr-ui/pull/475)
+
 ## 4.1.1
 
 - Fix error handling in `Feedback` component to only send error to Sentry if `forwardEvent` returns one. [#473](https://github.com/mapbox/dr-ui/pull/473)

--- a/src/components/feedback/__tests__/category-like.test.js
+++ b/src/components/feedback/__tests__/category-like.test.js
@@ -380,27 +380,8 @@ describe('Workflow, Select multiple; do not submit text feedback', () => {
       expectThankYou(feedback);
     });
 
-    test('Then send to Sentry', () => {
-      expect(Sentry.init).toHaveBeenCalledWith({
-        dsn: expect.anything(),
-        environment: 'staging',
-        maxValueLength: 1000
-      });
-      expect(SentryMockScope.setTag.mock.calls).toEqual([
-        ['site', 'dr-ui'],
-        ['category', 'I like this page'],
-        ['categoryType', 'Something else,The information is accurate'],
-        ['referrer', ''],
-        ['helpful', true]
-      ]);
-      expect(SentryMockScope.setLevel).toHaveBeenCalledWith('info');
-      expect(SentryMockScope.setFingerprint).toHaveBeenCalledWith([
-        'dr-ui',
-        'I like this page',
-        expect.anything(),
-        expect.any(Date)
-      ]);
-      expect(Sentry.captureMessage).toHaveBeenCalledWith('');
+    test('Do not send to Sentry', () => {
+      expect(Sentry.init).not.toHaveBeenCalled();
     });
 
     test('Then send to Segment', () => {

--- a/src/components/feedback/feedback.js
+++ b/src/components/feedback/feedback.js
@@ -103,7 +103,7 @@ class Feedback extends React.PureComponent {
     this.setState({ categoryType, feedback, sentFeedback: true }, () => {
       const { state, props } = this;
       sendToSegment({ state, props });
-      sendToSentry({ state, props });
+      if (feedback) sendToSentry({ state, props });
     });
   }
 


### PR DESCRIPTION
This PR updates the Feedback component to only send an event to Sentry if feedback exists.


## How to test

For testing data sent to Segment/Sentry:

1. `npm ci`
2. `npm run start`
3. Visit the Feedback test cses
4. Open the #bots channel in Slack (to see Segment events) and the docs-feedback Sentry project.
5. Click through Feedback component and watch events come through in #bots and the final "Submit feedback" will trigger a new Sentry issue (if you submit text feedback). There should **not** be a Sentry issue for "I like" feedback that does not contain text feedback.

## QA checklist

Not needed for this change.

## Before merge

- [x] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
