### PR TITLE
Update class in make-table-scroll plugin

### DIFF
--- a/src/plugins/make-table-scroll.js
+++ b/src/plugins/make-table-scroll.js
@@ -15,7 +15,7 @@ module.exports = () => {
 
   function visitor(node, index, parent) {
     if (node.tagName && node.tagName === 'table') {
-      parent.children[index] = h('div.scroll-auto.mb18', node);
+      parent.children[index] = h('div.overflow-auto.mb18', node);
     }
   }
 };


### PR DESCRIPTION
This PR updates the make-table-scroll plugin to Assembly v1.

@malwoodsantoro this plugin is included in the `batfish.config.json` for each site. It wraps a div around each table and adds the `overflow-auto` class so that tables, especially on smaller screens, will scroll.

## QA checklist

Not needed for this change.

## Before merge

- [ ] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
