### PR TITLE
Add signup banner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,9 @@ scripts:
   - jest src/helpers/batfish/__tests__/sitemap.test.js
 
 before_install:
-  - npm install -g npm@7
+  # Install mbx-ci and make it executable.
+  - curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64 > mbx-ci && chmod 755 ./mbx-ci
+  - export MBX_CI_DOMAIN=o619qyc20d.execute-api.us-east-1.amazonaws.com
+  - ./mbx-ci npm token --write-file
+install:
+  - npm ci

--- a/src/components/page-layout/components/content.js
+++ b/src/components/page-layout/components/content.js
@@ -8,6 +8,57 @@ import OverviewHeader from '../../overview-header/overview-header';
 import NextPage from './next-page.js';
 import GuideGroupIndex from './guide-group-index.js';
 
+import themes from '../../themes';
+
+class SignupBanner extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = { isLoggedIn: true };
+  }
+
+  componentDidMount() {
+    if (typeof MapboxPageShell !== 'undefined') {
+      MapboxPageShell.afterUserCheck(() => {
+        this.setState({
+          isLoggedIn: !!MapboxPageShell.getUser()
+        });
+      });
+    } else {
+      // if no MapboxPageShell, show the component (necessary when developing dr-ui)
+      this.setState({
+        isLoggedIn: false
+      });
+    }
+  }
+
+  render() {
+    if (this.state.isLoggedIn) return null;
+    const { background, color } = themes['default'];
+    return (
+      <div
+        className={`dr-ui--signup-banner py18 px18 round flex mb18 ${background} ${color}`}
+      >
+        <div className="w-full prose flex flex--column-mxl">
+          <div className="flex-child-grow">
+            <div className="txt-bold mb6">Ready to get started?</div>
+            <div className="txt-ms mb18-mxl">
+              Create a free account to start building with Mapbox.
+            </div>
+          </div>
+          <div className="flex flex--center-cross flex-child-no-shrink">
+            <a
+              href="https://account.mapbox.com/auth/signup"
+              className="btn btn--blue round-full unprose"
+            >
+              Sign Up
+            </a>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
 export default class Content extends React.PureComponent {
   render() {
     const {
@@ -84,6 +135,7 @@ export class ContentWrapper extends React.PureComponent {
         {showToc && headings && headings.length > 0 && (
           <OnThisPage headings={headings} themeWrapper="mb24-mxl mb18" />
         )}
+        <SignupBanner />
         {showFeedback && (
           <div className="none block-mxl">{this.renderFeedback()}</div>
         )}
@@ -154,6 +206,7 @@ export class ContentWrapper extends React.PureComponent {
                   'block none-mxl': layout !== 'full' // hide feedback at bottom of page on larger screens unless layout is full (always show it on the bottom)
                 })}
               >
+                <SignupBanner />
                 {this.renderFeedback()}
               </div>
             )}


### PR DESCRIPTION
Adds a call to action to Sign Up to `PageLayout`, visible when the user is signed out.  It is displayed in the sidebar on large screens.  On smaller screens it is shown BOTH below the page index AND after the content.

## How to test

Run dr-ui locally and inspect the `PageLayout` examples.  Change viewport width to see the two different display modes.

## QA checklist

<!-- Complete this checklist when adding a new component or package. -->

- [x] No errors logged to console.
- [ ] Accessibility score in [Chrome DevTools Audit/Lighthouse](https://developers.google.com/web/tools/lighthouse#devtools) is 100% with Lighthouse version: `#.#.#`.
- [x] Component is accessible at mobile-size viewport.
- [x] Component is accessible at tablet-size viewport.
- [x] Component is accessible at laptop-size viewport.
- [x] Component is accessible at big-monitor-size viewport.

Open the test cases app locally on:

- [x] Chrome, no errors logged to console.
- [ ] Firefox, no errors logged to console.
- [ ] Safari, no errors logged to console.
- [ ] Edge, no errors logged to console.
- [ ] Mobile Safari, no errors logged to console.
- [ ] Android Chrome, no errors logged to console.

## Before merge

- [x] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
