### PR TITLE
upgrade 5.1.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/dr-ui",
-  "version": "5.1.11",
+  "version": "5.1.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/dr-ui",
-      "version": "5.1.11",
+      "version": "5.1.12",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/react-search-ui": "^1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/dr-ui",
-  "version": "5.1.12",
+  "version": "5.1.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/dr-ui",
-      "version": "5.1.12",
+      "version": "5.1.13",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/react-search-ui": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dr-ui",
-  "version": "5.1.11",
+  "version": "5.1.12",
   "description": "Mapbox frontend tools for documentation websites.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dr-ui",
-  "version": "5.1.12",
+  "version": "5.1.13",
   "description": "Mapbox frontend tools for documentation websites.",
   "main": "index.js",
   "scripts": {

--- a/src/helpers/batfish/__tests__/filters.test.js
+++ b/src/helpers/batfish/__tests__/filters.test.js
@@ -145,7 +145,7 @@ describe('generateTopics', () => {
 });
 
 describe('pageSorter', () => {
-  it('works', () => {
+  it('works, level', () => {
     expect(
       pageSorter([
         {
@@ -179,7 +179,41 @@ describe('pageSorter', () => {
     ]);
   });
 
-  it('works, jp', () => {
+  it('works, order', () => {
+    expect(
+      pageSorter([
+        {
+          title: 'Donkey',
+          topic: '3D'
+        },
+        {
+          title: 'Spider Monkey',
+          order: 1
+        },
+        {
+          title: 'Zebra',
+          topic: 'Getting started',
+          order: 3
+        },
+        {
+          title: 'Zedonk',
+          topics: ['Getting started']
+        },
+        {
+          title: 'Giraffe',
+          order: 3
+        }
+      ])
+    ).toEqual([
+      { title: 'Zebra', topic: 'Getting started', order: 3 },
+      { title: 'Zedonk', topics: ['Getting started'] },
+      { order: 1, title: 'Spider Monkey' },
+      { order: 3, title: 'Giraffe' },
+      { title: 'Donkey', topic: '3D' }
+    ]);
+  });
+
+  it('works, level, jp', () => {
     expect(
       pageSorter([
         {
@@ -208,6 +242,39 @@ describe('pageSorter', () => {
       { title: 'Zedonk', topics: ['まず始めに'] },
       { level: 1, title: 'Spider Monkey' },
       { level: 3, title: 'Giraffe' },
+      { title: 'Donkey', topic: 'Webアプリ' }
+    ]);
+  });
+
+  it('works, order, jp', () => {
+    expect(
+      pageSorter([
+        {
+          title: 'Donkey',
+          topic: 'Webアプリ'
+        },
+        {
+          title: 'Spider Monkey',
+          order: 1
+        },
+        {
+          title: 'Zebra',
+          topic: 'まず始めに'
+        },
+        {
+          title: 'Zedonk',
+          topics: ['まず始めに']
+        },
+        {
+          title: 'Giraffe',
+          order: 3
+        }
+      ])
+    ).toEqual([
+      { title: 'Zebra', topic: 'まず始めに' },
+      { title: 'Zedonk', topics: ['まず始めに'] },
+      { order: 1, title: 'Spider Monkey' },
+      { order: 3, title: 'Giraffe' },
       { title: 'Donkey', topic: 'Webアプリ' }
     ]);
   });

--- a/src/helpers/batfish/__tests__/fixtures/data.json
+++ b/src/helpers/batfish/__tests__/fixtures/data.json
@@ -354,6 +354,12 @@
       "frontMatter": {
         "hideFromSearchEngines": true
       }
+    },
+    {
+      "filePath": "./node_modules/@mapbox/batfish/dist/webpack/default-not-found.js",
+      "path": "/dr-ui/404/",
+      "is404": true,
+      "frontMatter": {}
     }
   ]
 }

--- a/src/helpers/batfish/__tests__/fixtures/data.json
+++ b/src/helpers/batfish/__tests__/fixtures/data.json
@@ -354,12 +354,6 @@
       "frontMatter": {
         "hideFromSearchEngines": true
       }
-    },
-    {
-      "filePath": "./node_modules/@mapbox/batfish/dist/webpack/default-not-found.js",
-      "path": "/dr-ui/404/",
-      "is404": true,
-      "frontMatter": {}
     }
   ]
 }

--- a/src/helpers/batfish/filters.js
+++ b/src/helpers/batfish/filters.js
@@ -114,30 +114,23 @@ function pageSorter(pages) {
     (page) => !page.level && !page.order && notGettingStarted(page)
   );
 
-  // If / else prevents 'level' and 'order' from interacting.
+  // sortedByLevelOrder prevents 'level' and 'order' from interacting.
   // DO NOT USE 'level' AND 'order' IN THE SAME FRONTMATTER.
   // If you do, this filter will completely ignore `order`.
+  let sortedByLevelOrOrder = sortBy(withLevel, 'level');
   if (withLevel.length > 0) {
-    return [
-      // add items with topic
-      ...withTopicEn,
-      ...withTopicJp,
-      // add items with level and sort them by level
-      ...sortBy(withLevel, 'level'),
-      // add all other items and sort them alphabetically by title
-      ...sortAlpha(theRest)
-    ];
-  } else {
-    return [
-      // add items with topic
-      ...withTopicEn,
-      ...withTopicJp,
-      // add items with order and sort them by order
-      ...sortBy(withOrder, 'order'),
-      // add all other items and sort them alphabetically by title
-      ...sortAlpha(theRest)
-    ];
+    sortedByLevelOrOrder = sortBy(withOrder, 'order');
   }
+
+  return [
+    // add items with topic
+    ...withTopicEn,
+    ...withTopicJp,
+    // add items sorted by level, or by order if level does not exist in the collection of items
+    ...sortedByLevelOrOrder,
+    // add all other items and sort them alphabetically by title
+    ...sortAlpha(theRest)
+  ];
 }
 
 module.exports = {

--- a/src/helpers/batfish/filters.js
+++ b/src/helpers/batfish/filters.js
@@ -118,7 +118,7 @@ function pageSorter(pages) {
   // DO NOT USE 'level' AND 'order' IN THE SAME FRONTMATTER.
   // If you do, this filter will completely ignore `order`.
   let sortedByLevelOrOrder = sortBy(withLevel, 'level');
-  if (withLevel.length > 0) {
+  if (withLevel.length === 0) {
     sortedByLevelOrOrder = sortBy(withOrder, 'order');
   }
 

--- a/src/helpers/batfish/filters.js
+++ b/src/helpers/batfish/filters.js
@@ -120,8 +120,7 @@ function pageSorter(pages) {
     ...withTopicJp,
     // add items with level and sort them by level
     ...sortBy(withLevel, 'level'),
-    // add items with nonLevelOrder and sort them by order
-    // DON'T USE nonLevelOrder and level at the same time...they don't interact well. :(
+    // add items with order and sort them by order
     ...sortBy(withOrder, 'order'),
     // add all other items and sort them alphabetically by title
     ...sortAlpha(theRest)

--- a/src/helpers/batfish/filters.js
+++ b/src/helpers/batfish/filters.js
@@ -104,16 +104,25 @@ function pageSorter(pages) {
   const withLevel = pages.filter(
     (page) => page.level && notGettingStarted(page)
   );
+
+  const withOrder = pages.filter(
+    (page) => page.order && notGettingStarted(page)
+  );
+
   // exclude withTopic and withLevel values
   const theRest = pages.filter(
-    (page) => !page.level && notGettingStarted(page)
+    (page) => !page.level && !page.order && notGettingStarted(page)
   );
+
   return [
     // add items with topic
     ...withTopicEn,
     ...withTopicJp,
     // add items with level and sort them by level
     ...sortBy(withLevel, 'level'),
+    // add items with nonLevelOrder and sort them by order
+    // DON'T USE nonLevelOrder and level at the same time...they don't interact well. :(
+    ...sortBy(withOrder, 'order'),
     // add all other items and sort them alphabetically by title
     ...sortAlpha(theRest)
   ];

--- a/src/helpers/batfish/filters.js
+++ b/src/helpers/batfish/filters.js
@@ -114,17 +114,30 @@ function pageSorter(pages) {
     (page) => !page.level && !page.order && notGettingStarted(page)
   );
 
-  return [
-    // add items with topic
-    ...withTopicEn,
-    ...withTopicJp,
-    // add items with level and sort them by level
-    ...sortBy(withLevel, 'level'),
-    // add items with order and sort them by order
-    ...sortBy(withOrder, 'order'),
-    // add all other items and sort them alphabetically by title
-    ...sortAlpha(theRest)
-  ];
+  // If / else prevents 'level' and 'order' from interacting.
+  // DO NOT USE 'level' AND 'order' IN THE SAME FRONTMATTER.
+  // If you do, this filter will completely ignore `order`.
+  if (withLevel.length > 0) {
+    return [
+      // add items with topic
+      ...withTopicEn,
+      ...withTopicJp,
+      // add items with level and sort them by level
+      ...sortBy(withLevel, 'level'),
+      // add all other items and sort them alphabetically by title
+      ...sortAlpha(theRest)
+    ];
+  } else {
+    return [
+      // add items with topic
+      ...withTopicEn,
+      ...withTopicJp,
+      // add items with order and sort them by order
+      ...sortBy(withOrder, 'order'),
+      // add all other items and sort them alphabetically by title
+      ...sortAlpha(theRest)
+    ];
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
- use 'order' to order GL JS examples
- 5.1.12
- fix collision between 'order' and 'level'
- 5.1.13
