### PR TITLE
External link cards

### DIFF
--- a/src/components/card-container/__tests__/__snapshots__/card-container.test.js.snap
+++ b/src/components/card-container/__tests__/__snapshots__/card-container.test.js.snap
@@ -49,9 +49,10 @@ exports[`card-container Basic renders as expected 1`] = `
         </div>
         <div>
           <div
-            className="mb6"
+            className="mb6 flex flex--center-cross"
           >
             Example one
+             
           </div>
           <div
             className="color-gray color-gray-on-hover"
@@ -84,9 +85,10 @@ exports[`card-container Basic renders as expected 1`] = `
         </div>
         <div>
           <div
-            className="mb6"
+            className="mb6 flex flex--center-cross"
           >
             Example two
+             
           </div>
           <div
             className="color-gray color-gray-on-hover"
@@ -135,9 +137,10 @@ exports[`card-container Full width renders as expected 1`] = `
       >
         <div>
           <div
-            className="mb6"
+            className="mb6 flex flex--center-cross"
           >
             Example one
+             
           </div>
           <div
             className="color-gray color-gray-on-hover"
@@ -156,9 +159,10 @@ exports[`card-container Full width renders as expected 1`] = `
       >
         <div>
           <div
-            className="mb6"
+            className="mb6 flex flex--center-cross"
           >
             Example two
+             
           </div>
           <div
             className="color-gray color-gray-on-hover"
@@ -221,9 +225,10 @@ exports[`card-container Use cardColSize renders as expected 1`] = `
         </div>
         <div>
           <div
-            className="mb6"
+            className="mb6 flex flex--center-cross"
           >
             Example one
+             
           </div>
           <div
             className="color-gray color-gray-on-hover"
@@ -256,9 +261,10 @@ exports[`card-container Use cardColSize renders as expected 1`] = `
         </div>
         <div>
           <div
-            className="mb6"
+            className="mb6 flex flex--center-cross"
           >
             Example two
+             
           </div>
           <div
             className="color-gray color-gray-on-hover"
@@ -291,9 +297,10 @@ exports[`card-container Use cardColSize renders as expected 1`] = `
         </div>
         <div>
           <div
-            className="mb6"
+            className="mb6 flex flex--center-cross"
           >
             Example one
+             
           </div>
           <div
             className="color-gray color-gray-on-hover"
@@ -326,9 +333,10 @@ exports[`card-container Use cardColSize renders as expected 1`] = `
         </div>
         <div>
           <div
-            className="mb6"
+            className="mb6 flex flex--center-cross"
           >
             Example two
+             
           </div>
           <div
             className="color-gray color-gray-on-hover"

--- a/src/components/card/__tests__/__snapshots__/card.test.js.snap
+++ b/src/components/card/__tests__/__snapshots__/card.test.js.snap
@@ -92,9 +92,10 @@ exports[`card Card with image renders as expected 1`] = `
       </span>
     </div>
     <div
-      className="mb6"
+      className="mb6 flex flex--center-cross"
     >
       My cool card
+       
     </div>
     <div
       className="color-gray color-gray-on-hover"
@@ -183,9 +184,10 @@ exports[`card Card with no image renders as expected 1`] = `
       </span>
     </div>
     <div
-      className="mb6"
+      className="mb6 flex flex--center-cross"
     >
       My cool card
+       
     </div>
     <div
       className="color-gray color-gray-on-hover"
@@ -288,9 +290,10 @@ exports[`card Card without description renders as expected 1`] = `
       </span>
     </div>
     <div
-      className="mb6"
+      className="mb6 flex flex--center-cross"
     >
       My cool card without a description
+       
     </div>
   </div>
 </a>

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -6,7 +6,8 @@ import LevelIndicator from '../level-indicator/level-indicator';
 
 class Card extends React.PureComponent {
   render() {
-    const { thumbnail, level, language, description, path, title } = this.props;
+    const { thumbnail, level, language, description, path, link, title } =
+      this.props;
     const renderedThumbnail = thumbnail && (
       <div className="relative h120 mb6">{thumbnail}</div>
     );
@@ -19,10 +20,20 @@ class Card extends React.PureComponent {
       <IconText iconBefore="code">{language}</IconText>
     );
 
+    let externalLinkAttributes;
+
+    if (link) {
+      externalLinkAttributes = {
+        target: '_blank',
+        rel: 'nooopener noreferrer'
+      };
+    }
+
     return (
       <a
         className="dr-ui--card color-gray-dark transition color-blue-on-hover round clip inline-block w-full unprose pb18"
-        href={path}
+        href={link || path}
+        {...externalLinkAttributes}
       >
         {renderedThumbnail}
         <div>
@@ -32,7 +43,14 @@ class Card extends React.PureComponent {
               {renderedLanguage}
             </div>
           )}
-          <div className="mb6">{title}</div>
+          <div className="mb6 flex flex--center-cross">
+            {title}{' '}
+            {link && (
+              <svg className="icon ml3 mt3">
+                <use xlinkHref="#icon-share" />
+              </svg>
+            )}
+          </div>
           {description && (
             <div className="color-gray color-gray-on-hover">{description}</div>
           )}
@@ -48,7 +66,8 @@ Card.propTypes = {
   description: PropTypes.string,
   thumbnail: PropTypes.node,
   level: PropTypes.node,
-  language: PropTypes.string
+  language: PropTypes.string,
+  link: PropTypes.string
 };
 
 export default Card;

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -449,9 +449,10 @@ Array [
                           </span>
                         </div>
                         <div
-                          className="mb6"
+                          className="mb6 flex flex--center-cross"
                         >
                           Display a map
+                           
                         </div>
                         <div
                           className="color-gray color-gray-on-hover"
@@ -506,9 +507,10 @@ Array [
                           </span>
                         </div>
                         <div
-                          className="mb6"
+                          className="mb6 flex flex--center-cross"
                         >
                           Add a default marker
+                           
                         </div>
                         <div
                           className="color-gray color-gray-on-hover"
@@ -563,9 +565,10 @@ Array [
                           </span>
                         </div>
                         <div
-                          className="mb6"
+                          className="mb6 flex flex--center-cross"
                         >
                           Extrude polygons for 3D indoor mapping
+                           
                         </div>
                         <div
                           className="color-gray color-gray-on-hover"
@@ -2196,9 +2199,10 @@ Array [
                     >
                       <div>
                         <div
-                          className="mb6"
+                          className="mb6 flex flex--center-cross"
                         >
                           Web maps using older library versions
+                           
                         </div>
                         <div
                           className="color-gray color-gray-on-hover"
@@ -2217,9 +2221,10 @@ Array [
                     >
                       <div>
                         <div
-                          className="mb6"
+                          className="mb6 flex flex--center-cross"
                         >
                           Mobile applications using older SDK versions
+                           
                         </div>
                         <div
                           className="color-gray color-gray-on-hover"
@@ -2238,9 +2243,10 @@ Array [
                     >
                       <div>
                         <div
-                          className="mb6"
+                          className="mb6 flex flex--center-cross"
                         >
                           Data sources
+                           
                         </div>
                         <div
                           className="color-gray color-gray-on-hover"

--- a/src/components/page-layout/components/content.js
+++ b/src/components/page-layout/components/content.js
@@ -36,7 +36,7 @@ class SignupBanner extends React.PureComponent {
     const { background, color } = themes['default'];
     return (
       <div
-        className={`dr-ui--signup-banner py18 px18 round flex mb18 ${background} ${color}`}
+        className={`dr-ui--signup-banner py18 px18 round flex mt18 mb18 ${background} ${color}`}
       >
         <div className="w-full prose flex flex--column-mxl">
           <div className="flex-child-grow">

--- a/src/components/page-layout/components/example-index.js
+++ b/src/components/page-layout/components/example-index.js
@@ -366,6 +366,7 @@ export default class ExampleIndex extends React.PureComponent {
                     ? page.language.join(', ')
                     : undefined
                 }
+                link={page.link}
               />
             ))}
           />


### PR DESCRIPTION
Adds `link` prop to `Card` used in example listings.  This adds `target` attributes to the `a` tag used on the cards, and turns them into external links when clicked (versus navigating to a page on the docs site).

Also adds an external link icon next to the title

Once merged we can cut a new version 5.1.8.

<img width="682" alt="image" src="https://user-images.githubusercontent.com/1833820/212123156-1ada1094-9ed8-476b-bf75-488ce8aed7cc.png">
