### PR TITLE
Fix DownloadButton for GeoJSON

### DIFF
--- a/src/components/download-button/__tests__/download-button-test-cases.js
+++ b/src/components/download-button/__tests__/download-button-test-cases.js
@@ -35,6 +35,14 @@ testCases.zip = {
   }
 };
 
+testCases.geojson = {
+  component: DownloadButton,
+  description: 'DownloadButton for GeoJSON',
+  props: {
+    href: '../files/sample.geojson'
+  }
+};
+
 testCases.prose = {
   description: 'DownloadButton with prose class',
   element: (

--- a/src/components/download-button/download-button.js
+++ b/src/components/download-button/download-button.js
@@ -6,8 +6,12 @@ import PropTypes from 'prop-types';
 export default class DownloadButton extends React.PureComponent {
   render() {
     const { href, text } = this.props;
-    const fileType = href.split('.').pop().toUpperCase();
+    let fileType = href.split('.').pop().toUpperCase();
     const fileName = href.split('/').pop();
+
+    if (fileType === 'GEOJSON') {
+      fileType = 'GeoJSON';
+    }
 
     return (
       <Button

--- a/src/test-cases-app/files/sample.geojson
+++ b/src/test-cases-app/files/sample.geojson
@@ -1,0 +1,22 @@
+{
+  "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {},
+        "geometry": {
+          "type": "LineString",
+          "coordinates": [
+            [
+              -80.85937499999999,
+              18.312810846425442
+            ],
+            [
+              25.6640625,
+              43.83452678223682
+            ]
+          ]
+        }
+      }
+    ]
+}


### PR DESCRIPTION
Fixes text for GeoJSON download buttons so they appear as "GeoJSON" rather than "GEOJSON". Adds a test case and sample file. 

## How to test

- Run test cases app and confirm GeoJSON appears as expected 
- Make sure download functionality for GeoJSON works 

## Before merge

- [ ] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
