### PR TITLE
fix search modal appearing on page navigation

### DIFF
--- a/src/components/search/search-box.js
+++ b/src/components/search/search-box.js
@@ -14,7 +14,9 @@ export class SearchBox extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      modalOpen: true // open model for a smooth transition from the facade
+      // there is a new instance of SearchBox every time SearchProvider renders,
+      // this lets us control whether the modal should appear on first render
+      modalOpen: props.initialModalOpen
     };
     this.docsSeachInput = React.createRef;
     this.openModal = this.openModal.bind(this);
@@ -285,6 +287,10 @@ export class SearchBox extends React.PureComponent {
   }
 }
 
+SearchBox.defaultProps = {
+  initialModalOpen: false
+};
+
 SearchBox.propTypes = {
   searchTerm: PropTypes.string,
   trackClickThrough: PropTypes.func,
@@ -303,7 +309,8 @@ SearchBox.propTypes = {
   overrideSearchTerm: PropTypes.string,
   themeCompact: PropTypes.bool,
   emptyResultMessage: PropTypes.node,
-  useModal: PropTypes.bool.isRequired
+  useModal: PropTypes.bool.isRequired,
+  initialModalOpen: PropTypes.bool
 };
 
 export class SearchButton extends React.PureComponent {

--- a/src/components/search/search-provider.js
+++ b/src/components/search/search-provider.js
@@ -4,8 +4,22 @@ import { SearchProvider, WithSearch } from '@elastic/react-search-ui';
 import { SearchBox } from './search-box';
 
 class Search extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      firstRender: true // used to trigger the search modal only on the first click of SearchFacade
+    };
+  }
+
+  componentWillReceiveProps() {
+    this.setState({
+      firstRender: false
+    });
+  }
+
   render() {
     const { connector, resultsOnly, useModal } = this.props;
+    const { firstRender } = this.state;
 
     function handleMapContext({
       isLoading,
@@ -63,6 +77,7 @@ class Search extends React.PureComponent {
                 reset={reset}
                 {...this.props}
                 useModal={useModal && !resultsOnly} // disable modal if resultsOnly === true
+                initialModalOpen={firstRender}
               />
             );
           }}


### PR DESCRIPTION
Fixes a bug where the search modal would open on page navigation after it had already been loaded and dismissed once.

https://mapbox.atlassian.net/jira/software/c/projects/MARKETING/boards/254?modal=detail&selectedIssue=MARKETING-1627