### PR TITLE
Check that `parentPage` exists in `NavigationAccordion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 4.2.2
+
+- Fix issue in `NavigationAccordion` to handle pages that do not have a parent. [#479](https://github.com/mapbox/dr-ui/pull/479)
+
 ## 4.2.1
 
-- Fix release 
+- Fix release
 
 ## 4.2.0
 

--- a/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
+++ b/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`navigation-accordion An active (hidden) page without a parent renders as expected 1`] = `undefined`;
+
 exports[`navigation-accordion Basic NavigationAccordion renders as expected 1`] = `
 <nav
   className="mx-neg12"

--- a/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
+++ b/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
@@ -1,6 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`navigation-accordion An active (hidden) page without a parent renders as expected 1`] = `undefined`;
+exports[`navigation-accordion An active (hidden) page without a parent renders as expected 1`] = `
+<nav
+  className="mx-neg12"
+>
+  <ul>
+    <li>
+      <div
+        className="px12 flex-parent txt-uppercase txt-fancy round-full w-full color-darken75"
+      >
+        <a
+          className="flex-child flex-child--grow  color-blue-on-hover py6 py3-mm"
+          href="page-one"
+          style={
+            Object {
+              "letterSpacing": "0.025em",
+            }
+          }
+        >
+          Title one
+        </a>
+      </div>
+    </li>
+  </ul>
+</nav>
+`;
 
 exports[`navigation-accordion Basic NavigationAccordion renders as expected 1`] = `
 <nav

--- a/src/components/navigation-accordion/__tests__/navigation-accordion-test-cases.js
+++ b/src/components/navigation-accordion/__tests__/navigation-accordion-test-cases.js
@@ -127,4 +127,20 @@ testCases.withSubPages = {
   }
 };
 
+testCases.noParent = {
+  description: 'An active (hidden) page without a parent',
+  component: NavigationAccordion,
+  props: {
+    location: { pathname: 'heading-one' },
+    parentPage: undefined,
+    navigation: [
+      {
+        title: 'Title one',
+        path: 'page-one',
+        id: 'title-one'
+      }
+    ]
+  }
+};
+
 export { testCases };

--- a/src/components/navigation-accordion/__tests__/navigation-accordion.test.js
+++ b/src/components/navigation-accordion/__tests__/navigation-accordion.test.js
@@ -36,4 +36,28 @@ describe('navigation-accordion', () => {
       expect(tree).toMatchSnapshot();
     });
   });
+
+  describe(testCases.noParent.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      Object.defineProperty(document, 'body', {
+        value: {
+          clientWidth: 1000
+        }
+      });
+
+      testCase = testCases.noParent;
+      wrapper = renderer.create(
+        React.createElement(testCase.component, testCase.props)
+      );
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
 });

--- a/src/components/navigation-accordion/navigation-accordion.js
+++ b/src/components/navigation-accordion/navigation-accordion.js
@@ -36,7 +36,7 @@ export default class NavigationAccordion extends React.Component {
     // if device width is >= 640
     // determine which section is active and activate its toggle
     const { parentPage, navigation } = this.props;
-    if (isMM) {
+    if (isMM && parentPage) {
       navigation.forEach((nav) => {
         if (parentPage.indexOf(nav.path) > -1) {
           this.setToggle(nav.title);

--- a/src/components/navigation-accordion/navigation-accordion.js
+++ b/src/components/navigation-accordion/navigation-accordion.js
@@ -3,9 +3,6 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Icon from '@mapbox/mr-ui/icon';
 import Tag from '../tag/tag';
-// check if client body width is >= 640
-const isMM =
-  typeof document !== 'undefined' ? document.body.clientWidth >= 640 : false;
 
 export default class NavigationAccordion extends React.Component {
   constructor() {
@@ -31,6 +28,11 @@ export default class NavigationAccordion extends React.Component {
   };
 
   componentDidMount() {
+    // check if client body width is >= 640
+    const isMM =
+      typeof document !== 'undefined'
+        ? document.body.clientWidth >= 640
+        : false;
     // if device width is >= 640
     // determine which section is active and activate its toggle
     const { parentPage, navigation } = this.props;


### PR DESCRIPTION
This PR fixes an issue in NavigationAccordion, when a page does not have a parentPage then the sidebar will fail. 

- 3249699 - in this commit I prove the failure by adding a test case and mocking the document width. The result is a null snapshot because the component returns errors. Note: needed to move the `isMM` const inside the React component to properly mock the width.
- 7f19b62 - in this commit, I fix the failure by checking that the parentPage exist. The result is a snapshot with NavigationAccordion markup.

Fixes https://github.com/mapbox/dr-ui/issues/478

## How to test

<!-- List steps on how the reviewer can test this change. Make sure the user can test the component properly by creating a test case or adding an example to the catalog site. -->

## QA checklist

<!-- Complete this checklist when adding a new component or package. -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.

## Before merge

- [x] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
