### PR TITLE
[Assembly v1] CodeSnippetTitle

### DIFF
--- a/src/components/android-layout-code-block/__tests__/__snapshots__/android-layout-code-block.test.js.snap
+++ b/src/components/android-layout-code-block/__tests__/__snapshots__/android-layout-code-block.test.js.snap
@@ -673,11 +673,9 @@ exports[`android-layout-code-block With link to GitHub file renders as expected 
   className="my24"
 >
   <div
-    className="flex-parent-mm flex-parent--space-between-main-mm mb6"
+    className="flex-mm flex--space-between-main-mm mb6"
   >
-    <div
-      className="flex-child"
-    >
+    <div>
       <div
         className="inline-block txt-bold mb6 color-gray-dark"
       >

--- a/src/components/code-snippet-title/__tests__/__snapshots__/code-snippet-title.test.js.snap
+++ b/src/components/code-snippet-title/__tests__/__snapshots__/code-snippet-title.test.js.snap
@@ -2,11 +2,9 @@
 
 exports[`code-snippet-title Basic renders as expected 1`] = `
 <div
-  className="flex-parent-mm flex-parent--space-between-main-mm mb6"
+  className="flex-mm flex--space-between-main-mm mb6"
 >
-  <div
-    className="flex-child"
-  >
+  <div>
     <div
       className="inline-block txt-bold mb6 color-gray-dark"
     >
@@ -45,11 +43,9 @@ exports[`code-snippet-title Basic renders as expected 1`] = `
 
 exports[`code-snippet-title With a toggle renders as expected 1`] = `
 <div
-  className="flex-parent-mm flex-parent--space-between-main-mm mb6"
+  className="flex-mm flex--space-between-main-mm mb6"
 >
-  <div
-    className="flex-child"
-  >
+  <div>
     <div
       className="inline-block txt-bold mb6 color-gray-dark"
     >
@@ -83,9 +79,7 @@ exports[`code-snippet-title With a toggle renders as expected 1`] = `
       </a>
     </div>
   </div>
-  <div
-    className="flex-child"
-  >
+  <div>
     <div
       className="relative "
     >

--- a/src/components/code-snippet-title/code-snippet-title.js
+++ b/src/components/code-snippet-title/code-snippet-title.js
@@ -28,12 +28,12 @@ export default class CodeSnippetTitle extends React.PureComponent {
   render() {
     const { link, toggle } = this.props;
     return (
-      <div className="flex-parent-mm flex-parent--space-between-main-mm mb6">
-        <div className="flex-child">
+      <div className="flex-mm flex--space-between-main-mm mb6">
+        <div>
           {this.renderFilename()}
           {link && this.renderLink()}
         </div>
-        {toggle && <div className="flex-child">{toggle}</div>}
+        {toggle && <div>{toggle}</div>}
       </div>
     );
   }

--- a/src/components/code-snippet/__tests__/__snapshots__/code-snippet.test.js.snap
+++ b/src/components/code-snippet/__tests__/__snapshots__/code-snippet.test.js.snap
@@ -5,11 +5,9 @@ exports[`CodeSnippet A CodeSnippet with every feature (edit buttons, title) rend
   data-swiftype-index="false"
 >
   <div
-    className="flex-parent-mm flex-parent--space-between-main-mm mb6"
+    className="flex-mm flex--space-between-main-mm mb6"
   >
-    <div
-      className="flex-child"
-    >
+    <div>
       <div
         className="inline-block txt-bold mb6 color-gray-dark"
       >
@@ -210,11 +208,9 @@ exports[`CodeSnippet CodeSnippet with edit buttons and extractor renders as expe
   data-swiftype-index="false"
 >
   <div
-    className="flex-parent-mm flex-parent--space-between-main-mm mb6"
+    className="flex-mm flex--space-between-main-mm mb6"
   >
-    <div
-      className="flex-child"
-    >
+    <div>
       <div
         className="inline-block txt-bold mb6 color-gray-dark"
       >
@@ -954,11 +950,9 @@ exports[`CodeSnippet CodeSnippet with edit buttons with maxHeight. renders as ex
   data-swiftype-index="false"
 >
   <div
-    className="flex-parent-mm flex-parent--space-between-main-mm mb6"
+    className="flex-mm flex--space-between-main-mm mb6"
   >
-    <div
-      className="flex-child"
-    >
+    <div>
       <div
         className="inline-block txt-bold mb6 color-gray-dark"
       >
@@ -1073,7 +1067,7 @@ See the example: https://docs.mapbox.com//mapbox-gl-js/example/simple-map/"
       </form>
     </div>
     <div
-      className="relative round z0 scroll-styled overflow-auto"
+      className="relative round z0 scroll-styled scroll-auto"
       style={
         Object {
           "maxHeight": 150,
@@ -2100,11 +2094,9 @@ exports[`CodeSnippet CodeSnippet without edit buttons renders as expected 1`] = 
   data-swiftype-index="false"
 >
   <div
-    className="flex-parent-mm flex-parent--space-between-main-mm mb6"
+    className="flex-mm flex--space-between-main-mm mb6"
   >
-    <div
-      className="flex-child"
-    >
+    <div>
       <div
         className="inline-block txt-bold mb6 color-gray-dark"
       >

--- a/src/components/contextless-android-activity-toggle/__tests__/__snapshots__/contextless-android-activity-toggle.test.js.snap
+++ b/src/components/contextless-android-activity-toggle/__tests__/__snapshots__/contextless-android-activity-toggle.test.js.snap
@@ -9,7 +9,7 @@ exports[`contextless-android-activity-toggle Basic renders as expected 1`] = `
   >
     
     <div
-      className="relative round z0 scroll-styled overflow-auto"
+      className="relative round z0 scroll-styled scroll-auto"
       style={
         Object {
           "maxHeight": 480,
@@ -286,7 +286,7 @@ exports[`contextless-android-activity-toggle Kotlin only renders as expected 1`]
   >
     
     <div
-      className="relative round z0 scroll-styled overflow-auto"
+      className="relative round z0 scroll-styled scroll-auto"
       style={
         Object {
           "maxHeight": 480,
@@ -408,18 +408,14 @@ exports[`contextless-android-activity-toggle Two languages (code toggle not inte
     className="my24"
   >
     <div
-      className="flex-parent-mm flex-parent--space-between-main-mm mb6"
+      className="flex-mm flex--space-between-main-mm mb6"
     >
-      <div
-        className="flex-child"
-      >
+      <div>
         <div
           className="inline-block txt-bold mb6 color-gray-dark"
         />
       </div>
-      <div
-        className="flex-child"
-      >
+      <div>
         <div
           className="relative "
         >
@@ -474,7 +470,7 @@ exports[`contextless-android-activity-toggle Two languages (code toggle not inte
       </div>
     </div>
     <div
-      className="relative round z0 scroll-styled overflow-auto"
+      className="relative round z0 scroll-styled scroll-auto"
       style={
         Object {
           "maxHeight": 480,

--- a/src/components/contextless-ios-view-controller-toggle/__tests__/__snapshots__/contextless-ios-view-controller-toggle.test.js.snap
+++ b/src/components/contextless-ios-view-controller-toggle/__tests__/__snapshots__/contextless-ios-view-controller-toggle.test.js.snap
@@ -9,7 +9,7 @@ exports[`contextless-ios-view-controller-toggle Basic renders as expected 1`] = 
   >
     
     <div
-      className="relative round z0 scroll-styled overflow-auto"
+      className="relative round z0 scroll-styled scroll-auto"
       style={
         Object {
           "maxHeight": 480,
@@ -131,18 +131,14 @@ exports[`contextless-ios-view-controller-toggle Two languages (code toggle is no
     className="my24"
   >
     <div
-      className="flex-parent-mm flex-parent--space-between-main-mm mb6"
+      className="flex-mm flex--space-between-main-mm mb6"
     >
-      <div
-        className="flex-child"
-      >
+      <div>
         <div
           className="inline-block txt-bold mb6 color-gray-dark"
         />
       </div>
-      <div
-        className="flex-child"
-      >
+      <div>
         <div
           className="relative "
         >
@@ -197,7 +193,7 @@ exports[`contextless-ios-view-controller-toggle Two languages (code toggle is no
       </div>
     </div>
     <div
-      className="relative round z0 scroll-styled overflow-auto"
+      className="relative round z0 scroll-styled scroll-auto"
       style={
         Object {
           "maxHeight": 480,

--- a/src/components/download-button/__tests__/__snapshots__/download-button.test.js.snap
+++ b/src/components/download-button/__tests__/__snapshots__/download-button.test.js.snap
@@ -7,10 +7,10 @@ exports[`DownloadButton Default DownloadButton renders as expected 1`] = `
   href="../files/airports.csv"
 >
   <span
-    className="flex flex--center-cross"
+    className="flex-parent flex-parent--center-cross"
   >
     <span
-      className="mr6"
+      className="flex-child mr3"
     >
       <svg
         className="events-none icon"
@@ -29,7 +29,9 @@ exports[`DownloadButton Default DownloadButton renders as expected 1`] = `
         />
       </svg>
     </span>
-    <span>
+    <span
+      className="flex-child"
+    >
       Download CSV
     </span>
   </span>
@@ -43,10 +45,10 @@ exports[`DownloadButton DownloadButton for PNG renders as expected 1`] = `
   href="../files/shop-15.png"
 >
   <span
-    className="flex flex--center-cross"
+    className="flex-parent flex-parent--center-cross"
   >
     <span
-      className="mr6"
+      className="flex-child mr3"
     >
       <svg
         className="events-none icon"
@@ -65,7 +67,9 @@ exports[`DownloadButton DownloadButton for PNG renders as expected 1`] = `
         />
       </svg>
     </span>
-    <span>
+    <span
+      className="flex-child"
+    >
       Download PNG
     </span>
   </span>
@@ -79,10 +83,10 @@ exports[`DownloadButton DownloadButton with optional text renders as expected 1`
   href="../files/test-gzip.csv.gz"
 >
   <span
-    className="flex flex--center-cross"
+    className="flex-parent flex-parent--center-cross"
   >
     <span
-      className="mr6"
+      className="flex-child mr3"
     >
       <svg
         className="events-none icon"
@@ -101,7 +105,9 @@ exports[`DownloadButton DownloadButton with optional text renders as expected 1`
         />
       </svg>
     </span>
-    <span>
+    <span
+      className="flex-child"
+    >
       Download for iOS
     </span>
   </span>
@@ -118,10 +124,10 @@ exports[`DownloadButton DownloadButton with prose class renders as expected 1`] 
     href="../files/shop-15.png"
   >
     <span
-      className="flex flex--center-cross"
+      className="flex-parent flex-parent--center-cross"
     >
       <span
-        className="mr6"
+        className="flex-child mr3"
       >
         <svg
           className="events-none icon"
@@ -140,7 +146,9 @@ exports[`DownloadButton DownloadButton with prose class renders as expected 1`] 
           />
         </svg>
       </span>
-      <span>
+      <span
+        className="flex-child"
+      >
         Download PNG
       </span>
     </span>

--- a/src/components/feedback/__tests__/__snapshots__/category-like.test.js.snap
+++ b/src/components/feedback/__tests__/__snapshots__/category-like.test.js.snap
@@ -198,7 +198,7 @@ exports[`Workflow 2 - I like this page Check UI element state 1`] = `
                   ]
                 }
                 themeCheckbox="mr6 inline-block checkbox--gray checkbox--s-label"
-                themeCheckboxContainer="txt-s block mb6 flex"
+                themeCheckboxContainer="txt-s block mb6 flex-parent"
                 value={Array []}
               >
                 <ControlWrapper
@@ -230,7 +230,7 @@ exports[`Workflow 2 - I like this page Check UI element state 1`] = `
                         id="feedback-category-like"
                       >
                         <label
-                          className="checkbox-container txt-s block mb6 flex"
+                          className="checkbox-container txt-s block mb6 flex-parent"
                           key="I found what I need"
                         >
                           <input
@@ -273,7 +273,7 @@ exports[`Workflow 2 - I like this page Check UI element state 1`] = `
                           I found what I need
                         </label>
                         <label
-                          className="checkbox-container txt-s block mb6 flex"
+                          className="checkbox-container txt-s block mb6 flex-parent"
                           key="The information is accurate"
                         >
                           <input
@@ -316,7 +316,7 @@ exports[`Workflow 2 - I like this page Check UI element state 1`] = `
                           The information is accurate
                         </label>
                         <label
-                          className="checkbox-container txt-s block mb6 flex"
+                          className="checkbox-container txt-s block mb6 flex-parent"
                           key="Easy to understand"
                         >
                           <input
@@ -359,7 +359,7 @@ exports[`Workflow 2 - I like this page Check UI element state 1`] = `
                           The page is easy to understand
                         </label>
                         <label
-                          className="checkbox-container txt-s block mb6 flex"
+                          className="checkbox-container txt-s block mb6 flex-parent"
                           key="Something else"
                         >
                           <input

--- a/src/components/feedback/__tests__/__snapshots__/category-problem.test.js.snap
+++ b/src/components/feedback/__tests__/__snapshots__/category-problem.test.js.snap
@@ -198,7 +198,7 @@ exports[`Workflow 2 - Report a problem Check UI element state 1`] = `
                     ]
                   }
                   themeRadio="mr6 radio--gray radio--s-label inline-block"
-                  themeRadioContainer="txt-s block mb6 flex"
+                  themeRadioContainer="txt-s block mb6 flex-parent"
                   value=""
                 >
                   <ControlWrapper
@@ -216,7 +216,7 @@ exports[`Workflow 2 - Report a problem Check UI element state 1`] = `
                           role="radiogroup"
                         >
                           <label
-                            className="radio-container txt-s block mb6 flex"
+                            className="radio-container txt-s block mb6 flex-parent"
                             key="Something is incorrect or doesn't work"
                           >
                             <input
@@ -233,7 +233,7 @@ exports[`Workflow 2 - Report a problem Check UI element state 1`] = `
                             Something is incorrect or doesn't work
                           </label>
                           <label
-                            className="radio-container txt-s block mb6 flex"
+                            className="radio-container txt-s block mb6 flex-parent"
                             key="I see an error message"
                           >
                             <input
@@ -250,7 +250,7 @@ exports[`Workflow 2 - Report a problem Check UI element state 1`] = `
                             I see an error message
                           </label>
                           <label
-                            className="radio-container txt-s block mb6 flex"
+                            className="radio-container txt-s block mb6 flex-parent"
                             key="Something is missing"
                           >
                             <input
@@ -267,7 +267,7 @@ exports[`Workflow 2 - Report a problem Check UI element state 1`] = `
                             Something is missing
                           </label>
                           <label
-                            className="radio-container txt-s block mb6 flex"
+                            className="radio-container txt-s block mb6 flex-parent"
                             key="Something else"
                           >
                             <input

--- a/src/components/toggleable-code-block/__tests__/__snapshots__/toggleable-code-block.test.js.snap
+++ b/src/components/toggleable-code-block/__tests__/__snapshots__/toggleable-code-block.test.js.snap
@@ -5,11 +5,9 @@ exports[`toggleable-code-block Basic renders as expected 1`] = `
   className="my24"
 >
   <div
-    className="flex-parent-mm flex-parent--space-between-main-mm mb6"
+    className="flex-mm flex--space-between-main-mm mb6"
   >
-    <div
-      className="flex-child"
-    >
+    <div>
       <div
         className="inline-block txt-bold mb6 color-gray-dark"
       >
@@ -43,9 +41,7 @@ exports[`toggleable-code-block Basic renders as expected 1`] = `
         </a>
       </div>
     </div>
-    <div
-      className="flex-child"
-    >
+    <div>
       <div
         className="relative "
       >


### PR DESCRIPTION
This PR merge into https://github.com/mapbox/dr-ui/pull/481 and updates the CodeSnippetTitle component to Assembly v1.

- [x] Run codemod and look out for additional changes
- [x] Check docs-prose.css for any component-specific classes that should be updated or removed, including changes to the color scale.
- [x] Visually check test cases app for component

## How to test

<!-- List steps on how the reviewer can test this change. Make sure the user can test the component properly by creating a test case or adding an example to the catalog site. -->

## QA checklist

<!-- Complete this checklist when adding a new component or package. -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.

## Before merge

- [ ] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
