### PR TITLE
Do not preserve es modules in test environment

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -7,8 +7,9 @@ module.exports = {
     'babel-plugin-transform-react-remove-prop-types'
   ],
   env: {
-    // When running `test` Jest will enable compilation from ECMAScript modules to CommonJS automatically
+    // When running `test` and `start` Jest and ReactTestKitchen will enable compilation from ECMAScript modules to CommonJS automatically
     test: {
+      presets: [['@babel/preset-env'], '@babel/preset-react'],
       plugins: ['@babel/plugin-transform-modules-commonjs']
     }
   }


### PR DESCRIPTION
We recently [enabled es modules](https://babeljs.io/docs/en/babel-preset-env#modules) in #457, but https://github.com/mapbox/react-test-kitchen (the system for our test cases) works best with common js. This PR updates the `test` babel environment to not preserve es modules.

I noticed this when trying to interact with the /Search test case and the dynamic import failed to load.

## How to test

1. Run: `nvm use && npm ci && npm start`
2. Visit: /Search test cases
3. Interact with search, there should be no errors logged to the console (re: the dynamic import should load as expected).
