### PR TITLE
improve search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.1.7
 
 - Move CI from TravisCI to CircleCI (as we can no longer install private npm packages on public repos with travisCI)
+- Improve Search by lowering the debounce timout, removing loading spinners, styling highlighted words in the search results, and some other styling tweaks
 
 ## 5.1.6
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8773,13 +8773,19 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001271",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz",
-      "integrity": "sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001441",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz",
+      "integrity": "sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -36074,9 +36080,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001271",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz",
-      "integrity": "sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA=="
+      "version": "1.0.30001441",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz",
+      "integrity": "sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -150,7 +150,7 @@ export class SearchBox extends React.PureComponent {
     }
     function handleInputChange(newValue) {
       if (searchTerm === newValue) return;
-      setSearchTerm(newValue, { debounce: 1500 });
+      setSearchTerm(newValue, { debounce: 200 });
       // track query
       if (window && window.analytics) {
         analytics.track(segmentTrackEvent, {
@@ -192,11 +192,6 @@ export class SearchBox extends React.PureComponent {
               )}
               {(isOpen || resultsOnly) && searchTerm && (
                 <React.Fragment>
-                  {isLoading && (
-                    <div className="w-full h360 bg-lighten75 absolute z5">
-                      <div className="loading mx-auto mt60" />
-                    </div>
-                  )}
                   <div
                     className={classnames(
                       'color-text round mt3 bg-white w-full align-l',
@@ -370,14 +365,8 @@ SearchButton.propTypes = {
 
 export class SearchInput extends React.PureComponent {
   render() {
-    const {
-      placeholder,
-      getLabelProps,
-      useModal,
-      getInputProps,
-      autoFocus,
-      isLoading
-    } = this.props;
+    const { placeholder, getLabelProps, useModal, getInputProps, autoFocus } =
+      this.props;
     const labelProps = {
       ...(getLabelProps && getLabelProps())
     };
@@ -386,7 +375,7 @@ export class SearchInput extends React.PureComponent {
     };
     return (
       <>
-        <label className="cursor-pointer" {...labelProps}>
+        <label className="cursor-pointer" {...labelProps} htmlFor="searchInput">
           <div
             className={classnames(
               'absolute flex flex--center-cross flex--center-main',
@@ -406,26 +395,19 @@ export class SearchInput extends React.PureComponent {
               <use xlinkHref="#icon-search" />
             </svg>
           </div>
-          {isLoading && (
-            <div
-              className={classnames(
-                'loading w24 h24 absolute top right bg-white z5',
-                {
-                  'mt6 mr18': !useModal,
-                  'mt18 mr24': useModal
-                }
-              )}
-            />
-          )}
         </label>
         <input
+          id="searchInput"
           autoFocus={autoFocus}
           placeholder={placeholder}
-          className={classnames('input bg-white txt-color', {
-            'px60 h60 txt-l': useModal,
+          className={classnames('input bg-white txt-color shadow-darken25', {
+            'px60 h60': useModal,
             'px36 h36': !useModal
           })}
           {...inputProps}
+          style={{
+            boxShadow: 'none'
+          }}
         />
       </>
     );

--- a/src/components/search/search-modal.js
+++ b/src/components/search/search-modal.js
@@ -63,9 +63,11 @@ export default class Modal extends React.PureComponent {
       titleText: props.accessibleTitle,
       getApplicationNode: props.getApplicationNode,
       underlayProps: { 'data-popover-ignore-clicks': true },
-      underlayClass: 'bg-darken50 px12 py12 px60-mm py60-mm ',
+      underlayClass: 'px12 py12 px60-mm py60-mm ',
       underlayStyle: {
-        zIndex: 4
+        zIndex: 4,
+        backdropFilter: 'blur(4px)',
+        backgroundColor: 'rgba(0,0,0,.2)'
       }
     };
 

--- a/src/components/search/search-result.js
+++ b/src/components/search/search-result.js
@@ -43,7 +43,7 @@ class SearchResult extends React.PureComponent {
       >
         {title && url && (
           <div className="block link--gray">
-            <div className="mb3">
+            <div className="mb3 txt-s">
               <span className="txt-bold">
                 {resultTitle.map((t, index) => {
                   return (
@@ -58,7 +58,26 @@ class SearchResult extends React.PureComponent {
               </span>
             </div>
 
-            <div className="mb6">{ReactHtmlParser(excerpt)}</div>
+            <div className="mb6 txt-ms">
+              {ReactHtmlParser(excerpt, {
+                transform: (node, i) => {
+                  if (node.name === 'em') {
+                    return (
+                      <em
+                        key={i}
+                        className="txt-bold"
+                        style={{
+                          color: '#4264fb'
+                        }}
+                      >
+                        {' '}
+                        {node.children[0].data}
+                      </em>
+                    );
+                  }
+                }
+              })}
+            </div>
 
             <div className="txt-s">
               {type ? (


### PR DESCRIPTION
Improves the UX and styling of the search modal and search results pane.

- When the search modal is opened, uses `backdrop-filter` to blur the background instead of graying it out
- Removes loading spinner from search box and results pane (an overlay shown on loading was causing an unsightly flash
- Lowers debounce for the API call to Swifttype from `1500` to `200`, eliminating a lengthy delay for the user
- Removes a default `box-shadow` on the text input which was causing the input to appear as a few pixels less wide than the results pane... now both have the same box-shadow
- Styling updates: text in the input and the results are smaller, highlighted words appear in bold, underlined, and a different color


<img width="1307" alt="Test_cases" src="https://user-images.githubusercontent.com/1833820/208567322-f44f9a65-9572-4108-91b8-b96441739988.png">


## How to test

Run `dr-ui` locally, use the search component to try out some search strings.  Expect highlighted words in the results to be blue, expect results to update without seeing a loading spinner.  

## Before merge

- [x] Add entry to CHANGELOG.md to describe changes.
- [ ] If updating dependencies or creating a release, run `npx browserslist@latest --update-db` to update the [browser data](https://github.com/browserslist/browserslist#browsers-data-updating) and commit any changes to package-lock.json.
