### PR TITLE
Allow grouped guides on any type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Allow other sections, other than "Guides", to work with `GuideGroupIndex`.
+
 ## 5.1.1
 
 - Move `@sentry/browser` to `dependencies`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/dr-ui",
-  "version": "5.1.1",
+  "version": "5.2.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/dr-ui",
-      "version": "5.1.1",
+      "version": "5.2.0-beta.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/react-search-ui": "^1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/dr-ui",
-  "version": "5.2.0-beta.1",
+  "version": "5.2.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/dr-ui",
-      "version": "5.2.0-beta.1",
+      "version": "5.2.0-beta.2",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/react-search-ui": "^1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/dr-ui",
-  "version": "5.2.0-beta.0",
+  "version": "5.2.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/dr-ui",
-      "version": "5.2.0-beta.0",
+      "version": "5.2.0-beta.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/react-search-ui": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dr-ui",
-  "version": "5.2.0-beta.0",
+  "version": "5.2.0-beta.1",
   "description": "Mapbox frontend tools for documentation websites.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dr-ui",
-  "version": "5.1.1",
+  "version": "5.2.0-beta.0",
   "description": "Mapbox frontend tools for documentation websites.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dr-ui",
-  "version": "5.2.0-beta.1",
+  "version": "5.2.0-beta.2",
   "description": "Mapbox frontend tools for documentation websites.",
   "main": "index.js",
   "scripts": {

--- a/src/components/page-layout/__tests__/utils.test.js
+++ b/src/components/page-layout/__tests__/utils.test.js
@@ -144,4 +144,295 @@ describe('getSubPages', () => {
       }
     ]);
   });
+
+  test('android grouped pages', () => {
+    expect(
+      getSubPages(
+        {
+          hierarchy: {
+            '/PageLayout/guides/': {
+              parent: '/PageLayout/',
+              title: 'Guides'
+            },
+            '/PageLayout/guides/worldview/': {
+              parent: '/PageLayout/guides/',
+              title: 'Guides'
+            },
+            '/PageLayout/guides/worldview/border-styling/': {
+              parent: '/PageLayout/guides/worldview/',
+              title: 'Worldview'
+            }
+          },
+          navTabs: [
+            {
+              path: '/PageLayout/guides/',
+              title: 'Guides',
+              id: 'guides',
+              pages: [
+                {
+                  path: '/PageLayout/guides/annotations/',
+                  title: 'Annotations',
+                  id: 'annotations'
+                },
+                {
+                  path: '/PageLayout/guides/worldview/',
+                  title: 'Worldview',
+                  id: 'worldview',
+                  subPages: [
+                    {
+                      title: 'Web maps using older library versions',
+                      description:
+                        'Identify geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups.',
+                      path: '/PageLayout/guides/worldview/avilable-worldviews/',
+                      groupOrder: 1,
+                      id: 'sp-one'
+                    },
+                    {
+                      title: 'Mobile applications using older SDK versions',
+                      description:
+                        'When creating a map style with a tileset that uses worldviews, you must apply a filter to any layers that include a worldview data field.',
+                      path: '/PageLayout/guides/worldview/border-styling/',
+                      groupOrder: 2,
+                      id: 'sp-two'
+                    },
+                    {
+                      title: 'Data sources',
+                      description:
+                        'Some Mapbox vector tilesets, including Mapbox Streets v8 and Boundaries v3, include the worldview data field in several layers.',
+                      path: '/PageLayout/guides/worldview/data-sources/',
+                      groupOrder: 3,
+                      id: 'sp-three'
+                    }
+                  ]
+                },
+                {
+                  path: '/PageLayout/guides/expressions/',
+                  title: 'Expressions',
+                  id: 'expressions'
+                }
+              ]
+            },
+            {
+              path: '/PageLayout/specification/',
+              title: 'Specification',
+              id: 'specification'
+            },
+            {
+              path: '/PageLayout/examples/',
+              title: 'Examples',
+              id: 'examples'
+            },
+            {
+              path: '/PageLayout/demo/',
+              title: 'Demo',
+              id: 'demo'
+            }
+          ]
+        },
+        '/PageLayout/guides/worldview/',
+        {
+          title: 'Worldview',
+          layout: 'page',
+          group: true,
+          headings: []
+        }
+      )
+    ).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "description": "Identify geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups.",
+          "groupOrder": 1,
+          "id": "sp-one",
+          "path": "/PageLayout/guides/worldview/avilable-worldviews/",
+          "title": "Web maps using older library versions",
+        },
+        Object {
+          "description": "When creating a map style with a tileset that uses worldviews, you must apply a filter to any layers that include a worldview data field.",
+          "groupOrder": 2,
+          "id": "sp-two",
+          "path": "/PageLayout/guides/worldview/border-styling/",
+          "title": "Mobile applications using older SDK versions",
+        },
+        Object {
+          "description": "Some Mapbox vector tilesets, including Mapbox Streets v8 and Boundaries v3, include the worldview data field in several layers.",
+          "groupOrder": 3,
+          "id": "sp-three",
+          "path": "/PageLayout/guides/worldview/data-sources/",
+          "title": "Data sources",
+        },
+      ]
+    `);
+  });
+
+  test('non-guides grouped', () => {
+    expect(
+      getSubPages(
+        {
+          navTabs: [
+            {
+              navOrder: 1,
+              title: 'Style guide',
+              pages: [
+                {
+                  title: 'Build and publish docs',
+                  path: '/documentation/style-guide/publish/',
+                  order: 1
+                },
+                {
+                  title: 'Content types',
+                  path: '/documentation/style-guide/content-types/',
+                  order: 2,
+                  group: true,
+                  subPages: [
+                    {
+                      title: 'Example',
+                      path: '/documentation/style-guide/content-types/example/',
+                      groupOrder: 1
+                    },
+                    {
+                      title: 'Tutorial',
+                      path: '/documentation/style-guide/content-types/tutorial/',
+                      groupOrder: 1
+                    }
+                  ]
+                }
+              ],
+              id: 'style-guide',
+              path: '/documentation/style-guide/'
+            }
+          ],
+          hierarchy: {
+            '/documentation/style-guide/': {
+              title: 'Style guide',
+              parent: '/documentation/style-guide/'
+            },
+            '/documentation/style-guide/content-types/': {
+              title: 'Style guide',
+              parent: '/documentation/style-guide/'
+            },
+            '/documentation/style-guide/content-types/example/': {
+              title: 'Content types',
+              parent: '/documentation/style-guide/content-types/'
+            },
+            '/documentation/style-guide/content-types/tutorial/': {
+              title: 'Content types',
+              parent: '/documentation/style-guide/content-types/'
+            }
+          }
+        },
+        '/documentation/style-guide/content-types/',
+        {
+          title: 'Content types',
+          group: true
+        }
+      )
+    ).toMatchInlineSnapshot(`undefined`);
+  });
+
+  test('grouped guides, pathname not set on index', () => {
+    expect(
+      getSubPages(
+        {
+          hierarchy: {
+            '/PageLayout/guides/': { parent: '/PageLayout/', title: 'Guides' },
+            '/PageLayout/guides/worldview/': {
+              parent: '/PageLayout/guides/',
+              title: 'Guides'
+            },
+            '/PageLayout/guides/worldview/border-styling/': {
+              parent: '/PageLayout/guides/worldview/',
+              title: 'Worldview'
+            }
+          },
+          navTabs: [
+            {
+              path: '/PageLayout/guides/',
+              title: 'Guides',
+              id: 'guides',
+              pages: [
+                {
+                  path: '/PageLayout/guides/annotations/',
+                  title: 'Annotations',
+                  id: 'annotations'
+                },
+                {
+                  path: '/PageLayout/guides/worldview/',
+                  title: 'Worldview',
+                  id: 'worldview',
+                  subPages: [
+                    {
+                      title: 'Available worldviews',
+                      description:
+                        'Identify geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups.',
+                      path: '/PageLayout/guides/worldview/avilable-worldviews/',
+                      groupOrder: 1,
+                      id: 'sp-one'
+                    },
+                    {
+                      title: 'Border styling',
+                      description:
+                        'When creating a map style with a tileset that uses worldviews, you must apply a filter to any layers that include a worldview data field.',
+                      path: '/PageLayout/guides/worldview/border-styling/',
+                      groupOrder: 2,
+                      id: 'sp-two'
+                    },
+                    {
+                      title: 'Data sources',
+                      description:
+                        'Some Mapbox vector tilesets, including Mapbox Streets v8 and Boundaries v3, include the worldview data field in several layers.',
+                      path: '/PageLayout/guides/worldview/data-sources/',
+                      groupOrder: 3,
+                      id: 'sp-three'
+                    }
+                  ]
+                },
+                {
+                  path: '/PageLayout/guides/expressions/',
+                  title: 'Expressions',
+                  id: 'expressions'
+                }
+              ]
+            },
+            {
+              path: '/PageLayout/specification/',
+              title: 'Specification',
+              id: 'specification'
+            },
+            {
+              path: '/PageLayout/examples/',
+              title: 'Examples',
+              id: 'examples'
+            },
+            { path: '/PageLayout/demo/', title: 'Demo', id: 'demo' }
+          ]
+        },
+        '/PageLayout/guides/worldview/border-styling/',
+        { title: 'Border styling', layout: 'page', groupOrder: 2 }
+      )
+    ).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "description": "Identify geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups.",
+          "groupOrder": 1,
+          "id": "sp-one",
+          "path": "/PageLayout/guides/worldview/avilable-worldviews/",
+          "title": "Available worldviews",
+        },
+        Object {
+          "description": "When creating a map style with a tileset that uses worldviews, you must apply a filter to any layers that include a worldview data field.",
+          "groupOrder": 2,
+          "id": "sp-two",
+          "path": "/PageLayout/guides/worldview/border-styling/",
+          "title": "Border styling",
+        },
+        Object {
+          "description": "Some Mapbox vector tilesets, including Mapbox Streets v8 and Boundaries v3, include the worldview data field in several layers.",
+          "groupOrder": 3,
+          "id": "sp-three",
+          "path": "/PageLayout/guides/worldview/data-sources/",
+          "title": "Data sources",
+        },
+      ]
+    `);
+  });
 });

--- a/src/components/page-layout/__tests__/utils.test.js
+++ b/src/components/page-layout/__tests__/utils.test.js
@@ -326,7 +326,20 @@ describe('getSubPages', () => {
           group: true
         }
       )
-    ).toMatchInlineSnapshot(`undefined`);
+    ).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "groupOrder": 1,
+          "path": "/documentation/style-guide/content-types/example/",
+          "title": "Example",
+        },
+        Object {
+          "groupOrder": 1,
+          "path": "/documentation/style-guide/content-types/tutorial/",
+          "title": "Tutorial",
+        },
+      ]
+    `);
   });
 
   test('grouped guides, pathname not set on index', () => {

--- a/src/components/page-layout/components/content.js
+++ b/src/components/page-layout/components/content.js
@@ -92,8 +92,14 @@ export class ContentWrapper extends React.PureComponent {
   };
 
   render() {
-    const { children, frontMatter, layoutConfig, navigation, location } =
-      this.props;
+    const {
+      children,
+      frontMatter,
+      layoutConfig,
+      navigation,
+      location,
+      section
+    } = this.props;
     const { title, unProse, hideFeedback, layout, overviewHeader } =
       frontMatter;
     const { hideTitle } = layoutConfig;
@@ -135,7 +141,7 @@ export class ContentWrapper extends React.PureComponent {
             {frontMatter.group && (
               <GuideGroupIndex
                 pathname={location.pathname}
-                navigation={navigation}
+                navigation={section ? navigation[section] : navigation}
                 frontMatter={frontMatter}
               />
             )}

--- a/src/components/page-layout/page-layout.js
+++ b/src/components/page-layout/page-layout.js
@@ -101,6 +101,7 @@ export default class PageLayout extends React.PureComponent {
 
         <Content
           {...this.props}
+          section={hasSection ? hasSection.path : undefined}
           parentPath={parentPath}
           layoutConfig={config}
         />

--- a/src/components/page-layout/utils.js
+++ b/src/components/page-layout/utils.js
@@ -48,37 +48,28 @@ export function createUniqueCrumbs(links) {
   }, []);
 }
 
-function getGuidesNavTabs(array) {
-  return array.find((x) => x.title === 'Guides');
+/**
+ * Recursive function to return the subpages for a group index
+ */
+function findPages(arr, pathname) {
+  for (let i = 0; i < arr.length; i++) {
+    if (arr[i].path === pathname) return arr[i];
+    if (arr[i].pages) {
+      return findPages(arr[i].pages, pathname);
+    }
+  }
 }
 
-export function getSubPages(navigation, pathname, frontMatter) {
-  let sectionPath;
-  let pages;
-  let subPages;
-  // If the current page is a part of a section (a multi-structured
-  // site) then set sectionPath to the current section.
-  if (navigation.hierarchy[pathname].section) {
-    sectionPath = navigation.hierarchy[pathname].section.path;
-  }
-  // Get all pages for the repo or for the section if the current
-  // page is part of a section (a multi-structured site).
-  if (sectionPath) {
-    pages = getGuidesNavTabs(navigation[sectionPath].navTabs).pages;
-  } else if (getGuidesNavTabs(navigation.navTabs)) {
-    pages = getGuidesNavTabs(navigation.navTabs).pages;
-  }
-  // Get the relevant subPages. If the current page is the
-  // grouped guide index, get the `subPages` for that path.
-  // If the current page is one of the grouped guides, get its
-  // sibling pages within the current group.
-  if (frontMatter.group) {
-    subPages = pages && pages.find((x) => x.path === pathname).subPages;
-  } else if (frontMatter.groupOrder) {
-    subPages =
-      pages &&
-      pages.find((x) => x.path === navigation.hierarchy[pathname].parent)
-        .subPages;
-  }
-  return subPages;
+/**
+ * Returns the subpages for grouped guides
+ */
+export function getSubPages(navigation, pathname, frontmatter) {
+  // get the group index's parent path
+  const path = frontmatter.group
+    ? pathname
+    : findParentPath(navigation, pathname);
+  // get the object for the group index, including subPages
+  const groupIndex = findPages(navigation.navTabs, path);
+  // return subPages, if it exists
+  return groupIndex && groupIndex.subPages ? groupIndex.subPages : [];
 }


### PR DESCRIPTION
We recently ran into an issue where the grouped guides index was failing. I believe this is due to the following logic:

https://github.com/mapbox/dr-ui/blob/731f3a34e5bdf998486f9556b5de92eeb877f476/src/components/page-layout/utils.js#L51-L53

https://github.com/mapbox/dr-ui/blob/731f3a34e5bdf998486f9556b5de92eeb877f476/src/components/page-layout/utils.js#L66-L70

Which prevents sections other than "Guides" to return the collection of items. This PR updates the logic to be more flexible:

* In 3d508e541e3078f7126577ec7f16b8f3874581cc, I added a few more test cases and [proved the bug](https://github.com/mapbox/dr-ui/commit/3d508e541e3078f7126577ec7f16b8f3874581cc#diff-d8712ba5c8d208735b14601c92e530ba2360728086169955486c27e401dba9a8R329)
* In f8c382ed52d732357cb7ec56bcbd7a4000a5fb3a, I reworked the getSubPages function to find the group guide index path and then return its subpages

I also noticed the `<Content/>` component assumed a `section` prop was being passed through, this was not the case. This PR will also fix the `section` prop, which is used by Feedback and (now) GroupedGuidesIndex.

## How to test

- I created `dr-ui-5.2.0-beta.2` branch in android-docs to make sure the guides still work in a multi structured site. Try pulling that branch down, npm ci, then npm start.
- I bumped the documentation branch with the original bug with the beta release.

## QA checklist

Not require for this change.

## Before merge

- [x] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.



cc @colleenmcginnis 