### PR TITLE
Do not clear `Search` filter, reset `Search` when closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Move "I like..." category to bottom in `Feedback` component. [#518](https://github.com/mapbox/dr-ui/pull/518)
 - Decrease Sentry `tracesSampleRate` to `0.05`. [#517](https://github.com/mapbox/dr-ui/pull/517)
 - Updates `GuideGroupIndex` in `PageLayout` to use `CardContainer` to display full width cards. [#519](https://github.com/mapbox/dr-ui/pull/519)
-- Do not clear `Search` filter, reset Search when modal closes. [#528](https://github.com/mapbox/dr-ui/pull/528)
+- Do not clear `Search` filter and reset `Search` when closed. [#528](https://github.com/mapbox/dr-ui/pull/528)
 
 ## 4.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Move "I like..." category to bottom in `Feedback` component. [#518](https://github.com/mapbox/dr-ui/pull/518)
 - Decrease Sentry `tracesSampleRate` to `0.05`. [#517](https://github.com/mapbox/dr-ui/pull/517)
 - Updates `GuideGroupIndex` in `PageLayout` to use `CardContainer` to display full width cards. [#519](https://github.com/mapbox/dr-ui/pull/519)
+- Do not clear `Search` filter, reset Search when modal closes. [#528](https://github.com/mapbox/dr-ui/pull/528)
 
 ## 4.2.3
 

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -34,6 +34,7 @@ export class SearchBox extends React.PureComponent {
 
   closeModal() {
     this.props.reset();
+    this.props.resetFacade();
     this.setState({ modalOpen: false });
   }
 
@@ -308,7 +309,8 @@ SearchBox.propTypes = {
   overrideSearchTerm: PropTypes.string,
   themeCompact: PropTypes.bool,
   emptyResultMessage: PropTypes.node,
-  useModal: PropTypes.bool.isRequired
+  useModal: PropTypes.bool.isRequired,
+  resetFacade: PropTypes.func
 };
 
 export class SearchButton extends React.PureComponent {

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -14,7 +14,8 @@ export class SearchBox extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      modalOpen: true // open model for a smooth transition from the facade
+      modalOpen: true, // open model for a smooth transition from the facade
+      dropdownOpen: false // dropdown state
     };
     this.docsSeachInput = React.createRef;
     this.openModal = this.openModal.bind(this);
@@ -22,6 +23,7 @@ export class SearchBox extends React.PureComponent {
     this.renderModal = this.renderModal.bind(this);
     this.renderSearchBar = this.renderSearchBar.bind(this);
     this.singleLinksFacet = this.singleLinksFacet.bind(this);
+    this.onStateChange = this.onStateChange.bind(this);
     // if resultsOnly and overrideSearchTerm, set the search term
     if (this.props.resultsOnly && this.props.overrideSearchTerm) {
       props.setSearchTerm(this.props.overrideSearchTerm, {
@@ -103,8 +105,16 @@ export class SearchBox extends React.PureComponent {
     );
   };
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps, prevState) {
     const { isLoading, results, searchTerm } = this.props;
+    const { dropdownOpen } = this.state;
+
+    if (dropdownOpen !== prevState.dropdownOpen) {
+      // Reset to facade once dropdown closes
+      if (dropdownOpen === false) {
+        this.props.resetFacade();
+      }
+    }
 
     if (
       results !== prevProps.results &&
@@ -122,6 +132,10 @@ export class SearchBox extends React.PureComponent {
         Sentry.captureMessage(searchTerm);
       });
     }
+  }
+
+  onStateChange({ isOpen }) {
+    this.setState({ dropdownOpen: isOpen });
   }
 
   renderSearchBar() {
@@ -165,6 +179,7 @@ export class SearchBox extends React.PureComponent {
     function handleItemToString() {
       return searchTerm;
     }
+
     return (
       <Downshift
         id={inputId}
@@ -172,6 +187,7 @@ export class SearchBox extends React.PureComponent {
         onChange={handleSelection}
         onInputValueChange={handleInputChange}
         itemToString={handleItemToString}
+        onStateChange={this.onStateChange}
       >
         {(downshiftProps) => {
           const { getInputProps, isOpen, getLabelProps, openMenu } =

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -24,7 +24,9 @@ export class SearchBox extends React.PureComponent {
     this.singleLinksFacet = this.singleLinksFacet.bind(this);
     // if resultsOnly and overrideSearchTerm, set the search term
     if (this.props.resultsOnly && this.props.overrideSearchTerm) {
-      props.setSearchTerm(this.props.overrideSearchTerm);
+      props.setSearchTerm(this.props.overrideSearchTerm, {
+        shouldClearFilters: false
+      });
     }
   }
 
@@ -151,7 +153,7 @@ export class SearchBox extends React.PureComponent {
     }
     function handleInputChange(newValue) {
       if (searchTerm === newValue) return;
-      setSearchTerm(newValue, { debounce: 1500 });
+      setSearchTerm(newValue, { debounce: 1500, shouldClearFilters: false });
       // track query
       if (window && window.analytics) {
         analytics.track(segmentTrackEvent, {

--- a/src/components/search/search-provider.js
+++ b/src/components/search/search-provider.js
@@ -5,7 +5,7 @@ import { SearchBox } from './search-box';
 
 class Search extends React.PureComponent {
   render() {
-    const { connector, resultsOnly, useModal } = this.props;
+    const { connector, resultsOnly, useModal, resetFacade } = this.props;
 
     function handleMapContext({
       isLoading,
@@ -61,6 +61,7 @@ class Search extends React.PureComponent {
                 wasSearched={wasSearched}
                 isLoading={isLoading}
                 reset={reset}
+                resetFacade={resetFacade}
                 {...this.props}
                 useModal={useModal && !resultsOnly} // disable modal if resultsOnly === true
               />
@@ -75,7 +76,8 @@ class Search extends React.PureComponent {
 Search.propTypes = {
   connector: PropTypes.object.isRequired,
   resultsOnly: PropTypes.bool.isRequired,
-  useModal: PropTypes.bool.isRequired
+  useModal: PropTypes.bool.isRequired,
+  resetFacade: PropTypes.func
 };
 
 export default Search;

--- a/src/components/search/search.js
+++ b/src/components/search/search.js
@@ -38,9 +38,11 @@ export default class Search extends React.PureComponent {
     window.addEventListener('resize', this.checkWidth, { passive: true });
   }
 
+  /* When the user closes the modal, reset back to a facade */
   resetFacade() {
     this.setState({ SearchProvider: undefined }, () => {
-      window.history.pushState({}, document.title, window.location.pathname);
+      /* Remove Swiftype query string from the URL */
+      history.pushState(null, '', window.location.pathname);
     });
   }
 

--- a/src/components/search/search.js
+++ b/src/components/search/search.js
@@ -12,6 +12,7 @@ export default class Search extends React.PureComponent {
       SearchProvider: undefined,
       useModal: !this.props.disableModal || !this.props.resultsOnly
     };
+    this.resetFacade = this.resetFacade.bind(this);
   }
 
   /* Wait to load the full Search component */
@@ -35,6 +36,12 @@ export default class Search extends React.PureComponent {
   componentDidMount() {
     this.checkWidth();
     window.addEventListener('resize', this.checkWidth, { passive: true });
+  }
+
+  resetFacade() {
+    this.setState({ SearchProvider: undefined }, () => {
+      window.history.pushState({}, document.title, window.location.pathname);
+    });
   }
 
   /* If using `overrideSearchTerm`, don't load the full Search component until overrideSearchTerm is set */
@@ -62,7 +69,11 @@ export default class Search extends React.PureComponent {
         })}
       >
         {SearchProvider ? (
-          <SearchProvider useModal={useModal} {...this.props} />
+          <SearchProvider
+            resetFacade={this.resetFacade}
+            useModal={useModal}
+            {...this.props}
+          />
         ) : (
           <SearchFacade
             useModal={useModal}


### PR DESCRIPTION
This PR fixes to issues with `Search`:

- After using Search, clicking a hash link on the page re-opens the search modal (#527). This was happening because after opening search it stays in an active state. This PR will replace the Search facade to disable search: 8701004. We also want to reset to facade on smaller screens when just the input/dropdown appears: 6f045a2
- When searching with the site filter enabled, the toggle switches back if you change the query. By setting `shouldClearFilters` to false, the filter will persist: aaa9a82

Fixes #527 

## How to test

Clicking a hash link on the page should not re-open the search modal:
1. Run `npm run start-docs`. 
2. Click to open search. 
3. Make a query, but close out before selecting. 
4. Click a hash link from On this page. The search modal should **not** reopen.
5. Resize window to enable input only search. Follow steps 2-4.

The filter should not reset while searching:
1. Run `npm start`
2. Visit the `/Search` test case.
3. Click to open the second test case (Basic search with `site` set to show filter toggle).
4. Make a query like "api".
5. Click the toggle "API".
6. Make another query like "maps". The toggle should stay on "API".

## QA checklist

<!-- Complete this checklist when adding a new component or package. -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [ ] Edge, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [ ] Android Chrome, no errors logged to console.

## Before merge

- [x] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
