### PR TITLE
[Assembly v1] LevelIndicator

### DIFF
--- a/src/components/card/__tests__/__snapshots__/card.test.js.snap
+++ b/src/components/card/__tests__/__snapshots__/card.test.js.snap
@@ -30,7 +30,7 @@ exports[`card Card with image renders as expected 1`] = `
           className="dr-ui--level-indicator flex flex--center-cross"
         >
           <div
-            className="w6 bg-orange align-middle mr3"
+            className="w6 bg-orange mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -39,7 +39,7 @@ exports[`card Card with image renders as expected 1`] = `
             }
           />
           <div
-            className="w6 bg-orange align-middle mr3"
+            className="w6 bg-orange mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -48,7 +48,7 @@ exports[`card Card with image renders as expected 1`] = `
             }
           />
           <div
-            className="w6 bg-orange-light align-middle mr3"
+            className="w6 bg-orange-light mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -117,7 +117,7 @@ exports[`card Card with no image renders as expected 1`] = `
           className="dr-ui--level-indicator flex flex--center-cross"
         >
           <div
-            className="w6 bg-orange align-middle mr3"
+            className="w6 bg-orange mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -126,7 +126,7 @@ exports[`card Card with no image renders as expected 1`] = `
             }
           />
           <div
-            className="w6 bg-orange align-middle mr3"
+            className="w6 bg-orange mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -135,7 +135,7 @@ exports[`card Card with no image renders as expected 1`] = `
             }
           />
           <div
-            className="w6 bg-orange-light align-middle mr3"
+            className="w6 bg-orange-light mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -217,7 +217,7 @@ exports[`card Card without description renders as expected 1`] = `
           className="dr-ui--level-indicator flex flex--center-cross"
         >
           <div
-            className="w6 bg-orange align-middle mr3"
+            className="w6 bg-orange mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -226,7 +226,7 @@ exports[`card Card without description renders as expected 1`] = `
             }
           />
           <div
-            className="w6 bg-orange align-middle mr3"
+            className="w6 bg-orange mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -235,7 +235,7 @@ exports[`card Card without description renders as expected 1`] = `
             }
           />
           <div
-            className="w6 bg-orange-light align-middle mr3"
+            className="w6 bg-orange-light mr3"
             style={
               Object {
                 "borderRadius": "1px",

--- a/src/components/card/__tests__/__snapshots__/card.test.js.snap
+++ b/src/components/card/__tests__/__snapshots__/card.test.js.snap
@@ -27,10 +27,10 @@ exports[`card Card with image renders as expected 1`] = `
         className="inline-block mr18 txt-s txt-bold"
       >
         <div
-          className="dr-ui--level-indicator flex-parent flex-parent--center-cross"
+          className="dr-ui--level-indicator flex flex--center-cross"
         >
           <div
-            className="inline-block w6 bg-orange align-middle mr3"
+            className="w6 bg-orange align-middle mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -39,7 +39,7 @@ exports[`card Card with image renders as expected 1`] = `
             }
           />
           <div
-            className="inline-block w6 bg-orange align-middle mr3"
+            className="w6 bg-orange align-middle mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -48,7 +48,7 @@ exports[`card Card with image renders as expected 1`] = `
             }
           />
           <div
-            className="inline-block w6 bg-orange-light align-middle mr3"
+            className="w6 bg-orange-light align-middle mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -57,7 +57,7 @@ exports[`card Card with image renders as expected 1`] = `
             }
           />
           <div
-            className="inline-block color-gray ml3"
+            className="color-gray ml3"
           >
             Intermediate
           </div>
@@ -114,10 +114,10 @@ exports[`card Card with no image renders as expected 1`] = `
         className="inline-block mr18 txt-s txt-bold"
       >
         <div
-          className="dr-ui--level-indicator flex-parent flex-parent--center-cross"
+          className="dr-ui--level-indicator flex flex--center-cross"
         >
           <div
-            className="inline-block w6 bg-orange align-middle mr3"
+            className="w6 bg-orange align-middle mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -126,7 +126,7 @@ exports[`card Card with no image renders as expected 1`] = `
             }
           />
           <div
-            className="inline-block w6 bg-orange align-middle mr3"
+            className="w6 bg-orange align-middle mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -135,7 +135,7 @@ exports[`card Card with no image renders as expected 1`] = `
             }
           />
           <div
-            className="inline-block w6 bg-orange-light align-middle mr3"
+            className="w6 bg-orange-light align-middle mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -144,7 +144,7 @@ exports[`card Card with no image renders as expected 1`] = `
             }
           />
           <div
-            className="inline-block color-gray ml3"
+            className="color-gray ml3"
           >
             Intermediate
           </div>
@@ -214,10 +214,10 @@ exports[`card Card without description renders as expected 1`] = `
         className="inline-block mr18 txt-s txt-bold"
       >
         <div
-          className="dr-ui--level-indicator flex-parent flex-parent--center-cross"
+          className="dr-ui--level-indicator flex flex--center-cross"
         >
           <div
-            className="inline-block w6 bg-orange align-middle mr3"
+            className="w6 bg-orange align-middle mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -226,7 +226,7 @@ exports[`card Card without description renders as expected 1`] = `
             }
           />
           <div
-            className="inline-block w6 bg-orange align-middle mr3"
+            className="w6 bg-orange align-middle mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -235,7 +235,7 @@ exports[`card Card without description renders as expected 1`] = `
             }
           />
           <div
-            className="inline-block w6 bg-orange-light align-middle mr3"
+            className="w6 bg-orange-light align-middle mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -244,7 +244,7 @@ exports[`card Card without description renders as expected 1`] = `
             }
           />
           <div
-            className="inline-block color-gray ml3"
+            className="color-gray ml3"
           >
             Intermediate
           </div>

--- a/src/components/card/__tests__/__snapshots__/card.test.js.snap
+++ b/src/components/card/__tests__/__snapshots__/card.test.js.snap
@@ -30,7 +30,7 @@ exports[`card Card with image renders as expected 1`] = `
           className="dr-ui--level-indicator flex flex--center-cross"
         >
           <div
-            className="w6 bg-orange mr3"
+            className="w6 bg-orange flex-child-no-shrink mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -39,7 +39,7 @@ exports[`card Card with image renders as expected 1`] = `
             }
           />
           <div
-            className="w6 bg-orange mr3"
+            className="w6 bg-orange flex-child-no-shrink mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -48,7 +48,7 @@ exports[`card Card with image renders as expected 1`] = `
             }
           />
           <div
-            className="w6 bg-orange-light mr3"
+            className="w6 bg-orange-light flex-child-no-shrink mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -117,7 +117,7 @@ exports[`card Card with no image renders as expected 1`] = `
           className="dr-ui--level-indicator flex flex--center-cross"
         >
           <div
-            className="w6 bg-orange mr3"
+            className="w6 bg-orange flex-child-no-shrink mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -126,7 +126,7 @@ exports[`card Card with no image renders as expected 1`] = `
             }
           />
           <div
-            className="w6 bg-orange mr3"
+            className="w6 bg-orange flex-child-no-shrink mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -135,7 +135,7 @@ exports[`card Card with no image renders as expected 1`] = `
             }
           />
           <div
-            className="w6 bg-orange-light mr3"
+            className="w6 bg-orange-light flex-child-no-shrink mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -217,7 +217,7 @@ exports[`card Card without description renders as expected 1`] = `
           className="dr-ui--level-indicator flex flex--center-cross"
         >
           <div
-            className="w6 bg-orange mr3"
+            className="w6 bg-orange flex-child-no-shrink mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -226,7 +226,7 @@ exports[`card Card without description renders as expected 1`] = `
             }
           />
           <div
-            className="w6 bg-orange mr3"
+            className="w6 bg-orange flex-child-no-shrink mr3"
             style={
               Object {
                 "borderRadius": "1px",
@@ -235,7 +235,7 @@ exports[`card Card without description renders as expected 1`] = `
             }
           />
           <div
-            className="w6 bg-orange-light mr3"
+            className="w6 bg-orange-light flex-child-no-shrink mr3"
             style={
               Object {
                 "borderRadius": "1px",

--- a/src/components/level-indicator/__tests__/__snapshots__/level-indicator.test.js.snap
+++ b/src/components/level-indicator/__tests__/__snapshots__/level-indicator.test.js.snap
@@ -6,7 +6,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
     className="dr-ui--level-indicator flex flex--center-cross"
   >
     <div
-      className="w6 bg-green mr3"
+      className="w6 bg-green flex-child-no-shrink mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -15,7 +15,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
       }
     />
     <div
-      className="w6 bg-green-light mr3"
+      className="w6 bg-green-light flex-child-no-shrink mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -24,7 +24,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
       }
     />
     <div
-      className="w6 bg-green-light mr3"
+      className="w6 bg-green-light flex-child-no-shrink mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -42,7 +42,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
     className="dr-ui--level-indicator flex flex--center-cross"
   >
     <div
-      className="w6 bg-orange mr3"
+      className="w6 bg-orange flex-child-no-shrink mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -51,7 +51,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
       }
     />
     <div
-      className="w6 bg-orange mr3"
+      className="w6 bg-orange flex-child-no-shrink mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -60,7 +60,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
       }
     />
     <div
-      className="w6 bg-orange-light mr3"
+      className="w6 bg-orange-light flex-child-no-shrink mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -78,7 +78,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
     className="dr-ui--level-indicator flex flex--center-cross"
   >
     <div
-      className="w6 bg-red mr3"
+      className="w6 bg-red flex-child-no-shrink mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -87,7 +87,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
       }
     />
     <div
-      className="w6 bg-red mr3"
+      className="w6 bg-red flex-child-no-shrink mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -96,7 +96,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
       }
     />
     <div
-      className="w6 bg-red mr3"
+      className="w6 bg-red flex-child-no-shrink mr3"
       style={
         Object {
           "borderRadius": "1px",

--- a/src/components/level-indicator/__tests__/__snapshots__/level-indicator.test.js.snap
+++ b/src/components/level-indicator/__tests__/__snapshots__/level-indicator.test.js.snap
@@ -6,7 +6,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
     className="dr-ui--level-indicator flex flex--center-cross"
   >
     <div
-      className="w6 bg-green align-middle mr3"
+      className="w6 bg-green mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -15,7 +15,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
       }
     />
     <div
-      className="w6 bg-green-light align-middle mr3"
+      className="w6 bg-green-light mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -24,7 +24,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
       }
     />
     <div
-      className="w6 bg-green-light align-middle mr3"
+      className="w6 bg-green-light mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -42,7 +42,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
     className="dr-ui--level-indicator flex flex--center-cross"
   >
     <div
-      className="w6 bg-orange align-middle mr3"
+      className="w6 bg-orange mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -51,7 +51,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
       }
     />
     <div
-      className="w6 bg-orange align-middle mr3"
+      className="w6 bg-orange mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -60,7 +60,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
       }
     />
     <div
-      className="w6 bg-orange-light align-middle mr3"
+      className="w6 bg-orange-light mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -78,7 +78,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
     className="dr-ui--level-indicator flex flex--center-cross"
   >
     <div
-      className="w6 bg-red align-middle mr3"
+      className="w6 bg-red mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -87,7 +87,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
       }
     />
     <div
-      className="w6 bg-red align-middle mr3"
+      className="w6 bg-red mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -96,7 +96,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
       }
     />
     <div
-      className="w6 bg-red align-middle mr3"
+      className="w6 bg-red mr3"
       style={
         Object {
           "borderRadius": "1px",

--- a/src/components/level-indicator/__tests__/__snapshots__/level-indicator.test.js.snap
+++ b/src/components/level-indicator/__tests__/__snapshots__/level-indicator.test.js.snap
@@ -3,10 +3,10 @@
 exports[`level-indicator Basic renders as expected 1`] = `
 <div>
   <div
-    className="dr-ui--level-indicator flex-parent flex-parent--center-cross"
+    className="dr-ui--level-indicator flex flex--center-cross"
   >
     <div
-      className="inline-block w6 bg-green align-middle mr3"
+      className="w6 bg-green align-middle mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -15,7 +15,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
       }
     />
     <div
-      className="inline-block w6 bg-green-light align-middle mr3"
+      className="w6 bg-green-light align-middle mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -24,7 +24,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
       }
     />
     <div
-      className="inline-block w6 bg-green-light align-middle mr3"
+      className="w6 bg-green-light align-middle mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -33,16 +33,16 @@ exports[`level-indicator Basic renders as expected 1`] = `
       }
     />
     <div
-      className="inline-block color-gray ml3"
+      className="color-gray ml3"
     >
       Beginner
     </div>
   </div>
   <div
-    className="dr-ui--level-indicator flex-parent flex-parent--center-cross"
+    className="dr-ui--level-indicator flex flex--center-cross"
   >
     <div
-      className="inline-block w6 bg-orange align-middle mr3"
+      className="w6 bg-orange align-middle mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -51,7 +51,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
       }
     />
     <div
-      className="inline-block w6 bg-orange align-middle mr3"
+      className="w6 bg-orange align-middle mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -60,7 +60,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
       }
     />
     <div
-      className="inline-block w6 bg-orange-light align-middle mr3"
+      className="w6 bg-orange-light align-middle mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -69,16 +69,16 @@ exports[`level-indicator Basic renders as expected 1`] = `
       }
     />
     <div
-      className="inline-block color-gray ml3"
+      className="color-gray ml3"
     >
       Intermediate
     </div>
   </div>
   <div
-    className="dr-ui--level-indicator flex-parent flex-parent--center-cross"
+    className="dr-ui--level-indicator flex flex--center-cross"
   >
     <div
-      className="inline-block w6 bg-red align-middle mr3"
+      className="w6 bg-red align-middle mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -87,7 +87,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
       }
     />
     <div
-      className="inline-block w6 bg-red align-middle mr3"
+      className="w6 bg-red align-middle mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -96,7 +96,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
       }
     />
     <div
-      className="inline-block w6 bg-red align-middle mr3"
+      className="w6 bg-red align-middle mr3"
       style={
         Object {
           "borderRadius": "1px",
@@ -105,7 +105,7 @@ exports[`level-indicator Basic renders as expected 1`] = `
       }
     />
     <div
-      className="inline-block color-gray ml3"
+      className="color-gray ml3"
     >
       Advanced
     </div>

--- a/src/components/level-indicator/level-indicator.js
+++ b/src/components/level-indicator/level-indicator.js
@@ -34,7 +34,7 @@ class LevelIndicator extends React.PureComponent {
             height: '8px',
             borderRadius: '1px'
           }}
-          className={`w6 bg-${squareColor} mr3`}
+          className={`w6 bg-${squareColor} flex-child-no-shrink mr3`}
         />
       );
     });

--- a/src/components/level-indicator/level-indicator.js
+++ b/src/components/level-indicator/level-indicator.js
@@ -34,7 +34,7 @@ class LevelIndicator extends React.PureComponent {
             height: '8px',
             borderRadius: '1px'
           }}
-          className={`w6 bg-${squareColor} align-middle mr3`}
+          className={`w6 bg-${squareColor} mr3`}
         />
       );
     });

--- a/src/components/level-indicator/level-indicator.js
+++ b/src/components/level-indicator/level-indicator.js
@@ -34,14 +34,14 @@ class LevelIndicator extends React.PureComponent {
             height: '8px',
             borderRadius: '1px'
           }}
-          className={`inline-block w6 bg-${squareColor} align-middle mr3`}
+          className={`w6 bg-${squareColor} align-middle mr3`}
         />
       );
     });
     return (
-      <div className="dr-ui--level-indicator flex-parent flex-parent--center-cross">
+      <div className="dr-ui--level-indicator flex flex--center-cross">
         {levelSquares}
-        <div className="inline-block color-gray ml3">{levelLabel}</div>
+        <div className="color-gray ml3">{levelLabel}</div>
       </div>
     );
   }


### PR DESCRIPTION
This PR merges into #481 and updates LevelIndicator to Assembly v1. This PR also removes unused classes `inline-block` and `align-middle`.


- [x] Run codemod and look out for additional changes and check step 4 in Use codemode list
- [x] Check docs-prose.css for any component-specific classes that should be updated or removed, including changes to the color scale.
- [x] Visually check test cases app for component


## How to test

<!-- List steps on how the reviewer can test this change. Make sure the user can test the component properly by creating a test case or adding an example to the catalog site. -->

## QA checklist

<!-- Complete this checklist when adding a new component or package. -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.

## Before merge

- [ ] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
