### PR TITLE
[Assembly v1] h2 fix

### DIFF
--- a/docs/src/pages/guides/test-pages/a11y.md
+++ b/docs/src/pages/guides/test-pages/a11y.md
@@ -2,12 +2,12 @@
 title: Accessibility test page
 description: Page for testing accessibility of components.
 layout: page
-order: 6
+groupOrder: 1
 contentType: guide
 products:
   - Documentation
 prependJs:
-  - "import Note from '../../../../src/components/note/note';"
+  - "import Note from '../../../../../src/components/note/note';"
 ---
 
 Use this test page to check color contrast and other accessibility considerations.

--- a/docs/src/pages/guides/test-pages/headings.md
+++ b/docs/src/pages/guides/test-pages/headings.md
@@ -1,0 +1,29 @@
+---
+title: Headings
+description: Page for testing headings.
+layout: page
+groupOrder: 2
+contentType: guide
+products:
+  - Documentation
+---
+
+## Heading 2
+
+This first heading should have padding between the text and top border.
+
+### Heading 3
+
+This is a heading 3 section. This is a heading 3 section. This is a heading 3 section. This is a heading 3 section. This is a heading 3 section. This is a heading 3 section. This is a heading 3 section. This is a heading 3 section. This is a heading 3 section. This is a heading 3 section. This is a heading 3 section. This is a heading 3 section. This is a heading 3 section.
+
+#### Heading 4
+
+This is a heading 4 section. This is a heading 4 section. This is a heading 4 section. This is a heading 4 section. This is a heading 4 section. This is a heading 4 section. This is a heading 4 section. This is a heading 4 section. This is a heading 4 section. This is a heading 4 section. This is a heading 4 section. This is a heading 4 section. This is a heading 4 section.
+
+##### Heading 5
+
+This is a heading 5 section. This is a heading 5 section. This is a heading 5 section. This is a heading 5 section. This is a heading 5 section. This is a heading 5 section. This is a heading 5 section. This is a heading 5 section. This is a heading 5 section. This is a heading 5 section. This is a heading 5 section. This is a heading 5 section. This is a heading 5 section.
+
+## Heading 2
+
+This is a heading 2 section. This is a heading 2 section. This is a heading 2 section. This is a heading 2 section. This is a heading 2 section. This is a heading 2 section. This is a heading 2 section. This is a heading 2 section. This is a heading 2 section. This is a heading 2 section. This is a heading 2 section. This is a heading 2 section. This is a heading 2 section.

--- a/docs/src/pages/guides/test-pages/index.md
+++ b/docs/src/pages/guides/test-pages/index.md
@@ -1,0 +1,10 @@
+---
+title: Test pages
+description: A group of test pages.
+order: 6
+contentType: guide
+layout: page
+group: true
+products:
+  - Documentation
+---

--- a/src/css/docs-prose.css
+++ b/src/css/docs-prose.css
@@ -8,6 +8,7 @@
   border-top: 1px solid !important;
   border-color: #bccbd7 !important;
   margin: 36px 0px 18px;
+  padding-top: 30px;
 }
 
 #docs-content .prose h3:not(.unprose) {

--- a/src/helpers/batfish/__tests__/__snapshots__/navigation.test.js.snap
+++ b/src/helpers/batfish/__tests__/__snapshots__/navigation.test.js.snap
@@ -2155,10 +2155,6 @@ Object {
       "parent": "/dr-ui/guides/",
       "title": "Guides",
     },
-    "/dr-ui/guides/a11y/": Object {
-      "parent": "/dr-ui/guides/",
-      "title": "Guides",
-    },
     "/dr-ui/guides/batfish-helpers/": Object {
       "parent": "/dr-ui/guides/",
       "title": "Guides",
@@ -2190,6 +2186,18 @@ Object {
     "/dr-ui/guides/split-pages/": Object {
       "parent": "/dr-ui/guides/",
       "title": "Guides",
+    },
+    "/dr-ui/guides/test-pages/": Object {
+      "parent": "/dr-ui/guides/",
+      "title": "Guides",
+    },
+    "/dr-ui/guides/test-pages/a11y/": Object {
+      "parent": "/dr-ui/guides/test-pages/",
+      "title": "Test pages",
+    },
+    "/dr-ui/guides/test-pages/headings/": Object {
+      "parent": "/dr-ui/guides/test-pages/",
+      "title": "Test pages",
     },
   },
   "navTabs": Array [
@@ -2265,10 +2273,34 @@ Object {
           "title": "Multi-structured sites",
         },
         Object {
-          "description": "Page for testing accessibility of components.",
+          "description": "A group of test pages.",
+          "group": true,
           "layout": "page",
           "order": 6,
-          "path": "/dr-ui/guides/a11y/",
+          "path": "/dr-ui/guides/test-pages/",
+          "subPages": Array [
+            Object {
+              "description": "Page for testing accessibility of components.",
+              "groupOrder": 1,
+              "layout": "page",
+              "path": "/dr-ui/guides/test-pages/a11y/",
+              "title": "Accessibility test page",
+            },
+            Object {
+              "description": "Page for testing headings.",
+              "groupOrder": 2,
+              "layout": "page",
+              "path": "/dr-ui/guides/test-pages/headings/",
+              "title": "Headings",
+            },
+          ],
+          "title": "Test pages",
+        },
+        Object {
+          "description": "Page for testing accessibility of components.",
+          "groupOrder": 1,
+          "layout": "page",
+          "path": "/dr-ui/guides/test-pages/a11y/",
           "title": "Accessibility test page",
         },
         Object {
@@ -2284,6 +2316,13 @@ Object {
           "layout": "page",
           "path": "/dr-ui/guides/grouped-guides/frontmatter/",
           "title": "Frontmatter",
+        },
+        Object {
+          "description": "Page for testing headings.",
+          "groupOrder": 2,
+          "layout": "page",
+          "path": "/dr-ui/guides/test-pages/headings/",
+          "title": "Headings",
         },
         Object {
           "description": "This section of the catalog site illustrates how grouped guides look and work.",

--- a/src/helpers/batfish/__tests__/fixtures/data.json
+++ b/src/helpers/batfish/__tests__/fixtures/data.json
@@ -29,7 +29,8 @@
           "changelogLink": "/dr-ui/changelog/",
           "installLink": "https://github.com/mapbox/dr-ui/blob/main/README.md",
           "ghLink": "https://github.com/mapbox/dr-ui",
-          "theme": "bg-purple-faint"
+          "lightText": true,
+          "theme": "bg-purple-deep"
         }
       }
     },
@@ -118,21 +119,6 @@
         "navOrder": 3,
         "layout": "example",
         "products": ["Documentation"]
-      }
-    },
-    {
-      "filePath": "./docs/src/pages/guides/a11y.md",
-      "path": "/dr-ui/guides/a11y/",
-      "frontMatter": {
-        "title": "Accessibility test page",
-        "description": "Page for testing accessibility of components.",
-        "layout": "page",
-        "order": 6,
-        "contentType": "guide",
-        "products": ["Documentation"],
-        "prependJs": [
-          "import Note from '../../../../src/components/note/note';"
-        ]
       }
     },
     {
@@ -323,17 +309,51 @@
       }
     },
     {
+      "filePath": "./docs/src/pages/guides/test-pages/a11y.md",
+      "path": "/dr-ui/guides/test-pages/a11y/",
+      "frontMatter": {
+        "title": "Accessibility test page",
+        "description": "Page for testing accessibility of components.",
+        "layout": "page",
+        "groupOrder": 1,
+        "contentType": "guide",
+        "products": ["Documentation"],
+        "prependJs": [
+          "import Note from '../../../../../src/components/note/note';"
+        ]
+      }
+    },
+    {
+      "filePath": "./docs/src/pages/guides/test-pages/headings.md",
+      "path": "/dr-ui/guides/test-pages/headings/",
+      "frontMatter": {
+        "title": "Headings",
+        "description": "Page for testing headings.",
+        "layout": "page",
+        "groupOrder": 2,
+        "contentType": "guide",
+        "products": ["Documentation"]
+      }
+    },
+    {
+      "filePath": "./docs/src/pages/guides/test-pages/index.md",
+      "path": "/dr-ui/guides/test-pages/",
+      "frontMatter": {
+        "title": "Test pages",
+        "description": "A group of test pages.",
+        "order": 6,
+        "contentType": "guide",
+        "layout": "page",
+        "group": true,
+        "products": ["Documentation"]
+      }
+    },
+    {
       "filePath": "./docs/src/pages/index.js",
       "path": "/dr-ui/",
       "frontMatter": {
         "hideFromSearchEngines": true
       }
-    },
-    {
-      "filePath": "./node_modules/@mapbox/batfish/dist/webpack/default-not-found.js",
-      "path": "/dr-ui/404/",
-      "is404": true,
-      "frontMatter": {}
     }
   ]
 }

--- a/src/helpers/batfish/__tests__/sitemap.test.js
+++ b/src/helpers/batfish/__tests__/sitemap.test.js
@@ -132,7 +132,6 @@ describe('prepareSitemap', () => {
         'https://mapbox.github.io/dr-ui/examples/example-4',
         'https://mapbox.github.io/dr-ui/examples/example-5',
         'https://mapbox.github.io/dr-ui/guides',
-        'https://mapbox.github.io/dr-ui/guides/a11y',
         'https://mapbox.github.io/dr-ui/guides/batfish-helpers',
         'https://mapbox.github.io/dr-ui/guides/grouped-guides',
         'https://mapbox.github.io/dr-ui/guides/grouped-guides/file-structure',
@@ -140,7 +139,10 @@ describe('prepareSitemap', () => {
         'https://mapbox.github.io/dr-ui/guides/grouped-guides/resulting-ui',
         'https://mapbox.github.io/dr-ui/guides/multi-structured',
         'https://mapbox.github.io/dr-ui/guides/page-layout',
-        'https://mapbox.github.io/dr-ui/guides/split-pages'
+        'https://mapbox.github.io/dr-ui/guides/split-pages',
+        'https://mapbox.github.io/dr-ui/guides/test-pages',
+        'https://mapbox.github.io/dr-ui/guides/test-pages/a11y',
+        'https://mapbox.github.io/dr-ui/guides/test-pages/headings'
       ]);
     });
   }


### PR DESCRIPTION
This PR will add back `padding-top` to docs-prose.css to fix an issues seen across several sites. This PR also makes a small adjustment to the catalog site:

- Adds "Test pages" grouped guide section
- Moves the accessibility test page under the Test pages group
- Add a Headings test page which allowed me to reproduce and confirm that the heading bug was fixed.

## How to test

1. Run `npm run start-docs`
2. Visit http://localhost:8080/dr-ui/guides/test-pages/headings/
3. Confirm that the padding between the h2 and the border-top is there!

## QA checklist

<!-- Complete this checklist when adding a new component or package. -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

Not required for this change.

## Before merge

- [ ] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
