### PR TITLE
Handle NavigiationAccordion when there is no `activeItem`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Handle `NavigiationAccordion` when there is no `activeItem`. [#495](https://github.com/mapbox/dr-ui/pull/495)
+
 ## 4.2.3
 
 - Fix casing for `DownloadButton` with GeoJSON filetype. [#484](https://github.com/mapbox/dr-ui/pull/484)

--- a/src/components/navigation-accordion/__tests__/navigation-accordion.test.js
+++ b/src/components/navigation-accordion/__tests__/navigation-accordion.test.js
@@ -23,6 +23,7 @@ describe('navigation-accordion', () => {
       const component = mount(testCase.element);
       // subpages are not visible
       expect(component.find('#menu-guides').exists()).toBeFalsy();
+      // find then click first chevron-down button
       const navLink = component.find('button').first();
       navLink.simulate('click');
       // after click, subpages are visible

--- a/src/components/navigation-accordion/__tests__/navigation-accordion.test.js
+++ b/src/components/navigation-accordion/__tests__/navigation-accordion.test.js
@@ -17,8 +17,17 @@ describe('navigation-accordion', () => {
 
     test('renders as expected', () => {
       expect(tree).toMatchSnapshot();
-      const navLink = mount(testCase.element).find('button').first();
+    });
+
+    test('toggle navigation', () => {
+      const component = mount(testCase.element);
+      // subpages are not visible
+      expect(component.find('#menu-guides').exists()).toBeFalsy();
+      const navLink = component.find('button').first();
       navLink.simulate('click');
+      // after click, subpages are visible
+      component.update();
+      expect(component.find('#menu-guides').exists()).toBeTruthy();
     });
   });
 

--- a/src/components/navigation-accordion/__tests__/navigation-accordion.test.js
+++ b/src/components/navigation-accordion/__tests__/navigation-accordion.test.js
@@ -20,13 +20,15 @@ describe('navigation-accordion', () => {
     });
 
     test('toggle navigation', () => {
+      // mount the test case
       const component = mount(testCase.element);
-      // subpages are not visible
+      // assert that subpages are not visible
       expect(component.find('#menu-guides').exists()).toBeFalsy();
-      // find then click first chevron-down button
+      // find the first button (chevron-down icon)
       const navLink = component.find('button').first();
+      // click the button
       navLink.simulate('click');
-      // after click, subpages are visible
+      // after click, assert that subpages are now visible
       component.update();
       expect(component.find('#menu-guides').exists()).toBeTruthy();
     });

--- a/src/components/navigation-accordion/__tests__/navigation-accordion.test.js
+++ b/src/components/navigation-accordion/__tests__/navigation-accordion.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { testCases } from './navigation-accordion-test-cases.js';
+import { mount } from 'enzyme';
 
 describe('navigation-accordion', () => {
   describe(testCases.basic.description, () => {
@@ -16,6 +17,8 @@ describe('navigation-accordion', () => {
 
     test('renders as expected', () => {
       expect(tree).toMatchSnapshot();
+      const navLink = mount(testCase.element).find('button').first();
+      navLink.simulate('click');
     });
   });
 

--- a/src/components/navigation-accordion/navigation-accordion.js
+++ b/src/components/navigation-accordion/navigation-accordion.js
@@ -140,7 +140,8 @@ export default class NavigationAccordion extends React.Component {
               {page.tag && this.renderTag(page)}
             </a>
           </li>
-          {activeItem.indexOf(page.path) > -1 &&
+          {activeItem &&
+            activeItem.includes(page.path) &&
             page.subPages &&
             this.renderSubPages(page.subPages, activeItem)}
         </React.Fragment>


### PR DESCRIPTION
While working on updating NavigationAccordion to Assembly v1, I noticed that the basic test case was broken. When I click the chevron-down icon, the component failed. This PR:

- Adds a test to prove the bug: df4fb4a (the [Travis build fails](https://app.travis-ci.com/github/mapbox/dr-ui/builds/237641095#L836) with `TypeError: Cannot read property 'indexOf' of undefined`)
- Fixes the bug and adds test to assert the fix: c544e8a


## How to test

1. `nvm use && npm ci && npm start`
2. Visit `/NavigationAccordion` test cases
3. Toggle the chevron-down icons on all examples: you should not see any errors

## QA checklist

<!-- Complete this checklist when adding a new component or package. -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.

## Before merge

- [x] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
