### PR TITLE
Add optional height prop to DemoIframe

### DIFF
--- a/src/components/demo-iframe/__tests__/demo-iframe-test-cases.js
+++ b/src/components/demo-iframe/__tests__/demo-iframe-test-cases.js
@@ -44,7 +44,7 @@ testCases.height = {
   component: DemoIframe,
   description: 'Custom height used for iframe.',
   props: {
-    title: 'Static API request',
+    title: 'Light map style',
     src: './files/ios-horizontal.png',
     height: 100
   }

--- a/src/components/demo-iframe/__tests__/demo-iframe-test-cases.js
+++ b/src/components/demo-iframe/__tests__/demo-iframe-test-cases.js
@@ -40,4 +40,14 @@ testCases.missing = {
   }
 };
 
+testCases.height = {
+  component: DemoIframe,
+  description: 'Custom height used for iframe.',
+  props: {
+    title: 'Static API request',
+    src: './files/ios-horizontal.png',
+    height: 100
+  }
+};
+
 export { testCases, noRenderCases };

--- a/src/components/demo-iframe/demo-iframe.js
+++ b/src/components/demo-iframe/demo-iframe.js
@@ -23,7 +23,7 @@ export default class DemoIframe extends React.PureComponent {
 
   render() {
     let { src } = this.props;
-    const { title, gl } = this.props;
+    const { title, gl, height } = this.props;
     const { mapboxAccessToken } = this.state;
     // check to see if the src is making a request to mapbox api
     const makeRequest = src.indexOf('MapboxAccessToken') > -1;
@@ -38,11 +38,9 @@ export default class DemoIframe extends React.PureComponent {
       ? src.replace('MapboxAccessToken', mapboxAccessToken)
       : src;
 
-    const iframeHeight = 400;
-
     const contents = (
       <div>
-        <iframe title={title} src={src} width="100%" height={iframeHeight} />
+        <iframe title={title} src={src} width="100%" height={height} />
         <a href={src} className="link">
           <ChevronousText text="View fullscreen demo" />
         </a>
@@ -50,7 +48,7 @@ export default class DemoIframe extends React.PureComponent {
     );
 
     return gl ? (
-      <MapWrapper height={iframeHeight + 30 /* add space for demo link */}>
+      <MapWrapper height={height + 30 /* add space for demo link */}>
         {contents}
       </MapWrapper>
     ) : (
@@ -60,7 +58,8 @@ export default class DemoIframe extends React.PureComponent {
 }
 
 DemoIframe.defaultProps = {
-  gl: true
+  gl: true,
+  height: 400
 };
 
 DemoIframe.propTypes = {
@@ -71,5 +70,7 @@ DemoIframe.propTypes = {
   /** Replace instance of `MapboxAccessToken` in the `src` prop with the value of this Mapbox access token. */
   MapboxAccessToken: PropTypes.string,
   /** A title to describe the content of the iframe. */
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  /** Height of iframe in pixels. Default `400`. */
+  height: PropTypes.number
 };


### PR DESCRIPTION
Addresses https://github.com/mapbox/dr-ui/issues/505

## How to test

<!-- List steps on how the reviewer can test this change. Make sure the user can test the component properly by creating a test case or adding an example to the catalog site. -->

## QA checklist

<!-- Complete this checklist when adding a new component or package. -->

- [x] No errors logged to console.
- [x] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [x] Firefox, no errors logged to console.
- [x] Safari, no errors logged to console.
- [x] Edge, no errors logged to console.
- [x] Mobile Safari, no errors logged to console.
- [x] Android Chrome, no errors logged to console.

## Before merge

- [ ] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
