### PR TITLE
Updates `GuideGroupIndex` in `PageLayout` to use `CardContainer` to display full width cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Handle `NavigiationAccordion` when there is no `activeItem`. [#495](https://github.com/mapbox/dr-ui/pull/495)
+- Updates `GuideGroupIndex` in `PageLayout` to use `CardContainer` to display full width cards. [#519](https://github.com/mapbox/dr-ui/pull/519)
 
 ## 4.2.3
 

--- a/src/components/navigation-accordion/navigation-accordion.js
+++ b/src/components/navigation-accordion/navigation-accordion.js
@@ -123,28 +123,27 @@ export default class NavigationAccordion extends React.Component {
     const subItemEls = subItems
       .filter((page) => !page.groupOrder || page.groupOrder === undefined)
       .map((page) => (
-        <React.Fragment key={page.title}>
-          <li
-            // Required on parents containing tags to prevent unwanted scrollbars on IE
-            className={classnames('mb3', {
-              'scroll-hidden': page.tag
+        <li
+          key={page.title}
+          // Required on parents containing tags to prevent unwanted scrollbars on IE
+          className={classnames('mb3', {
+            'scroll-hidden': page.tag
+          })}
+        >
+          <a
+            className={classnames('inline-block w-full color-blue-on-hover', {
+              'color-blue': activeItem === page.path
             })}
+            href={page.path}
           >
-            <a
-              className={classnames('inline-block w-full color-blue-on-hover', {
-                'color-blue': activeItem === page.path
-              })}
-              href={page.path}
-            >
-              {page.title}
-              {page.tag && this.renderTag(page)}
-            </a>
-          </li>
+            {page.title}
+            {page.tag && this.renderTag(page)}
+          </a>
           {activeItem &&
             activeItem.includes(page.path) &&
             page.subPages &&
             this.renderSubPages(page.subPages, activeItem)}
-        </React.Fragment>
+        </li>
       ));
 
     return (

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -2189,58 +2189,79 @@ Array [
             <div
               className="col col--8-mxl col--12 prose"
             >
-              <div
-                className="flex-parent-ml flex-parent--start-cross mb12 border-b border--gray-light pb12"
-              >
+              <div>
                 <div
-                  className="flex-child-ml flex-child--no-shrink txt-bold w240 my0-ml mt18 mb12"
+                  className=""
                 >
-                  <a
-                    href="/PageLayout/guides/worldview/avilable-worldviews/"
+                  <div
+                    className="mb18 border-b border--darken10"
                   >
-                    Available worldviews
-                  </a>
-                </div>
-                <div
-                  className="flex-child-ml flex-child--grow"
-                >
-                  Identify geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups.
-                </div>
-              </div>
-              <div
-                className="flex-parent-ml flex-parent--start-cross mb12 border-b border--gray-light pb12"
-              >
-                <div
-                  className="flex-child-ml flex-child--no-shrink txt-bold w240 my0-ml mt18 mb12"
-                >
-                  <a
-                    href="/PageLayout/guides/worldview/border-styling/"
+                    <a
+                      className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
+                      href="/PageLayout/guides/worldview/avilable-worldviews/"
+                    >
+                      
+                      <div>
+                        
+                        <div
+                          className="mb6"
+                        >
+                          Available worldviews
+                        </div>
+                        <div
+                          className="color-gray color-gray-on-hover"
+                        >
+                          Identify geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups.
+                        </div>
+                      </div>
+                    </a>
+                  </div>
+                  <div
+                    className="mb18 border-b border--darken10"
                   >
-                    Border styling
-                  </a>
-                </div>
-                <div
-                  className="flex-child-ml flex-child--grow"
-                >
-                  When creating a map style with a tileset that uses worldviews, you must apply a filter to any layers that include a worldview data field.
-                </div>
-              </div>
-              <div
-                className="flex-parent-ml flex-parent--start-cross mb12"
-              >
-                <div
-                  className="flex-child-ml flex-child--no-shrink txt-bold w240 my0-ml mt18 mb12"
-                >
-                  <a
-                    href="/PageLayout/guides/worldview/data-sources/"
+                    <a
+                      className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
+                      href="/PageLayout/guides/worldview/border-styling/"
+                    >
+                      
+                      <div>
+                        
+                        <div
+                          className="mb6"
+                        >
+                          Border styling
+                        </div>
+                        <div
+                          className="color-gray color-gray-on-hover"
+                        >
+                          When creating a map style with a tileset that uses worldviews, you must apply a filter to any layers that include a worldview data field.
+                        </div>
+                      </div>
+                    </a>
+                  </div>
+                  <div
+                    className="mb18 border-b border--darken10"
                   >
-                    Data sources
-                  </a>
-                </div>
-                <div
-                  className="flex-child-ml flex-child--grow"
-                >
-                  Some Mapbox vector tilesets, including Mapbox Streets v8 and Boundaries v3, include the worldview data field in several layers.
+                    <a
+                      className="color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
+                      href="/PageLayout/guides/worldview/data-sources/"
+                    >
+                      
+                      <div>
+                        
+                        <div
+                          className="mb6"
+                        >
+                          Data sources
+                        </div>
+                        <div
+                          className="color-gray color-gray-on-hover"
+                        >
+                          Some Mapbox vector tilesets, including Mapbox Streets v8 and Boundaries v3, include the worldview data field in several layers.
+                        </div>
+                      </div>
+                    </a>
+                  </div>
                 </div>
               </div>
               <div

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -1831,6 +1831,478 @@ Array [
 ]
 `;
 
+exports[`page-layout Page layout: group index renders as expected 1`] = `
+Array [
+  <div
+    className="shell-header-buffer"
+  />,
+  <div
+    className="limiter limiter--wide"
+  >
+    <div
+      className="flex-parent-mm"
+    >
+      <div
+        className="flex-child flex-child--no-shrink w-full w180-mm w240-ml mr36-mm "
+        style={
+          Object {
+            "width": "100%",
+          }
+        }
+      >
+        <div
+          className="sticky-mm scroll-auto-mm scroll-styled viewport-almost-mm px12-mm"
+          data-swiftype-index="false"
+          id="dr-ui--page-layout-sidebar"
+          style={
+            Object {
+              "top": "10px",
+            }
+          }
+        >
+          <div
+            className="mb6 border-b border--darken10"
+          >
+            <div
+              className="mb6"
+            >
+              <div
+                className="dr-ui--product-menu"
+              >
+                <a
+                  className="txt-fancy txt-l block color-blue-on-hover"
+                  href="/dr-ui/"
+                >
+                  dr-ui
+                </a>
+              </div>
+            </div>
+            <div
+              className="mb6 h36"
+            >
+              <div
+                className="relative h36"
+              >
+                <button
+                  className="w-full block"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="flex-parent flex-parent--center-cross btn--gray color-gray-light btn btn--stroke py3 pl6 pr12 round mb6 w-full"
+                    style={Object {}}
+                  >
+                    <span
+                      className="mr6 color-gray"
+                    >
+                      <svg
+                        className="icon w18 h18"
+                      >
+                        <use
+                          xlinkHref="#icon-search"
+                        />
+                      </svg>
+                    </span>
+                     
+                    <span
+                      className="color-gray"
+                    >
+                      Search
+                    </span>
+                  </div>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            className=""
+          >
+            <nav
+              className="mx-neg12"
+            >
+              <ul>
+                <li>
+                  <div
+                    className="px12 flex-parent txt-uppercase txt-fancy round-full w-full color-darken75 bg-blue-faint color-blue flex-parent flex-parent--space-between-main"
+                  >
+                    <a
+                      className="flex-child flex-child--grow  color-blue-on-hover py6 py3-mm"
+                      href="/PageLayout/guides/"
+                      style={
+                        Object {
+                          "letterSpacing": "0.025em",
+                        }
+                      }
+                    >
+                      Guides
+                    </a>
+                    <button
+                      aria-controls="menu-guides"
+                      aria-expanded={false}
+                      aria-label="Toggle Guides menu"
+                      className="flex-child flex-child--no-shrink color-blue-on-hover px12 px0-mm"
+                      onClick={[Function]}
+                      value="Guides"
+                    >
+                      <svg
+                        className="events-none icon inline-block align-t"
+                        focusable="false"
+                        role="presentation"
+                        style={
+                          Object {
+                            "height": 18,
+                            "width": 18,
+                          }
+                        }
+                      >
+                        <use
+                          xlinkHref="#icon-chevron-down"
+                          xmlnsXlink="http://www.w3.org/1999/xlink"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </li>
+                <li>
+                  <div
+                    className="px12 flex-parent txt-uppercase txt-fancy round-full w-full color-darken75"
+                  >
+                    <a
+                      className="flex-child flex-child--grow  color-blue-on-hover py6 py3-mm"
+                      href="/PageLayout/specification/"
+                      style={
+                        Object {
+                          "letterSpacing": "0.025em",
+                        }
+                      }
+                    >
+                      Specification
+                    </a>
+                  </div>
+                </li>
+                <li>
+                  <div
+                    className="px12 flex-parent txt-uppercase txt-fancy round-full w-full color-darken75"
+                  >
+                    <a
+                      className="flex-child flex-child--grow  color-blue-on-hover py6 py3-mm"
+                      href="/PageLayout/examples/"
+                      style={
+                        Object {
+                          "letterSpacing": "0.025em",
+                        }
+                      }
+                    >
+                      Examples
+                    </a>
+                  </div>
+                </li>
+                <li>
+                  <div
+                    className="px12 flex-parent txt-uppercase txt-fancy round-full w-full color-darken75"
+                  >
+                    <a
+                      className="flex-child flex-child--grow  color-blue-on-hover py6 py3-mm"
+                      href="/PageLayout/demo/"
+                      style={
+                        Object {
+                          "letterSpacing": "0.025em",
+                        }
+                      }
+                    >
+                      Demo
+                    </a>
+                  </div>
+                </li>
+              </ul>
+            </nav>
+          </div>
+        </div>
+      </div>
+      <div
+        className="flex-child flex-child--grow"
+        style={
+          Object {
+            "width": "100%",
+          }
+        }
+      >
+        <div
+          className="dr-ui--breadcrumb pt3 pb12 none block-mm"
+          data-swiftype-index="false"
+        >
+          <span
+            className="none inline-block-mm"
+          >
+            <a
+              className="link"
+              href="https://docs.mapbox.com"
+            >
+              All docs
+            </a>
+            <span
+              className="color-gray-light inline-block-mm none px6"
+            >
+              <svg
+                className="events-none icon inline-block align-t"
+                focusable="false"
+                role="presentation"
+                style={
+                  Object {
+                    "height": 18,
+                    "width": 18,
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#icon-chevron-right"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className="none inline-block-mm"
+          >
+            <a
+              className="link"
+              href="/dr-ui/"
+            >
+              dr-ui
+            </a>
+            <span
+              className="color-gray-light inline-block-mm none px6"
+            >
+              <svg
+                className="events-none icon inline-block align-t"
+                focusable="false"
+                role="presentation"
+                style={
+                  Object {
+                    "height": 18,
+                    "width": 18,
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#icon-chevron-right"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className=""
+          >
+            <span
+              className="color-gray-light inline-block none-mm pr6"
+            >
+              <svg
+                className="events-none icon inline-block align-t"
+                focusable="false"
+                role="presentation"
+                style={
+                  Object {
+                    "height": 18,
+                    "width": 18,
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#icon-arrow-left"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                />
+              </svg>
+            </span>
+            <a
+              className="link"
+              href="/PageLayout/guides/"
+            >
+              Guides
+            </a>
+            <span
+              className="color-gray-light inline-block-mm none px6"
+            >
+              <svg
+                className="events-none icon inline-block align-t"
+                focusable="false"
+                role="presentation"
+                style={
+                  Object {
+                    "height": 18,
+                    "width": 18,
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#icon-chevron-right"
+                  xmlnsXlink="http://www.w3.org/1999/xlink"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className="color-gray none inline-block-mm"
+          >
+            Worldview
+          </span>
+        </div>
+        <div
+          id="docs-content"
+        >
+          <div
+            className="col prose col--8-mxl col--12"
+          >
+            <h1
+              className="txt-fancy"
+            >
+              Worldview
+            </h1>
+          </div>
+          <div
+            className="grid grid--gut60"
+          >
+            <div
+              className="dr-ui--page-layout-aside col col--12 col--4-mxl"
+            >
+              <aside
+                className="scroll-auto-mxl scroll-styled viewport-almost-mxl sticky-mxl"
+                data-swiftype-index="false"
+                style={
+                  Object {
+                    "top": "10px",
+                  }
+                }
+              >
+                <div
+                  className="none block-mxl"
+                >
+                  <button
+                    className="btn"
+                    onClick={[Function]}
+                    value="Share"
+                  >
+                    Share your feedback
+                  </button>
+                </div>
+              </aside>
+            </div>
+            <div
+              className="col col--8-mxl col--12 prose"
+            >
+              <div
+                className="flex-parent-ml flex-parent--start-cross mb12 border-b border--gray-light pb12"
+              >
+                <div
+                  className="flex-child-ml flex-child--no-shrink txt-bold w240 my0-ml mt18 mb12"
+                >
+                  <a
+                    href="/PageLayout/guides/worldview/avilable-worldviews/"
+                  >
+                    Available worldviews
+                  </a>
+                </div>
+                <div
+                  className="flex-child-ml flex-child--grow"
+                >
+                  Identify geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups.
+                </div>
+              </div>
+              <div
+                className="flex-parent-ml flex-parent--start-cross mb12 border-b border--gray-light pb12"
+              >
+                <div
+                  className="flex-child-ml flex-child--no-shrink txt-bold w240 my0-ml mt18 mb12"
+                >
+                  <a
+                    href="/PageLayout/guides/worldview/border-styling/"
+                  >
+                    Border styling
+                  </a>
+                </div>
+                <div
+                  className="flex-child-ml flex-child--grow"
+                >
+                  When creating a map style with a tileset that uses worldviews, you must apply a filter to any layers that include a worldview data field.
+                </div>
+              </div>
+              <div
+                className="flex-parent-ml flex-parent--start-cross mb12"
+              >
+                <div
+                  className="flex-child-ml flex-child--no-shrink txt-bold w240 my0-ml mt18 mb12"
+                >
+                  <a
+                    href="/PageLayout/guides/worldview/data-sources/"
+                  >
+                    Data sources
+                  </a>
+                </div>
+                <div
+                  className="flex-child-ml flex-child--grow"
+                >
+                  Some Mapbox vector tilesets, including Mapbox Streets v8 and Boundaries v3, include the worldview data field in several layers.
+                </div>
+              </div>
+              <div
+                className="my36 block none-mxl"
+              >
+                <button
+                  className="btn"
+                  onClick={[Function]}
+                  value="Share"
+                >
+                  Share your feedback
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="fixed block none-mm mx24 my24 z5 bottom right"
+  >
+    <div
+      className="block mx24 my24 z5"
+    >
+      <div
+        className="inline-block"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+      >
+        <button
+          aria-label="Back to top"
+          className="btn--blue w60 h60 px0 round-full shadow-darken25 color-white flex-parent flex-parent--center-main flex-parent--center-cross"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            className="events-none icon"
+            focusable="false"
+            role="presentation"
+            style={
+              Object {
+                "height": 30,
+                "width": 30,
+              }
+            }
+          >
+            <use
+              xlinkHref="#icon-arrow-up"
+              xmlnsXlink="http://www.w3.org/1999/xlink"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
 exports[`page-layout full layout renders as expected 1`] = `
 Array [
   <div

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -1937,7 +1937,7 @@ Array [
                     </a>
                     <button
                       aria-controls="menu-guides"
-                      aria-expanded={false}
+                      aria-expanded={true}
                       aria-label="Toggle Guides menu"
                       className="flex-child flex-child--no-shrink color-blue-on-hover px12 px0-mm"
                       onClick={[Function]}
@@ -1955,12 +1955,75 @@ Array [
                         }
                       >
                         <use
-                          xlinkHref="#icon-chevron-down"
+                          xlinkHref="#icon-chevron-up"
                           xmlnsXlink="http://www.w3.org/1999/xlink"
                         />
                       </svg>
                     </button>
                   </div>
+                  <ul
+                    className="mb12 ml12"
+                    id="menu-guides"
+                  >
+                    <li
+                      className="mb3"
+                    >
+                      <a
+                        className="inline-block w-full color-blue-on-hover"
+                        href="/PageLayout/guides/annotations/"
+                      >
+                        Annotations
+                      </a>
+                    </li>
+                    <li
+                      className="mb3"
+                    >
+                      <a
+                        className="inline-block w-full color-blue-on-hover color-blue"
+                        href="/PageLayout/guides/worldview/"
+                      >
+                        Worldview
+                      </a>
+                    </li>
+                    <ul
+                      className="mb6 ml3"
+                    >
+                      <li>
+                        <a
+                          className="pl12 inline-block w-full color-blue-on-hover border-l border--gray-light border-l--2"
+                          href="/PageLayout/guides/worldview/avilable-worldviews/"
+                        >
+                          Available worldviews
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          className="pl12 inline-block w-full color-blue-on-hover border-l border--gray-light border-l--2"
+                          href="/PageLayout/guides/worldview/border-styling/"
+                        >
+                          Border styling
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          className="pl12 inline-block w-full color-blue-on-hover border-l border--gray-light border-l--2"
+                          href="/PageLayout/guides/worldview/data-sources/"
+                        >
+                          Data sources
+                        </a>
+                      </li>
+                    </ul>
+                    <li
+                      className="mb3"
+                    >
+                      <a
+                        className="inline-block w-full color-blue-on-hover"
+                        href="/PageLayout/guides/expressions/"
+                      >
+                        Expressions
+                      </a>
+                    </li>
+                  </ul>
                 </li>
                 <li>
                   <div

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -1984,35 +1984,35 @@ Array [
                       >
                         Worldview
                       </a>
+                      <ul
+                        className="mb6 ml3"
+                      >
+                        <li>
+                          <a
+                            className="pl12 inline-block w-full color-blue-on-hover border-l border--gray-light border-l--2"
+                            href="/PageLayout/guides/worldview/avilable-worldviews/"
+                          >
+                            Available worldviews
+                          </a>
+                        </li>
+                        <li>
+                          <a
+                            className="pl12 inline-block w-full color-blue-on-hover border-l border--gray-light border-l--2"
+                            href="/PageLayout/guides/worldview/border-styling/"
+                          >
+                            Border styling
+                          </a>
+                        </li>
+                        <li>
+                          <a
+                            className="pl12 inline-block w-full color-blue-on-hover border-l border--gray-light border-l--2"
+                            href="/PageLayout/guides/worldview/data-sources/"
+                          >
+                            Data sources
+                          </a>
+                        </li>
+                      </ul>
                     </li>
-                    <ul
-                      className="mb6 ml3"
-                    >
-                      <li>
-                        <a
-                          className="pl12 inline-block w-full color-blue-on-hover border-l border--gray-light border-l--2"
-                          href="/PageLayout/guides/worldview/avilable-worldviews/"
-                        >
-                          Available worldviews
-                        </a>
-                      </li>
-                      <li>
-                        <a
-                          className="pl12 inline-block w-full color-blue-on-hover border-l border--gray-light border-l--2"
-                          href="/PageLayout/guides/worldview/border-styling/"
-                        >
-                          Border styling
-                        </a>
-                      </li>
-                      <li>
-                        <a
-                          className="pl12 inline-block w-full color-blue-on-hover border-l border--gray-light border-l--2"
-                          href="/PageLayout/guides/worldview/data-sources/"
-                        >
-                          Data sources
-                        </a>
-                      </li>
-                    </ul>
                     <li
                       className="mb3"
                     >

--- a/src/components/page-layout/__tests__/page-layout.test.js
+++ b/src/components/page-layout/__tests__/page-layout.test.js
@@ -88,6 +88,12 @@ describe('page-layout', () => {
     let tree;
 
     beforeEach(() => {
+      Object.defineProperty(document, 'body', {
+        value: {
+          clientWidth: 1000
+        }
+      });
+
       testCase = testCases.groupIndexPage;
       wrapper = renderer.create(testCase.element);
       tree = wrapper.toJSON();

--- a/src/components/page-layout/__tests__/page-layout.test.js
+++ b/src/components/page-layout/__tests__/page-layout.test.js
@@ -81,4 +81,20 @@ describe('page-layout', () => {
       expect(tree).toMatchSnapshot();
     });
   });
+
+  describe(testCases.groupIndexPage.description, () => {
+    let testCase;
+    let wrapper;
+    let tree;
+
+    beforeEach(() => {
+      testCase = testCases.groupIndexPage;
+      wrapper = renderer.create(testCase.element);
+      tree = wrapper.toJSON();
+    });
+
+    test('renders as expected', () => {
+      expect(tree).toMatchSnapshot();
+    });
+  });
 });

--- a/src/components/page-layout/__tests__/page-layout.test.js
+++ b/src/components/page-layout/__tests__/page-layout.test.js
@@ -88,6 +88,7 @@ describe('page-layout', () => {
     let tree;
 
     beforeEach(() => {
+      /* Force snapshot at desktop view, so we can capture the NavigationAccordion for grouped guides */
       Object.defineProperty(document, 'body', {
         value: {
           clientWidth: 1000

--- a/src/components/page-layout/components/guide-group-index.js
+++ b/src/components/page-layout/components/guide-group-index.js
@@ -1,36 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 import { getSubPages } from '../utils.js';
+import CardContainer from '../../card-container/card-container';
+import Card from '../../card/card';
 
 export default class GuideGroupIndex extends React.PureComponent {
   render() {
     const { pathname, navigation, frontMatter } = this.props;
     const subPages = getSubPages(navigation, pathname, frontMatter);
+    if (!subPages.length) return <div />;
     return (
-      <React.Fragment>
-        {subPages &&
-          subPages.map((subpage, i) => {
-            return (
-              <div
-                key={subpage.title}
-                className={classnames(
-                  'flex-parent-ml flex-parent--start-cross mb12',
-                  {
-                    'border-b border--gray-light pb12': i < subPages.length - 1
-                  }
-                )}
-              >
-                <div className="flex-child-ml flex-child--no-shrink txt-bold w240 my0-ml mt18 mb12">
-                  <a href={subpage.path}>{subpage.title}</a>
-                </div>
-                <div className="flex-child-ml flex-child--grow">
-                  {subpage.description}
-                </div>
-              </div>
-            );
-          })}
-      </React.Fragment>
+      <CardContainer
+        fullWidthCards={true}
+        cards={subPages.map((page) => (
+          <Card key={page.title} {...page} />
+        ))}
+      />
     );
   }
 }

--- a/src/components/page-layout/components/guide-group-index.js
+++ b/src/components/page-layout/components/guide-group-index.js
@@ -12,8 +12,13 @@ export default class GuideGroupIndex extends React.PureComponent {
     return (
       <CardContainer
         fullWidthCards={true}
-        cards={subPages.map((page) => (
-          <Card key={page.title} {...page} />
+        cards={subPages.map(({ title, description, path }) => (
+          <Card
+            key={title}
+            title={title}
+            description={description}
+            path={path}
+          />
         ))}
       />
     );


### PR DESCRIPTION
This PR updates `GuideGroupIndex` in `PageLayout` to use `CardContainer` to display full width cards. This helps reduce patterns and improve consistency. This PR will also generate a snapshot test for the grouped guides test case.

This PR will also fix an accessibility issue with the NavigationAccordion where the subpages were not properly nested: https://github.com/mapbox/dr-ui/pull/519/commits/6eb9fbf1f3a0cfd0da88da168be9e60bddd14883

Fixes #509 

## How to test

1. `nvm use && npm ci && npm start`
2. Visit /PageLayout test case, specifically `Page layout: group index.`
3. `npm run start-docs`
4. Visit http://localhost:8080/dr-ui/guides/grouped-guides/

## QA checklist

<!-- Complete this checklist when adding a new component or package. -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.

## Before merge

- [x] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
