### PR TITLE
adds `height` prop to `demo-iframe` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Handle `NavigiationAccordion` when there is no `activeItem`. [#495](https://github.com/mapbox/dr-ui/pull/495)
+- Added new `height` prop to `DemoIframe` component. [#506](https://github.com/mapbox/dr-ui/pull/506)
 
 ## 4.2.3
 

--- a/src/components/demo-iframe/demo-iframe.js
+++ b/src/components/demo-iframe/demo-iframe.js
@@ -23,7 +23,7 @@ export default class DemoIframe extends React.PureComponent {
 
   render() {
     let { src } = this.props;
-    const { title, gl } = this.props;
+    const { title, gl, height } = this.props;
     const { mapboxAccessToken } = this.state;
     // check to see if the src is making a request to mapbox api
     const makeRequest = src.indexOf('MapboxAccessToken') > -1;
@@ -38,7 +38,7 @@ export default class DemoIframe extends React.PureComponent {
       ? src.replace('MapboxAccessToken', mapboxAccessToken)
       : src;
 
-    const iframeHeight = 400;
+    const iframeHeight = height || 400;
 
     const contents = (
       <div>
@@ -70,6 +70,8 @@ DemoIframe.propTypes = {
   gl: PropTypes.bool,
   /** Replace instance of `MapboxAccessToken` in the `src` prop with the value of this Mapbox access token. */
   MapboxAccessToken: PropTypes.string,
+  /** Height of the iframe in pixels. */
+  height: PropTypes.number,
   /** A title to describe the content of the iframe. */
   title: PropTypes.string.isRequired
 };


### PR DESCRIPTION
Adds a new`height` prop to `demo-iframe` component.

## How to test

- run `npm run start-docs`
- navigate to `http://localhost:8080/dr-ui/components/#demoiframe`
- check that the new height prop is listed in the description

## QA checklist

<!-- Complete this checklist when adding a new component or package. -->

- [ ] No errors logged to console.
- [ ] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [ ] Component is accessible at mobile-size viewport.
- [ ] Component is accessible at tablet-size viewport.
- [ ] Component is accessible at laptop-size viewport.
- [ ] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [ ] Chrome, no errors logged to console.
- [ ] Firefox, no errors logged to console.
- [ ] Safari, no errors logged to console.
- [ ] Edge, no errors logged to console.
- [ ] Mobile Safari, no errors logged to console.
- [ ] Android Chrome, no errors logged to console.

## Before merge

- [x] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
