### PR TITLE
[Assembly v1] Fix border color and set icon color for `lightText` on `OverviewHeader

### DIFF
--- a/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
+++ b/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`overview-header Adds Contact Us button renders as expected 1`] = `
 <div
-  className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--darken10"
+  className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--gray-light"
 >
   <div
     className="flex flex--center-cross"
@@ -152,7 +152,7 @@ exports[`overview-header Adds Contact Us button renders as expected 1`] = `
 
 exports[`overview-header All, plus Contact Us button renders as expected 1`] = `
 <div
-  className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--darken10"
+  className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--gray-light"
 >
   <div
     className="flex flex--center-cross"
@@ -340,7 +340,7 @@ exports[`overview-header All, plus Contact Us button renders as expected 1`] = `
 
 exports[`overview-header Basic renders as expected 1`] = `
 <div
-  className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--darken10"
+  className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--gray-light"
 >
   <div
     className="flex flex--center-cross"
@@ -522,7 +522,7 @@ exports[`overview-header Basic renders as expected 1`] = `
 
 exports[`overview-header Beta product renders as expected 1`] = `
 <div
-  className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--darken10"
+  className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--gray-light"
 >
   <div
     className="flex flex--center-cross"
@@ -679,7 +679,7 @@ exports[`overview-header Beta product renders as expected 1`] = `
 
 exports[`overview-header No optional props renders as expected 1`] = `
 <div
-  className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--darken10"
+  className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--gray-light"
 >
   <div
     className="flex flex--center-cross"
@@ -860,7 +860,7 @@ exports[`overview-header No optional props renders as expected 1`] = `
 
 exports[`overview-header Some optional props renders as expected 1`] = `
 <div
-  className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--darken10"
+  className="dr-ui--overview-header prose mb24 pr60-mxl undefined border-b border--gray-light"
 >
   <div
     className="flex flex--center-cross"

--- a/src/components/overview-header/overview-header.js
+++ b/src/components/overview-header/overview-header.js
@@ -105,7 +105,12 @@ class OverviewHeader extends React.PureComponent {
       features &&
       features.map((feature) => (
         <li key={feature} className="flex">
-          <div className="flex-child-no-shrink mr6 color-gray">
+          <div
+            className={classnames('flex-child-no-shrink mr6', {
+              'color-gray': !lightText,
+              'color-white': lightText
+            })}
+          >
             <Icon name="check" inline={true} />
           </div>
           <div className="flex-child-grow">{feature}</div>
@@ -117,7 +122,7 @@ class OverviewHeader extends React.PureComponent {
         className={classnames(
           `dr-ui--overview-header prose mb24 pr60-mxl ${theme}`,
           {
-            'border-b border--darken10': !theme,
+            'border-b border--gray-light': !theme,
             'round py12 px24': theme,
             'color-white': lightText
           }

--- a/src/helpers/batfish/__tests__/fixtures/data.json
+++ b/src/helpers/batfish/__tests__/fixtures/data.json
@@ -29,7 +29,8 @@
           "changelogLink": "/dr-ui/changelog/",
           "installLink": "https://github.com/mapbox/dr-ui/blob/main/README.md",
           "ghLink": "https://github.com/mapbox/dr-ui",
-          "theme": "bg-purple-faint"
+          "lightText": true,
+          "theme": "bg-purple-deep"
         }
       }
     },


### PR DESCRIPTION
This PR fixes two minor design features with OverviewHeader:

1. Sets the bottom border color over OverviewHeader to match the border color of h2 (gray-light)

Stage | Image
---|---
Current | ![image](https://user-images.githubusercontent.com/2180540/134920012-459d739e-3b6d-49c6-86fb-99db133d5810.png)
Proposed | ![image](https://user-images.githubusercontent.com/2180540/134920107-ab93d6cd-6813-488a-9f32-73d0dd3c97bf.png)



2. Sets the check icon color when `lightText` is defined:

Stage | Image
---|---
Current | ![image](https://user-images.githubusercontent.com/2180540/134919826-ed00c303-725e-4175-801b-863e16df6d84.png)
Proposed | ![image](https://user-images.githubusercontent.com/2180540/134919893-bb2af85b-fb42-4bbc-b7e9-f96b655eb3e3.png)



## How to test

Visit the /OverviewHeader testcase and catalog page http://localhost:8080/dr-ui/components/

## QA checklist

<!-- Complete this checklist when adding a new component or package. -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.

## Before merge

- [ ] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
