### PR TITLE
Move I like... category to bottom of list in Feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Handle `NavigiationAccordion` when there is no `activeItem`. [#495](https://github.com/mapbox/dr-ui/pull/495)
-- Move "I like..." category to bottom in `Feedback1 component. [#518](https://github.com/mapbox/dr-ui/pull/518)
+- Move "I like..." category to bottom in `Feedback` component. [#518](https://github.com/mapbox/dr-ui/pull/518)
 
 ## 4.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Handle `NavigiationAccordion` when there is no `activeItem`. [#495](https://github.com/mapbox/dr-ui/pull/495)
+- Move "I like..." category to bottom in `Feedback1 component. [#518](https://github.com/mapbox/dr-ui/pull/518)
 
 ## 4.2.3
 

--- a/src/components/feedback/__tests__/__snapshots__/contact-support.test.js.snap
+++ b/src/components/feedback/__tests__/__snapshots__/contact-support.test.js.snap
@@ -143,14 +143,6 @@ exports[`Workflow 2 - Contact support Click button, then set state 1`] = `
           >
             <button
               className="btn w-full mb6"
-              key="I like this page"
-              onClick={[Function]}
-              value="I like this page"
-            >
-              I like this page
-            </button>
-            <button
-              className="btn w-full mb6"
               key="Report a problem"
               onClick={[Function]}
               value="Report a problem"
@@ -164,6 +156,14 @@ exports[`Workflow 2 - Contact support Click button, then set state 1`] = `
               value="Something is confusing"
             >
               Something is confusing
+            </button>
+            <button
+              className="btn w-full mb6"
+              key="I like this page"
+              onClick={[Function]}
+              value="I like this page"
+            >
+              I like this page
             </button>
           </div>
           <div

--- a/src/components/feedback/categories.js
+++ b/src/components/feedback/categories.js
@@ -14,29 +14,6 @@ import CategoryConfusing from './components/category-confusing.js';
 export function categories({ type, submitFeedback }) {
   const genericType = returnGenericType(type);
   return {
-    [`I like this ${genericType}`]: {
-      helpful: true,
-      children: (
-        <CategoryLike
-          leadText={`Tell us what you like about this ${type}.`}
-          placeholder="What did you like?"
-          // NOTE: changing the `value` will affect reporting in Mode and Sentry
-          options={[
-            { label: 'I found what I need', value: 'I found what I need' },
-            {
-              label: 'The information is accurate',
-              value: 'The information is accurate'
-            },
-            {
-              label: `The ${genericType} is easy to understand`,
-              value: 'Easy to understand'
-            },
-            { label: 'Something else', value: 'Something else' }
-          ]}
-          submitFeedback={submitFeedback}
-        />
-      )
-    },
     'Report a problem': {
       helpful: false,
       children: (
@@ -73,6 +50,29 @@ export function categories({ type, submitFeedback }) {
         <CategoryConfusing
           option={`What about this ${type} is confusing? How can we improve the content?`}
           placeholder="Let us know what is confusing."
+          submitFeedback={submitFeedback}
+        />
+      )
+    },
+    [`I like this ${genericType}`]: {
+      helpful: true,
+      children: (
+        <CategoryLike
+          leadText={`Tell us what you like about this ${type}.`}
+          placeholder="What did you like?"
+          // NOTE: changing the `value` will affect reporting in Mode and Sentry
+          options={[
+            { label: 'I found what I need', value: 'I found what I need' },
+            {
+              label: 'The information is accurate',
+              value: 'The information is accurate'
+            },
+            {
+              label: `The ${genericType} is easy to understand`,
+              value: 'Easy to understand'
+            },
+            { label: 'Something else', value: 'Something else' }
+          ]}
           submitFeedback={submitFeedback}
         />
       )


### PR DESCRIPTION
This PR moves the "I like..." category in `Feedback` to the button of the list.

Fixes https://github.com/mapbox/dr-ui/issues/515

## How to test

1. `nvm use && npm ci && npm start`
2. Visit /Feedback test case
3. Click "Share feedback", the "I like.." button should be the last button option.
4. Test to make sure feedback is sent as expected: submit feedback, check payload in #bots Slack channel and that an issue is opened in Sentry.

## QA checklist

<!-- Complete this checklist when adding a new component or package. -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.

## Before merge

- [x] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
