### PR TITLE
[Assembly v1] CardContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 This release updates to Assembly v1. [#481](https://github.com/mapbox/dr-ui/pull/481)
 
 - 🚨 Replace `customStyles` prop in `Tag` with `customBorder`, `customColor,` and `customBackground`. The new props accept class names.
-- 🚨 `CardContainer` no longer accepts a number for `cardColSize`, choose: `'1/4'` for 4 cards or `'1/3'` for 3 cards per row. The default is `'1/2'` for 2 card per row.
+- 🚨 `CardContainer` no longer accepts a number for `cardColSize`, choose: `'1/4'` for 4 cards or `'1/3'` for 3 cards per row. The default is `'1/2'` for 2 cards per row.
 
 ## 4.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 This release updates to Assembly v1. [#481](https://github.com/mapbox/dr-ui/pull/481)
 
 - 🚨 Replace `customStyles` prop in `Tag` with `customBorder`, `customColor,` and `customBackground`. The new props accept class names.
+- 🚨 `CardContainer` no longer accepts a number for `cardColSize`, choose: `'1/4'` for 4 cards or `'1/3'` for 3 cards per row. The default is `'1/2'` for 2 card per row.
 
 ## 4.2.3
 

--- a/src/components/card-container/__tests__/__snapshots__/card-container.test.js.snap
+++ b/src/components/card-container/__tests__/__snapshots__/card-container.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`card-container Basic renders as expected 1`] = `
-<div>
+<div
+  className="dr-ui--card-container"
+>
   <a
     className="unprose mb18 block color-blue-on-hover"
     href="#category"
@@ -25,7 +27,7 @@ exports[`card-container Basic renders as expected 1`] = `
     className="grid grid--gut36"
   >
     <div
-      className="mb18 col col--12 col--6-ml"
+      className="mb18 col w-full w-1/2-ml"
     >
       <a
         className="dr-ui--card color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
@@ -60,7 +62,7 @@ exports[`card-container Basic renders as expected 1`] = `
       </a>
     </div>
     <div
-      className="mb18 col col--12 col--6-ml"
+      className="mb18 col w-full w-1/2-ml"
     >
       <a
         className="dr-ui--card color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
@@ -99,7 +101,9 @@ exports[`card-container Basic renders as expected 1`] = `
 `;
 
 exports[`card-container Full width renders as expected 1`] = `
-<div>
+<div
+  className="dr-ui--card-container"
+>
   <a
     className="unprose mb18 block color-blue-on-hover"
     href="#another-category"
@@ -169,7 +173,9 @@ exports[`card-container Full width renders as expected 1`] = `
 `;
 
 exports[`card-container Use cardColSize renders as expected 1`] = `
-<div>
+<div
+  className="dr-ui--card-container"
+>
   <a
     className="unprose mb18 block color-blue-on-hover"
     href="#another-category"
@@ -193,7 +199,7 @@ exports[`card-container Use cardColSize renders as expected 1`] = `
     className="grid grid--gut36"
   >
     <div
-      className="mb18 col col--12 col--3-ml"
+      className="mb18 col w-full w-1/4-ml"
     >
       <a
         className="dr-ui--card color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
@@ -228,7 +234,7 @@ exports[`card-container Use cardColSize renders as expected 1`] = `
       </a>
     </div>
     <div
-      className="mb18 col col--12 col--3-ml"
+      className="mb18 col w-full w-1/4-ml"
     >
       <a
         className="dr-ui--card color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
@@ -263,7 +269,7 @@ exports[`card-container Use cardColSize renders as expected 1`] = `
       </a>
     </div>
     <div
-      className="mb18 col col--12 col--3-ml"
+      className="mb18 col w-full w-1/4-ml"
     >
       <a
         className="dr-ui--card color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
@@ -298,7 +304,7 @@ exports[`card-container Use cardColSize renders as expected 1`] = `
       </a>
     </div>
     <div
-      className="mb18 col col--12 col--3-ml"
+      className="mb18 col w-full w-1/4-ml"
     >
       <a
         className="dr-ui--card color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"

--- a/src/components/card-container/card-container.js
+++ b/src/components/card-container/card-container.js
@@ -4,45 +4,40 @@ import classnames from 'classnames';
 
 class CardContainer extends React.PureComponent {
   render() {
-    const { props } = this;
-    let cardClasses = 'mb18 ';
-    if (!props.fullWidthCards) {
-      cardClasses += `col col--12 col--${this.props.cardColSize}-ml`;
-    } else {
-      cardClasses += 'border-b border--darken10';
-    }
-
-    const containerClasses = classnames('', {
-      'grid grid--gut36': !props.fullWidthCards
-    });
-    const renderedCards = props.cards.map((card, index) => {
-      return (
-        <div key={index} className={cardClasses}>
-          {card}
-        </div>
-      );
-    });
+    const { fullWidthCards, cards, title, path, cardColSize } = this.props;
+    const cardClasses = `mb18 ${
+      fullWidthCards
+        ? 'border-b border--darken10'
+        : `col w-full w-${cardColSize}-ml`
+    }`;
+    const renderedCards = cards.map((card, index) => (
+      <div key={index} className={cardClasses}>
+        {card}
+      </div>
+    ));
     return (
-      <div>
-        {props.title && props.path && (
-          <a
-            href={props.path}
-            className="unprose mb18 block color-blue-on-hover"
-          >
-            <h2 className="txt-bold unprose" id={props.path.split('#')[1]}>
-              {props.title}{' '}
-              <span data-swiftype-index="false">({props.cards.length})</span>
+      <div className="dr-ui--card-container">
+        {title && path && (
+          <a href={path} className="unprose mb18 block color-blue-on-hover">
+            <h2 className="txt-bold unprose" id={path.split('#')[1]}>
+              {title} <span data-swiftype-index="false">({cards.length})</span>
             </h2>
           </a>
         )}
-        <div className={containerClasses}>{renderedCards}</div>
+        <div
+          className={classnames({
+            'grid grid--gut36': !fullWidthCards
+          })}
+        >
+          {renderedCards}
+        </div>
       </div>
     );
   }
 }
 
 CardContainer.defaultProps = {
-  cardColSize: 6,
+  cardColSize: '1/2',
   fullWidthCards: false
 };
 
@@ -51,7 +46,7 @@ CardContainer.propTypes = {
   path: PropTypes.string,
   fullWidthCards: PropTypes.bool,
   cards: PropTypes.arrayOf(PropTypes.node).isRequired,
-  cardColSize: PropTypes.oneOf([1, 2, 3, 4, 5, 6])
+  cardColSize: PropTypes.oneOf(['1/4', '1/3', '1/2'])
 };
 
 export default CardContainer;

--- a/src/components/card-container/examples/cols.js
+++ b/src/components/card-container/examples/cols.js
@@ -11,7 +11,7 @@ export default class Example extends React.PureComponent {
       <CardContainer
         title="Another category"
         path="#another-category"
-        cardColSize={3}
+        cardColSize="1/4"
         cards={[
           <Card
             key="0"

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -418,12 +418,14 @@ Array [
             <div
               className="col prose"
             >
-              <div>
+              <div
+                className="dr-ui--card-container"
+              >
                 <div
                   className="grid grid--gut36"
                 >
                   <div
-                    className="mb18 col col--12 col--6-ml"
+                    className="mb18 col w-full w-1/2-ml"
                   >
                     <a
                       className="dr-ui--card color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
@@ -480,7 +482,7 @@ Array [
                     </a>
                   </div>
                   <div
-                    className="mb18 col col--12 col--6-ml"
+                    className="mb18 col w-full w-1/2-ml"
                   >
                     <a
                       className="dr-ui--card color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
@@ -537,7 +539,7 @@ Array [
                     </a>
                   </div>
                   <div
-                    className="mb18 col col--12 col--6-ml"
+                    className="mb18 col w-full w-1/2-ml"
                   >
                     <a
                       className="dr-ui--card color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"

--- a/src/components/page-layout/components/example-index.js
+++ b/src/components/page-layout/components/example-index.js
@@ -402,7 +402,7 @@ ExampleIndex.propTypes = {
     fullWidthCards: PropTypes.bool,
     hideCardDescription: PropTypes.bool,
     hideCardLanguage: PropTypes.bool,
-    cardColSize: PropTypes.number,
+    cardColSize: PropTypes.string,
     showFilters: PropTypes.arrayOf(PropTypes.oneOf(filterOptions))
   }).isRequired,
   AppropriateImage: PropTypes.func

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -207,7 +207,7 @@ PageLayout.propTypes = {
     sidebarTheme: PropTypes.string,
     showCards: PropTypes.bool,
     fullWidthCards: PropTypes.bool,
-    cardColSize: PropTypes.number,
+    cardColSize: PropTypes.string,
     unProse: PropTypes.bool,
     noShellHeaderBuffer: PropTypes.bool,
     hideFromNav: PropTypes.bool,


### PR DESCRIPTION
This PR merges into #481 and updates the CardContainer component to Assembly v1.

- [x] Run codemod and look out for additional changes
- [x] Check docs-prose.css for any component-specific classes that should be updated or removed, including changes to the color scale.
- [x] Visually check test cases app for component

Current | Proposed
---|---
![screencapture-192-168-7-223-9966-CardContainer-2021-09-14-11_26_01](https://user-images.githubusercontent.com/2180540/133286809-44d9576a-63be-416e-ab60-9be3307d4b0a.png) | ![screencapture-192-168-7-223-9966-CardContainer-2021-09-14-11_23_47](https://user-images.githubusercontent.com/2180540/133286387-e7219530-277c-417d-8d94-02215e182fd1.png)


## QA checklist

<!-- Complete this checklist when adding a new component or package. -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.

## Before merge

- [x] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
