### PR TITLE
[Assembly v1] Update default theme to use `color-text`

### DIFF
--- a/src/components/note/__tests__/__snapshots__/note.test.js.snap
+++ b/src/components/note/__tests__/__snapshots__/note.test.js.snap
@@ -802,7 +802,7 @@ exports[`note A warning note to let the user know something has changed or will 
 
 exports[`note Default note renders as expected 1`] = `
 <div
-  className="dr-ui--note py18 px18 round flex mb18 bg-gray-faint color-gray-dark"
+  className="dr-ui--note py18 px18 round flex mb18 bg-gray-faint color-text"
 >
   <div
     className="mr18 none block-mm pt3"
@@ -851,7 +851,7 @@ exports[`note Default note renders as expected 1`] = `
 
 exports[`note Note with custom title. renders as expected 1`] = `
 <div
-  className="dr-ui--note py18 px18 round flex mb18 bg-gray-faint color-gray-dark"
+  className="dr-ui--note py18 px18 round flex mb18 bg-gray-faint color-text"
 >
   <div
     className="mr18 none block-mm pt3"

--- a/src/components/themes/__tests__/__snapshots__/themes.test.js.snap
+++ b/src/components/themes/__tests__/__snapshots__/themes.test.js.snap
@@ -137,7 +137,7 @@ exports[`themes Custom tag renders as expected 1`] = `
 
 exports[`themes Default renders as expected 1`] = `
 <div
-  className="dr-ui--note py18 px18 round flex mb18 bg-gray-faint color-gray-dark"
+  className="dr-ui--note py18 px18 round flex mb18 bg-gray-faint color-text"
 >
   <div
     className="mr18 none block-mm pt3"

--- a/src/components/themes/themes.js
+++ b/src/components/themes/themes.js
@@ -35,15 +35,13 @@ const themes = {
     image: <Image icon="book" color="gray" />,
     label: 'Note',
     icon: 'book',
-
     background: 'bg-gray-faint',
-    color: 'color-gray-dark'
+    color: 'color-text'
   },
   warning: {
     image: <Image icon="alert" color="orange" />,
     label: 'Warning',
     icon: 'alert',
-
     background: 'bg-orange-faint',
     color: 'color-orange-dark',
     border: 'border--orange-dark'
@@ -52,7 +50,6 @@ const themes = {
     image: <Image icon="alert" color="red" />,
     label: 'Error',
     icon: 'alert',
-
     background: 'bg-red-faint',
     color: 'color-red-dark'
   },
@@ -61,7 +58,6 @@ const themes = {
     label: 'Beta',
     icon: 'lightning',
     tooltipText: 'This feature is in public beta and is subject to changes.',
-
     background: 'bg-blue-faint',
     color: 'color-blue-dark',
     border: 'border--blue-dark'
@@ -71,7 +67,6 @@ const themes = {
     label: 'New!',
     icon: 'plus',
     tooltipText: 'This feature was released recently.',
-
     background: 'bg-green-faint',
     color: 'color-green-dark',
     border: 'border--green-dark'
@@ -80,7 +75,6 @@ const themes = {
     image: <Image icon="arrow-down" color="purple" />,
     label: 'Download',
     icon: 'arrow-down',
-
     background: 'bg-purple-faint',
     color: 'color-purple-dark'
   },
@@ -89,7 +83,6 @@ const themes = {
     icon: 'bookmark',
     tooltipText:
       'The concepts described here are fundamental to using this product.',
-
     background: 'bg-pink-faint',
     color: 'color-pink-dark',
     border: 'border--pink-dark'
@@ -98,7 +91,6 @@ const themes = {
     image: <Image icon="creditcard" color="green" />,
     label: 'Pricing',
     tooltipText: 'This contains information about product pricing.',
-
     background: 'bg-green-faint',
     color: 'color-green-dark',
     border: 'border--green-dark'

--- a/src/helpers/batfish/__tests__/fixtures/data.json
+++ b/src/helpers/batfish/__tests__/fixtures/data.json
@@ -29,7 +29,8 @@
           "changelogLink": "/dr-ui/changelog/",
           "installLink": "https://github.com/mapbox/dr-ui/blob/main/README.md",
           "ghLink": "https://github.com/mapbox/dr-ui",
-          "theme": "bg-purple-faint"
+          "lightText": true,
+          "theme": "bg-purple-deep"
         }
       }
     },


### PR DESCRIPTION
I was noticing that the font color for the default theme seemed to dark. I think we should switch it to `color-text`.

Stage | Image
---|---
Current | ![image](https://user-images.githubusercontent.com/2180540/135120518-39ca6c58-0cb6-4ba2-8bb9-794f84e47aad.png) 
Proposed | ![image](https://user-images.githubusercontent.com/2180540/135120441-25cd8f0d-98c7-4b2c-bb96-6e5b6bc4661c.png)


## How to test

Visit /Note and /Themes test cases

## QA checklist

<!-- Complete this checklist when adding a new component or package. -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.

## Before merge

- [ ] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
