### PR TITLE
Fix cta layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@elastic/react-search-ui-views": "^1.7.0",
         "@elastic/search-ui-site-search-connector": "^1.7.0",
         "@mapbox/mapbox-gl-supported": "^2.0.0",
-        "@mapbox/mr-ui": "^2.1.4",
+        "@mapbox/mr-ui": "2.4.0",
         "@sentry/browser": "^6.13.3",
         "@sentry/tracing": "^6.13.3",
         "classnames": "^2.3.1",
@@ -5040,9 +5040,9 @@
       }
     },
     "node_modules/@mapbox/mr-ui": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@mapbox/mr-ui/-/mr-ui-2.1.4.tgz",
-      "integrity": "sha512-fBUQOiNP9zSf2R+GsS+iJf5TfFOEK2pGWJcpx9VSTRPDzC3r1V7fet/ZSrgmcl7rG8ha2NGvi4mmHZll8GT50g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mr-ui/-/mr-ui-2.4.0.tgz",
+      "integrity": "sha512-3yzJrQdX76yarfUWjIDVR/blV+0dqF3C5d3+EqA8NvYhoJ3EBDwcKK19mZJ2kEcpb5ke2uTUugnXCnEiDH8hgg==",
       "dependencies": {
         "@mapbox/mbx-assembly": "^1.3.0",
         "@mapbox/query-selector-contains-node": "^1.0.0",
@@ -15944,34 +15944,26 @@
     },
     "node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -15979,17 +15971,13 @@
     },
     "node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -15997,75 +15985,57 @@
     },
     "node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/debug": {
       "version": "3.2.6",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
-      "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -16075,27 +16045,21 @@
     },
     "node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.7",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "minipass": "^2.6.0"
       }
     },
     "node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -16109,10 +16073,8 @@
     },
     "node_modules/fsevents/node_modules/glob": {
       "version": "7.1.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -16130,17 +16092,13 @@
     },
     "node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -16150,20 +16108,16 @@
     },
     "node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "minimatch": "^3.0.4"
       }
     },
     "node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -16171,27 +16125,21 @@
     },
     "node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -16201,17 +16149,13 @@
     },
     "node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -16221,17 +16165,13 @@
     },
     "node_modules/fsevents/node_modules/minimist": {
       "version": "1.2.5",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/minipass": {
       "version": "2.9.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -16239,10 +16179,8 @@
     },
     "node_modules/fsevents/node_modules/minizlib": {
       "version": "1.3.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "minipass": "^2.9.0"
       }
@@ -16250,10 +16188,8 @@
     "node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.3",
       "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -16263,17 +16199,13 @@
     },
     "node_modules/fsevents/node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/needle": {
       "version": "2.3.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -16288,10 +16220,8 @@
     },
     "node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.14.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -16310,10 +16240,8 @@
     },
     "node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -16324,27 +16252,21 @@
     },
     "node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "node_modules/fsevents/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.8",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1",
@@ -16353,10 +16275,8 @@
     },
     "node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -16366,60 +16286,48 @@
     },
     "node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -16427,27 +16335,21 @@
     },
     "node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
-      "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -16460,10 +16362,8 @@
     },
     "node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.7",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -16476,10 +16376,8 @@
     },
     "node_modules/fsevents/node_modules/rimraf": {
       "version": "2.7.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -16489,65 +16387,49 @@
     },
     "node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/semver": {
       "version": "5.7.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -16559,10 +16441,8 @@
     },
     "node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -16572,20 +16452,16 @@
     },
     "node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/tar": {
       "version": "4.4.13",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -16601,34 +16477,26 @@
     },
     "node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
       }
     },
     "node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/yallist": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -34976,9 +34844,9 @@
       }
     },
     "@mapbox/mr-ui": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@mapbox/mr-ui/-/mr-ui-2.1.4.tgz",
-      "integrity": "sha512-fBUQOiNP9zSf2R+GsS+iJf5TfFOEK2pGWJcpx9VSTRPDzC3r1V7fet/ZSrgmcl7rG8ha2NGvi4mmHZll8GT50g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mr-ui/-/mr-ui-2.4.0.tgz",
+      "integrity": "sha512-3yzJrQdX76yarfUWjIDVR/blV+0dqF3C5d3+EqA8NvYhoJ3EBDwcKK19mZJ2kEcpb5ke2uTUugnXCnEiDH8hgg==",
       "requires": {
         "@mapbox/mbx-assembly": "^1.3.0",
         "@mapbox/query-selector-contains-node": "^1.0.0",
@@ -43457,27 +43325,19 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -43485,15 +43345,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -43501,81 +43357,57 @@
         },
         "chownr": {
           "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "debug": {
           "version": "3.2.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "fs-minipass": {
           "version": "1.2.7",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -43590,8 +43422,6 @@
         "glob": {
           "version": "7.1.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -43603,15 +43433,11 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "iconv-lite": {
           "version": "0.4.24",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -43619,8 +43445,6 @@
         "ignore-walk": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
@@ -43628,8 +43452,6 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -43637,51 +43459,37 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -43690,8 +43498,6 @@
         "minizlib": {
           "version": "1.3.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "minipass": "^2.9.0"
           }
@@ -43699,23 +43505,17 @@
         "mkdirp": {
           "version": "0.5.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
         },
         "ms": {
           "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "needle": {
           "version": "2.3.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
@@ -43725,8 +43525,6 @@
         "node-pre-gyp": {
           "version": "0.14.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
@@ -43743,8 +43541,6 @@
         "nopt": {
           "version": "4.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -43753,23 +43549,17 @@
         "npm-bundled": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "npm-packlist": {
           "version": "1.4.8",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1",
@@ -43779,8 +43569,6 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -43790,42 +43578,30 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -43833,21 +43609,15 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -43858,8 +43628,6 @@
         "readable-stream": {
           "version": "2.3.7",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -43873,53 +43641,37 @@
         "rimraf": {
           "version": "2.7.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "semver": {
           "version": "5.7.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -43927,8 +43679,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -43938,23 +43688,17 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "tar": {
           "version": "4.4.13",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -43967,30 +43711,22 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "wide-align": {
           "version": "1.1.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@elastic/react-search-ui-views": "^1.7.0",
     "@elastic/search-ui-site-search-connector": "^1.7.0",
     "@mapbox/mapbox-gl-supported": "^2.0.0",
-    "@mapbox/mr-ui": "^2.1.4",
+    "@mapbox/mr-ui": "2.4.0",
     "@sentry/browser": "^6.13.3",
     "@sentry/tracing": "^6.13.3",
     "classnames": "^2.3.1",

--- a/src/components/back-to-top-button/__tests__/__snapshots__/back-to-top-button.test.js.snap
+++ b/src/components/back-to-top-button/__tests__/__snapshots__/back-to-top-button.test.js.snap
@@ -5,7 +5,7 @@ exports[`back-top-top-button Just the button renders as expected 1`] = `
   className="mx24 my24 z5"
 >
   <button
-    ariaLabel="Back to top"
+    aria-label="Back to top"
     className="btn btn--blue w60 h60 round-full shadow-darken25 flex flex--center-main flex--center-cross"
     data-state="closed"
     onBlur={[Function]}

--- a/src/components/back-to-top-button/back-to-top-button.js
+++ b/src/components/back-to-top-button/back-to-top-button.js
@@ -16,7 +16,7 @@ export default class BackToTopButton extends React.PureComponent {
           <button
             onClick={handleClick}
             className="btn btn--blue w60 h60 round-full shadow-darken25 flex flex--center-main flex--center-cross"
-            ariaLabel="Back to top"
+            aria-label="Back to top"
           >
             <Icon name="arrow-up" size={30} />
           </button>

--- a/src/components/card/__tests__/__snapshots__/card.test.js.snap
+++ b/src/components/card/__tests__/__snapshots__/card.test.js.snap
@@ -105,9 +105,7 @@ exports[`card Card with image renders as expected 1`] = `
             code
           </span>
         </span>
-        <span>
-          JavaScript
-        </span>
+        JavaScript
       </span>
     </div>
     <div
@@ -216,9 +214,7 @@ exports[`card Card with no image renders as expected 1`] = `
             code
           </span>
         </span>
-        <span>
-          JavaScript
-        </span>
+        JavaScript
       </span>
     </div>
     <div
@@ -341,9 +337,7 @@ exports[`card Card without description renders as expected 1`] = `
             code
           </span>
         </span>
-        <span>
-          JavaScript
-        </span>
+        JavaScript
       </span>
     </div>
     <div

--- a/src/components/download-button/__tests__/__snapshots__/download-button.test.js.snap
+++ b/src/components/download-button/__tests__/__snapshots__/download-button.test.js.snap
@@ -49,9 +49,7 @@ exports[`DownloadButton Default DownloadButton renders as expected 1`] = `
         arrow-down
       </span>
     </span>
-    <span>
-      Download CSV
-    </span>
+    Download CSV
   </span>
 </a>
 `;
@@ -105,9 +103,7 @@ exports[`DownloadButton DownloadButton for PNG renders as expected 1`] = `
         arrow-down
       </span>
     </span>
-    <span>
-      Download PNG
-    </span>
+    Download PNG
   </span>
 </a>
 `;
@@ -161,9 +157,7 @@ exports[`DownloadButton DownloadButton with optional text renders as expected 1`
         arrow-down
       </span>
     </span>
-    <span>
-      Download for iOS
-    </span>
+    Download for iOS
   </span>
 </a>
 `;
@@ -220,9 +214,7 @@ exports[`DownloadButton DownloadButton with prose class renders as expected 1`] 
           arrow-down
         </span>
       </span>
-      <span>
-        Download PNG
-      </span>
+      Download PNG
     </span>
   </a>
 </div>

--- a/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
+++ b/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
@@ -448,9 +448,7 @@ exports[`overview-header All, plus Contact Us button renders as expected 1`] = `
                 github
               </span>
             </span>
-            <span>
-              Contribute on GitHub
-            </span>
+            Contribute on GitHub
           </span>
         </a>
       </div>
@@ -706,9 +704,7 @@ exports[`overview-header Basic renders as expected 1`] = `
                 github
               </span>
             </span>
-            <span>
-              Contribute on GitHub
-            </span>
+            Contribute on GitHub
           </span>
         </a>
       </div>
@@ -1430,9 +1426,7 @@ exports[`overview-header Some optional props renders as expected 1`] = `
                 github
               </span>
             </span>
-            <span>
-              Contribute on GitHub
-            </span>
+            Contribute on GitHub
           </span>
         </a>
       </div>

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -626,9 +626,7 @@ Array [
                                 code
                               </span>
                             </span>
-                            <span>
-                              JavaScript
-                            </span>
+                            JavaScript
                           </span>
                         </div>
                         <div
@@ -703,9 +701,7 @@ Array [
                                 code
                               </span>
                             </span>
-                            <span>
-                              JavaScript
-                            </span>
+                            JavaScript
                           </span>
                         </div>
                         <div
@@ -780,9 +776,7 @@ Array [
                                 code
                               </span>
                             </span>
-                            <span>
-                              JavaScript
-                            </span>
+                            JavaScript
                           </span>
                         </div>
                         <div
@@ -814,7 +808,7 @@ Array [
       className="mx24 my24 z5"
     >
       <button
-        ariaLabel="Back to top"
+        aria-label="Back to top"
         className="btn btn--blue w60 h60 round-full shadow-darken25 flex flex--center-main flex--center-cross"
         data-state="closed"
         onBlur={[Function]}
@@ -1485,7 +1479,7 @@ Array [
       className="mx24 my24 z5"
     >
       <button
-        ariaLabel="Back to top"
+        aria-label="Back to top"
         className="btn btn--blue w60 h60 round-full shadow-darken25 flex flex--center-main flex--center-cross"
         data-state="closed"
         onBlur={[Function]}
@@ -1825,7 +1819,7 @@ Array [
       className="mx24 my24 z5"
     >
       <button
-        ariaLabel="Back to top"
+        aria-label="Back to top"
         className="btn btn--blue w60 h60 round-full shadow-darken25 flex flex--center-main flex--center-cross"
         data-state="closed"
         onBlur={[Function]}
@@ -2696,7 +2690,7 @@ Array [
       className="mx24 my24 z5"
     >
       <button
-        ariaLabel="Back to top"
+        aria-label="Back to top"
         className="btn btn--blue w60 h60 round-full shadow-darken25 flex flex--center-main flex--center-cross"
         data-state="closed"
         onBlur={[Function]}
@@ -3501,7 +3495,7 @@ Array [
       className="mx24 my24 z5"
     >
       <button
-        ariaLabel="Back to top"
+        aria-label="Back to top"
         className="btn btn--blue w60 h60 round-full shadow-darken25 flex flex--center-main flex--center-cross"
         data-state="closed"
         onBlur={[Function]}
@@ -3969,7 +3963,7 @@ Array [
       className="mx24 my24 z5"
     >
       <button
-        ariaLabel="Back to top"
+        aria-label="Back to top"
         className="btn btn--blue w60 h60 round-full shadow-darken25 flex flex--center-main flex--center-cross"
         data-state="closed"
         onBlur={[Function]}

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -1380,84 +1380,95 @@ Array [
               <div
                 className="my36 color-text block none-mxl"
               >
-                <a
-                  className="dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
-                  href="https://discord.gg/uMpcC5RmJh"
-                  rel="noopener noreferrer"
-                  style={
-                    Object {
-                      "backgroundColor": "#ECF1FD",
-                    }
-                  }
-                  target="_blank"
+                <div
+                  className="flex mx-neg12"
                 >
                   <div
-                    className="mt6 mr18"
-                  >
-                    <svg
-                      fill="none"
-                      height="46"
-                      viewBox="0 0 44 46"
-                      width="44"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M0 3.68C0 1.64759 1.64162 0 3.66667 0H40.3333C42.3584 0 44 1.64759 44 3.68V46C40.1176 44.2642 36.6667 42.5283 32.7843 37.3208L34.8265 42.1145C35.0851 42.7215 34.6414 43.3962 33.9837 43.3962H3.66667C1.64162 43.3962 0 41.7486 0 39.7162V3.68Z"
-                        fill="#4164FB"
-                      />
-                      <path
-                        d="M31.5451 11.9554C29.765 11.098 27.8616 10.4748 25.8717 10.12C25.6273 10.5749 25.3417 11.1867 25.1449 11.6734C23.0295 11.3459 20.9336 11.3459 18.8572 11.6734C18.6603 11.1867 18.3683 10.5749 18.1218 10.12C16.1297 10.4748 14.2241 11.1003 12.444 11.96C8.85345 17.5457 7.88011 22.9927 8.36678 28.3624C10.7482 30.1932 13.0561 31.3054 15.325 32.0332C15.8852 31.2394 16.3849 30.3956 16.8153 29.5064C15.9956 29.1857 15.2104 28.79 14.4685 28.3306C14.6653 28.1804 14.8579 28.0235 15.0439 27.862C19.5688 30.0408 24.4852 30.0408 28.9561 27.862C29.1442 28.0235 29.3367 28.1804 29.5314 28.3306C28.7873 28.7922 28 29.1879 27.1803 29.5087C27.6107 30.3956 28.1082 31.2417 28.6705 32.0354C30.9417 31.3076 33.2517 30.1955 35.6331 28.3624C36.2042 22.1376 34.6576 16.7406 31.5451 11.9554ZM17.4318 25.0601C16.0734 25.0601 14.9595 23.7546 14.9595 22.1648C14.9595 20.5751 16.0496 19.2674 17.4318 19.2674C18.8139 19.2674 19.9278 20.5728 19.904 22.1648C19.9062 23.7546 18.8139 25.0601 17.4318 25.0601ZM26.5681 25.0601C25.2098 25.0601 24.0959 23.7546 24.0959 22.1648C24.0959 20.5751 25.186 19.2674 26.5681 19.2674C27.9503 19.2674 29.0642 20.5728 29.0404 22.1648C29.0404 23.7546 27.9503 25.0601 26.5681 25.0601Z"
-                        fill="white"
-                      />
-                    </svg>
-                  </div>
+                    className="w-1/2 px6"
+                  />
                   <div
-                    className="flex-child-grow"
+                    className="w-1/2 px6"
                   >
-                    <span>
-                      Join the Mapbox Developers Discord Community
-                      <span
-                        className="ml6"
+                    <a
+                      className="dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
+                      href="https://discord.gg/uMpcC5RmJh"
+                      rel="noopener noreferrer"
+                      style={
+                        Object {
+                          "backgroundColor": "#ECF1FD",
+                        }
+                      }
+                      target="_blank"
+                    >
+                      <div
+                        className="mt6 mr18"
                       >
                         <svg
-                          aria-hidden="true"
-                          className="events-none icon inline-block align-t"
-                          data-testid="icon-arrow-right"
-                          focusable="false"
-                          style={
-                            Object {
-                              "height": 18,
-                              "width": 18,
-                            }
-                          }
+                          fill="none"
+                          height="46"
+                          viewBox="0 0 44 46"
+                          width="44"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <use
-                            xlinkHref="#icon-arrow-right"
-                            xmlnsXlink="http://www.w3.org/1999/xlink"
+                          <path
+                            d="M0 3.68C0 1.64759 1.64162 0 3.66667 0H40.3333C42.3584 0 44 1.64759 44 3.68V46C40.1176 44.2642 36.6667 42.5283 32.7843 37.3208L34.8265 42.1145C35.0851 42.7215 34.6414 43.3962 33.9837 43.3962H3.66667C1.64162 43.3962 0 41.7486 0 39.7162V3.68Z"
+                            fill="#4164FB"
+                          />
+                          <path
+                            d="M31.5451 11.9554C29.765 11.098 27.8616 10.4748 25.8717 10.12C25.6273 10.5749 25.3417 11.1867 25.1449 11.6734C23.0295 11.3459 20.9336 11.3459 18.8572 11.6734C18.6603 11.1867 18.3683 10.5749 18.1218 10.12C16.1297 10.4748 14.2241 11.1003 12.444 11.96C8.85345 17.5457 7.88011 22.9927 8.36678 28.3624C10.7482 30.1932 13.0561 31.3054 15.325 32.0332C15.8852 31.2394 16.3849 30.3956 16.8153 29.5064C15.9956 29.1857 15.2104 28.79 14.4685 28.3306C14.6653 28.1804 14.8579 28.0235 15.0439 27.862C19.5688 30.0408 24.4852 30.0408 28.9561 27.862C29.1442 28.0235 29.3367 28.1804 29.5314 28.3306C28.7873 28.7922 28 29.1879 27.1803 29.5087C27.6107 30.3956 28.1082 31.2417 28.6705 32.0354C30.9417 31.3076 33.2517 30.1955 35.6331 28.3624C36.2042 22.1376 34.6576 16.7406 31.5451 11.9554ZM17.4318 25.0601C16.0734 25.0601 14.9595 23.7546 14.9595 22.1648C14.9595 20.5751 16.0496 19.2674 17.4318 19.2674C18.8139 19.2674 19.9278 20.5728 19.904 22.1648C19.9062 23.7546 18.8139 25.0601 17.4318 25.0601ZM26.5681 25.0601C25.2098 25.0601 24.0959 23.7546 24.0959 22.1648C24.0959 20.5751 25.186 19.2674 26.5681 19.2674C27.9503 19.2674 29.0642 20.5728 29.0404 22.1648C29.0404 23.7546 27.9503 25.0601 26.5681 25.0601Z"
+                            fill="white"
                           />
                         </svg>
-                        <span
-                          style={
-                            Object {
-                              "border": 0,
-                              "clip": "rect(0, 0, 0, 0)",
-                              "height": 1,
-                              "margin": -1,
-                              "overflow": "hidden",
-                              "padding": 0,
-                              "position": "absolute",
-                              "whiteSpace": "nowrap",
-                              "width": 1,
-                              "wordWrap": "normal",
-                            }
-                          }
-                        >
-                          arrow-right
+                      </div>
+                      <div
+                        className="flex-child-grow"
+                      >
+                        <span>
+                          Join the Mapbox Developers Discord Community
+                          <span
+                            className="ml6"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              className="events-none icon inline-block align-t"
+                              data-testid="icon-arrow-right"
+                              focusable="false"
+                              style={
+                                Object {
+                                  "height": 18,
+                                  "width": 18,
+                                }
+                              }
+                            >
+                              <use
+                                xlinkHref="#icon-arrow-right"
+                                xmlnsXlink="http://www.w3.org/1999/xlink"
+                              />
+                            </svg>
+                            <span
+                              style={
+                                Object {
+                                  "border": 0,
+                                  "clip": "rect(0, 0, 0, 0)",
+                                  "height": 1,
+                                  "margin": -1,
+                                  "overflow": "hidden",
+                                  "padding": 0,
+                                  "position": "absolute",
+                                  "whiteSpace": "nowrap",
+                                  "width": 1,
+                                  "wordWrap": "normal",
+                                }
+                              }
+                            >
+                              arrow-right
+                            </span>
+                          </span>
                         </span>
-                      </span>
-                    </span>
+                      </div>
+                    </a>
                   </div>
-                </a>
+                </div>
                 <button
                   className="btn btn--gray btn--stroke"
                   onClick={[Function]}
@@ -1720,84 +1731,95 @@ Array [
               <div
                 className="my36 color-text"
               >
-                <a
-                  className="dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
-                  href="https://discord.gg/uMpcC5RmJh"
-                  rel="noopener noreferrer"
-                  style={
-                    Object {
-                      "backgroundColor": "#ECF1FD",
-                    }
-                  }
-                  target="_blank"
+                <div
+                  className="flex mx-neg12"
                 >
                   <div
-                    className="mt6 mr18"
-                  >
-                    <svg
-                      fill="none"
-                      height="46"
-                      viewBox="0 0 44 46"
-                      width="44"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M0 3.68C0 1.64759 1.64162 0 3.66667 0H40.3333C42.3584 0 44 1.64759 44 3.68V46C40.1176 44.2642 36.6667 42.5283 32.7843 37.3208L34.8265 42.1145C35.0851 42.7215 34.6414 43.3962 33.9837 43.3962H3.66667C1.64162 43.3962 0 41.7486 0 39.7162V3.68Z"
-                        fill="#4164FB"
-                      />
-                      <path
-                        d="M31.5451 11.9554C29.765 11.098 27.8616 10.4748 25.8717 10.12C25.6273 10.5749 25.3417 11.1867 25.1449 11.6734C23.0295 11.3459 20.9336 11.3459 18.8572 11.6734C18.6603 11.1867 18.3683 10.5749 18.1218 10.12C16.1297 10.4748 14.2241 11.1003 12.444 11.96C8.85345 17.5457 7.88011 22.9927 8.36678 28.3624C10.7482 30.1932 13.0561 31.3054 15.325 32.0332C15.8852 31.2394 16.3849 30.3956 16.8153 29.5064C15.9956 29.1857 15.2104 28.79 14.4685 28.3306C14.6653 28.1804 14.8579 28.0235 15.0439 27.862C19.5688 30.0408 24.4852 30.0408 28.9561 27.862C29.1442 28.0235 29.3367 28.1804 29.5314 28.3306C28.7873 28.7922 28 29.1879 27.1803 29.5087C27.6107 30.3956 28.1082 31.2417 28.6705 32.0354C30.9417 31.3076 33.2517 30.1955 35.6331 28.3624C36.2042 22.1376 34.6576 16.7406 31.5451 11.9554ZM17.4318 25.0601C16.0734 25.0601 14.9595 23.7546 14.9595 22.1648C14.9595 20.5751 16.0496 19.2674 17.4318 19.2674C18.8139 19.2674 19.9278 20.5728 19.904 22.1648C19.9062 23.7546 18.8139 25.0601 17.4318 25.0601ZM26.5681 25.0601C25.2098 25.0601 24.0959 23.7546 24.0959 22.1648C24.0959 20.5751 25.186 19.2674 26.5681 19.2674C27.9503 19.2674 29.0642 20.5728 29.0404 22.1648C29.0404 23.7546 27.9503 25.0601 26.5681 25.0601Z"
-                        fill="white"
-                      />
-                    </svg>
-                  </div>
+                    className="w-1/2 px6"
+                  />
                   <div
-                    className="flex-child-grow"
+                    className="w-1/2 px6"
                   >
-                    <span>
-                      Join the Mapbox Developers Discord Community
-                      <span
-                        className="ml6"
+                    <a
+                      className="dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
+                      href="https://discord.gg/uMpcC5RmJh"
+                      rel="noopener noreferrer"
+                      style={
+                        Object {
+                          "backgroundColor": "#ECF1FD",
+                        }
+                      }
+                      target="_blank"
+                    >
+                      <div
+                        className="mt6 mr18"
                       >
                         <svg
-                          aria-hidden="true"
-                          className="events-none icon inline-block align-t"
-                          data-testid="icon-arrow-right"
-                          focusable="false"
-                          style={
-                            Object {
-                              "height": 18,
-                              "width": 18,
-                            }
-                          }
+                          fill="none"
+                          height="46"
+                          viewBox="0 0 44 46"
+                          width="44"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <use
-                            xlinkHref="#icon-arrow-right"
-                            xmlnsXlink="http://www.w3.org/1999/xlink"
+                          <path
+                            d="M0 3.68C0 1.64759 1.64162 0 3.66667 0H40.3333C42.3584 0 44 1.64759 44 3.68V46C40.1176 44.2642 36.6667 42.5283 32.7843 37.3208L34.8265 42.1145C35.0851 42.7215 34.6414 43.3962 33.9837 43.3962H3.66667C1.64162 43.3962 0 41.7486 0 39.7162V3.68Z"
+                            fill="#4164FB"
+                          />
+                          <path
+                            d="M31.5451 11.9554C29.765 11.098 27.8616 10.4748 25.8717 10.12C25.6273 10.5749 25.3417 11.1867 25.1449 11.6734C23.0295 11.3459 20.9336 11.3459 18.8572 11.6734C18.6603 11.1867 18.3683 10.5749 18.1218 10.12C16.1297 10.4748 14.2241 11.1003 12.444 11.96C8.85345 17.5457 7.88011 22.9927 8.36678 28.3624C10.7482 30.1932 13.0561 31.3054 15.325 32.0332C15.8852 31.2394 16.3849 30.3956 16.8153 29.5064C15.9956 29.1857 15.2104 28.79 14.4685 28.3306C14.6653 28.1804 14.8579 28.0235 15.0439 27.862C19.5688 30.0408 24.4852 30.0408 28.9561 27.862C29.1442 28.0235 29.3367 28.1804 29.5314 28.3306C28.7873 28.7922 28 29.1879 27.1803 29.5087C27.6107 30.3956 28.1082 31.2417 28.6705 32.0354C30.9417 31.3076 33.2517 30.1955 35.6331 28.3624C36.2042 22.1376 34.6576 16.7406 31.5451 11.9554ZM17.4318 25.0601C16.0734 25.0601 14.9595 23.7546 14.9595 22.1648C14.9595 20.5751 16.0496 19.2674 17.4318 19.2674C18.8139 19.2674 19.9278 20.5728 19.904 22.1648C19.9062 23.7546 18.8139 25.0601 17.4318 25.0601ZM26.5681 25.0601C25.2098 25.0601 24.0959 23.7546 24.0959 22.1648C24.0959 20.5751 25.186 19.2674 26.5681 19.2674C27.9503 19.2674 29.0642 20.5728 29.0404 22.1648C29.0404 23.7546 27.9503 25.0601 26.5681 25.0601Z"
+                            fill="white"
                           />
                         </svg>
-                        <span
-                          style={
-                            Object {
-                              "border": 0,
-                              "clip": "rect(0, 0, 0, 0)",
-                              "height": 1,
-                              "margin": -1,
-                              "overflow": "hidden",
-                              "padding": 0,
-                              "position": "absolute",
-                              "whiteSpace": "nowrap",
-                              "width": 1,
-                              "wordWrap": "normal",
-                            }
-                          }
-                        >
-                          arrow-right
+                      </div>
+                      <div
+                        className="flex-child-grow"
+                      >
+                        <span>
+                          Join the Mapbox Developers Discord Community
+                          <span
+                            className="ml6"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              className="events-none icon inline-block align-t"
+                              data-testid="icon-arrow-right"
+                              focusable="false"
+                              style={
+                                Object {
+                                  "height": 18,
+                                  "width": 18,
+                                }
+                              }
+                            >
+                              <use
+                                xlinkHref="#icon-arrow-right"
+                                xmlnsXlink="http://www.w3.org/1999/xlink"
+                              />
+                            </svg>
+                            <span
+                              style={
+                                Object {
+                                  "border": 0,
+                                  "clip": "rect(0, 0, 0, 0)",
+                                  "height": 1,
+                                  "margin": -1,
+                                  "overflow": "hidden",
+                                  "padding": 0,
+                                  "position": "absolute",
+                                  "whiteSpace": "nowrap",
+                                  "width": 1,
+                                  "wordWrap": "normal",
+                                }
+                              }
+                            >
+                              arrow-right
+                            </span>
+                          </span>
                         </span>
-                      </span>
-                    </span>
+                      </div>
+                    </a>
                   </div>
-                </a>
+                </div>
                 <button
                   className="btn btn--gray btn--stroke"
                   onClick={[Function]}
@@ -2591,84 +2613,95 @@ Array [
               <div
                 className="my36 color-text block none-mxl"
               >
-                <a
-                  className="dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
-                  href="https://discord.gg/uMpcC5RmJh"
-                  rel="noopener noreferrer"
-                  style={
-                    Object {
-                      "backgroundColor": "#ECF1FD",
-                    }
-                  }
-                  target="_blank"
+                <div
+                  className="flex mx-neg12"
                 >
                   <div
-                    className="mt6 mr18"
-                  >
-                    <svg
-                      fill="none"
-                      height="46"
-                      viewBox="0 0 44 46"
-                      width="44"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M0 3.68C0 1.64759 1.64162 0 3.66667 0H40.3333C42.3584 0 44 1.64759 44 3.68V46C40.1176 44.2642 36.6667 42.5283 32.7843 37.3208L34.8265 42.1145C35.0851 42.7215 34.6414 43.3962 33.9837 43.3962H3.66667C1.64162 43.3962 0 41.7486 0 39.7162V3.68Z"
-                        fill="#4164FB"
-                      />
-                      <path
-                        d="M31.5451 11.9554C29.765 11.098 27.8616 10.4748 25.8717 10.12C25.6273 10.5749 25.3417 11.1867 25.1449 11.6734C23.0295 11.3459 20.9336 11.3459 18.8572 11.6734C18.6603 11.1867 18.3683 10.5749 18.1218 10.12C16.1297 10.4748 14.2241 11.1003 12.444 11.96C8.85345 17.5457 7.88011 22.9927 8.36678 28.3624C10.7482 30.1932 13.0561 31.3054 15.325 32.0332C15.8852 31.2394 16.3849 30.3956 16.8153 29.5064C15.9956 29.1857 15.2104 28.79 14.4685 28.3306C14.6653 28.1804 14.8579 28.0235 15.0439 27.862C19.5688 30.0408 24.4852 30.0408 28.9561 27.862C29.1442 28.0235 29.3367 28.1804 29.5314 28.3306C28.7873 28.7922 28 29.1879 27.1803 29.5087C27.6107 30.3956 28.1082 31.2417 28.6705 32.0354C30.9417 31.3076 33.2517 30.1955 35.6331 28.3624C36.2042 22.1376 34.6576 16.7406 31.5451 11.9554ZM17.4318 25.0601C16.0734 25.0601 14.9595 23.7546 14.9595 22.1648C14.9595 20.5751 16.0496 19.2674 17.4318 19.2674C18.8139 19.2674 19.9278 20.5728 19.904 22.1648C19.9062 23.7546 18.8139 25.0601 17.4318 25.0601ZM26.5681 25.0601C25.2098 25.0601 24.0959 23.7546 24.0959 22.1648C24.0959 20.5751 25.186 19.2674 26.5681 19.2674C27.9503 19.2674 29.0642 20.5728 29.0404 22.1648C29.0404 23.7546 27.9503 25.0601 26.5681 25.0601Z"
-                        fill="white"
-                      />
-                    </svg>
-                  </div>
+                    className="w-1/2 px6"
+                  />
                   <div
-                    className="flex-child-grow"
+                    className="w-1/2 px6"
                   >
-                    <span>
-                      Join the Mapbox Developers Discord Community
-                      <span
-                        className="ml6"
+                    <a
+                      className="dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
+                      href="https://discord.gg/uMpcC5RmJh"
+                      rel="noopener noreferrer"
+                      style={
+                        Object {
+                          "backgroundColor": "#ECF1FD",
+                        }
+                      }
+                      target="_blank"
+                    >
+                      <div
+                        className="mt6 mr18"
                       >
                         <svg
-                          aria-hidden="true"
-                          className="events-none icon inline-block align-t"
-                          data-testid="icon-arrow-right"
-                          focusable="false"
-                          style={
-                            Object {
-                              "height": 18,
-                              "width": 18,
-                            }
-                          }
+                          fill="none"
+                          height="46"
+                          viewBox="0 0 44 46"
+                          width="44"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <use
-                            xlinkHref="#icon-arrow-right"
-                            xmlnsXlink="http://www.w3.org/1999/xlink"
+                          <path
+                            d="M0 3.68C0 1.64759 1.64162 0 3.66667 0H40.3333C42.3584 0 44 1.64759 44 3.68V46C40.1176 44.2642 36.6667 42.5283 32.7843 37.3208L34.8265 42.1145C35.0851 42.7215 34.6414 43.3962 33.9837 43.3962H3.66667C1.64162 43.3962 0 41.7486 0 39.7162V3.68Z"
+                            fill="#4164FB"
+                          />
+                          <path
+                            d="M31.5451 11.9554C29.765 11.098 27.8616 10.4748 25.8717 10.12C25.6273 10.5749 25.3417 11.1867 25.1449 11.6734C23.0295 11.3459 20.9336 11.3459 18.8572 11.6734C18.6603 11.1867 18.3683 10.5749 18.1218 10.12C16.1297 10.4748 14.2241 11.1003 12.444 11.96C8.85345 17.5457 7.88011 22.9927 8.36678 28.3624C10.7482 30.1932 13.0561 31.3054 15.325 32.0332C15.8852 31.2394 16.3849 30.3956 16.8153 29.5064C15.9956 29.1857 15.2104 28.79 14.4685 28.3306C14.6653 28.1804 14.8579 28.0235 15.0439 27.862C19.5688 30.0408 24.4852 30.0408 28.9561 27.862C29.1442 28.0235 29.3367 28.1804 29.5314 28.3306C28.7873 28.7922 28 29.1879 27.1803 29.5087C27.6107 30.3956 28.1082 31.2417 28.6705 32.0354C30.9417 31.3076 33.2517 30.1955 35.6331 28.3624C36.2042 22.1376 34.6576 16.7406 31.5451 11.9554ZM17.4318 25.0601C16.0734 25.0601 14.9595 23.7546 14.9595 22.1648C14.9595 20.5751 16.0496 19.2674 17.4318 19.2674C18.8139 19.2674 19.9278 20.5728 19.904 22.1648C19.9062 23.7546 18.8139 25.0601 17.4318 25.0601ZM26.5681 25.0601C25.2098 25.0601 24.0959 23.7546 24.0959 22.1648C24.0959 20.5751 25.186 19.2674 26.5681 19.2674C27.9503 19.2674 29.0642 20.5728 29.0404 22.1648C29.0404 23.7546 27.9503 25.0601 26.5681 25.0601Z"
+                            fill="white"
                           />
                         </svg>
-                        <span
-                          style={
-                            Object {
-                              "border": 0,
-                              "clip": "rect(0, 0, 0, 0)",
-                              "height": 1,
-                              "margin": -1,
-                              "overflow": "hidden",
-                              "padding": 0,
-                              "position": "absolute",
-                              "whiteSpace": "nowrap",
-                              "width": 1,
-                              "wordWrap": "normal",
-                            }
-                          }
-                        >
-                          arrow-right
+                      </div>
+                      <div
+                        className="flex-child-grow"
+                      >
+                        <span>
+                          Join the Mapbox Developers Discord Community
+                          <span
+                            className="ml6"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              className="events-none icon inline-block align-t"
+                              data-testid="icon-arrow-right"
+                              focusable="false"
+                              style={
+                                Object {
+                                  "height": 18,
+                                  "width": 18,
+                                }
+                              }
+                            >
+                              <use
+                                xlinkHref="#icon-arrow-right"
+                                xmlnsXlink="http://www.w3.org/1999/xlink"
+                              />
+                            </svg>
+                            <span
+                              style={
+                                Object {
+                                  "border": 0,
+                                  "clip": "rect(0, 0, 0, 0)",
+                                  "height": 1,
+                                  "margin": -1,
+                                  "overflow": "hidden",
+                                  "padding": 0,
+                                  "position": "absolute",
+                                  "whiteSpace": "nowrap",
+                                  "width": 1,
+                                  "wordWrap": "normal",
+                                }
+                              }
+                            >
+                              arrow-right
+                            </span>
+                          </span>
                         </span>
-                      </span>
-                    </span>
+                      </div>
+                    </a>
                   </div>
-                </a>
+                </div>
                 <button
                   className="btn btn--gray btn--stroke"
                   onClick={[Function]}
@@ -3396,84 +3429,95 @@ Array [
               <div
                 className="my36 color-text block none-mxl"
               >
-                <a
-                  className="dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
-                  href="https://discord.gg/uMpcC5RmJh"
-                  rel="noopener noreferrer"
-                  style={
-                    Object {
-                      "backgroundColor": "#ECF1FD",
-                    }
-                  }
-                  target="_blank"
+                <div
+                  className="flex mx-neg12"
                 >
                   <div
-                    className="mt6 mr18"
-                  >
-                    <svg
-                      fill="none"
-                      height="46"
-                      viewBox="0 0 44 46"
-                      width="44"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M0 3.68C0 1.64759 1.64162 0 3.66667 0H40.3333C42.3584 0 44 1.64759 44 3.68V46C40.1176 44.2642 36.6667 42.5283 32.7843 37.3208L34.8265 42.1145C35.0851 42.7215 34.6414 43.3962 33.9837 43.3962H3.66667C1.64162 43.3962 0 41.7486 0 39.7162V3.68Z"
-                        fill="#4164FB"
-                      />
-                      <path
-                        d="M31.5451 11.9554C29.765 11.098 27.8616 10.4748 25.8717 10.12C25.6273 10.5749 25.3417 11.1867 25.1449 11.6734C23.0295 11.3459 20.9336 11.3459 18.8572 11.6734C18.6603 11.1867 18.3683 10.5749 18.1218 10.12C16.1297 10.4748 14.2241 11.1003 12.444 11.96C8.85345 17.5457 7.88011 22.9927 8.36678 28.3624C10.7482 30.1932 13.0561 31.3054 15.325 32.0332C15.8852 31.2394 16.3849 30.3956 16.8153 29.5064C15.9956 29.1857 15.2104 28.79 14.4685 28.3306C14.6653 28.1804 14.8579 28.0235 15.0439 27.862C19.5688 30.0408 24.4852 30.0408 28.9561 27.862C29.1442 28.0235 29.3367 28.1804 29.5314 28.3306C28.7873 28.7922 28 29.1879 27.1803 29.5087C27.6107 30.3956 28.1082 31.2417 28.6705 32.0354C30.9417 31.3076 33.2517 30.1955 35.6331 28.3624C36.2042 22.1376 34.6576 16.7406 31.5451 11.9554ZM17.4318 25.0601C16.0734 25.0601 14.9595 23.7546 14.9595 22.1648C14.9595 20.5751 16.0496 19.2674 17.4318 19.2674C18.8139 19.2674 19.9278 20.5728 19.904 22.1648C19.9062 23.7546 18.8139 25.0601 17.4318 25.0601ZM26.5681 25.0601C25.2098 25.0601 24.0959 23.7546 24.0959 22.1648C24.0959 20.5751 25.186 19.2674 26.5681 19.2674C27.9503 19.2674 29.0642 20.5728 29.0404 22.1648C29.0404 23.7546 27.9503 25.0601 26.5681 25.0601Z"
-                        fill="white"
-                      />
-                    </svg>
-                  </div>
+                    className="w-1/2 px6"
+                  />
                   <div
-                    className="flex-child-grow"
+                    className="w-1/2 px6"
                   >
-                    <span>
-                      Join the Mapbox Developers Discord Community
-                      <span
-                        className="ml6"
+                    <a
+                      className="dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
+                      href="https://discord.gg/uMpcC5RmJh"
+                      rel="noopener noreferrer"
+                      style={
+                        Object {
+                          "backgroundColor": "#ECF1FD",
+                        }
+                      }
+                      target="_blank"
+                    >
+                      <div
+                        className="mt6 mr18"
                       >
                         <svg
-                          aria-hidden="true"
-                          className="events-none icon inline-block align-t"
-                          data-testid="icon-arrow-right"
-                          focusable="false"
-                          style={
-                            Object {
-                              "height": 18,
-                              "width": 18,
-                            }
-                          }
+                          fill="none"
+                          height="46"
+                          viewBox="0 0 44 46"
+                          width="44"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <use
-                            xlinkHref="#icon-arrow-right"
-                            xmlnsXlink="http://www.w3.org/1999/xlink"
+                          <path
+                            d="M0 3.68C0 1.64759 1.64162 0 3.66667 0H40.3333C42.3584 0 44 1.64759 44 3.68V46C40.1176 44.2642 36.6667 42.5283 32.7843 37.3208L34.8265 42.1145C35.0851 42.7215 34.6414 43.3962 33.9837 43.3962H3.66667C1.64162 43.3962 0 41.7486 0 39.7162V3.68Z"
+                            fill="#4164FB"
+                          />
+                          <path
+                            d="M31.5451 11.9554C29.765 11.098 27.8616 10.4748 25.8717 10.12C25.6273 10.5749 25.3417 11.1867 25.1449 11.6734C23.0295 11.3459 20.9336 11.3459 18.8572 11.6734C18.6603 11.1867 18.3683 10.5749 18.1218 10.12C16.1297 10.4748 14.2241 11.1003 12.444 11.96C8.85345 17.5457 7.88011 22.9927 8.36678 28.3624C10.7482 30.1932 13.0561 31.3054 15.325 32.0332C15.8852 31.2394 16.3849 30.3956 16.8153 29.5064C15.9956 29.1857 15.2104 28.79 14.4685 28.3306C14.6653 28.1804 14.8579 28.0235 15.0439 27.862C19.5688 30.0408 24.4852 30.0408 28.9561 27.862C29.1442 28.0235 29.3367 28.1804 29.5314 28.3306C28.7873 28.7922 28 29.1879 27.1803 29.5087C27.6107 30.3956 28.1082 31.2417 28.6705 32.0354C30.9417 31.3076 33.2517 30.1955 35.6331 28.3624C36.2042 22.1376 34.6576 16.7406 31.5451 11.9554ZM17.4318 25.0601C16.0734 25.0601 14.9595 23.7546 14.9595 22.1648C14.9595 20.5751 16.0496 19.2674 17.4318 19.2674C18.8139 19.2674 19.9278 20.5728 19.904 22.1648C19.9062 23.7546 18.8139 25.0601 17.4318 25.0601ZM26.5681 25.0601C25.2098 25.0601 24.0959 23.7546 24.0959 22.1648C24.0959 20.5751 25.186 19.2674 26.5681 19.2674C27.9503 19.2674 29.0642 20.5728 29.0404 22.1648C29.0404 23.7546 27.9503 25.0601 26.5681 25.0601Z"
+                            fill="white"
                           />
                         </svg>
-                        <span
-                          style={
-                            Object {
-                              "border": 0,
-                              "clip": "rect(0, 0, 0, 0)",
-                              "height": 1,
-                              "margin": -1,
-                              "overflow": "hidden",
-                              "padding": 0,
-                              "position": "absolute",
-                              "whiteSpace": "nowrap",
-                              "width": 1,
-                              "wordWrap": "normal",
-                            }
-                          }
-                        >
-                          arrow-right
+                      </div>
+                      <div
+                        className="flex-child-grow"
+                      >
+                        <span>
+                          Join the Mapbox Developers Discord Community
+                          <span
+                            className="ml6"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              className="events-none icon inline-block align-t"
+                              data-testid="icon-arrow-right"
+                              focusable="false"
+                              style={
+                                Object {
+                                  "height": 18,
+                                  "width": 18,
+                                }
+                              }
+                            >
+                              <use
+                                xlinkHref="#icon-arrow-right"
+                                xmlnsXlink="http://www.w3.org/1999/xlink"
+                              />
+                            </svg>
+                            <span
+                              style={
+                                Object {
+                                  "border": 0,
+                                  "clip": "rect(0, 0, 0, 0)",
+                                  "height": 1,
+                                  "margin": -1,
+                                  "overflow": "hidden",
+                                  "padding": 0,
+                                  "position": "absolute",
+                                  "whiteSpace": "nowrap",
+                                  "width": 1,
+                                  "wordWrap": "normal",
+                                }
+                              }
+                            >
+                              arrow-right
+                            </span>
+                          </span>
                         </span>
-                      </span>
-                    </span>
+                      </div>
+                    </a>
                   </div>
-                </a>
+                </div>
                 <button
                   className="btn btn--gray btn--stroke"
                   onClick={[Function]}
@@ -3864,84 +3908,95 @@ Array [
               <div
                 className="my36 color-text"
               >
-                <a
-                  className="dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
-                  href="https://discord.gg/uMpcC5RmJh"
-                  rel="noopener noreferrer"
-                  style={
-                    Object {
-                      "backgroundColor": "#ECF1FD",
-                    }
-                  }
-                  target="_blank"
+                <div
+                  className="flex mx-neg12"
                 >
                   <div
-                    className="mt6 mr18"
-                  >
-                    <svg
-                      fill="none"
-                      height="46"
-                      viewBox="0 0 44 46"
-                      width="44"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M0 3.68C0 1.64759 1.64162 0 3.66667 0H40.3333C42.3584 0 44 1.64759 44 3.68V46C40.1176 44.2642 36.6667 42.5283 32.7843 37.3208L34.8265 42.1145C35.0851 42.7215 34.6414 43.3962 33.9837 43.3962H3.66667C1.64162 43.3962 0 41.7486 0 39.7162V3.68Z"
-                        fill="#4164FB"
-                      />
-                      <path
-                        d="M31.5451 11.9554C29.765 11.098 27.8616 10.4748 25.8717 10.12C25.6273 10.5749 25.3417 11.1867 25.1449 11.6734C23.0295 11.3459 20.9336 11.3459 18.8572 11.6734C18.6603 11.1867 18.3683 10.5749 18.1218 10.12C16.1297 10.4748 14.2241 11.1003 12.444 11.96C8.85345 17.5457 7.88011 22.9927 8.36678 28.3624C10.7482 30.1932 13.0561 31.3054 15.325 32.0332C15.8852 31.2394 16.3849 30.3956 16.8153 29.5064C15.9956 29.1857 15.2104 28.79 14.4685 28.3306C14.6653 28.1804 14.8579 28.0235 15.0439 27.862C19.5688 30.0408 24.4852 30.0408 28.9561 27.862C29.1442 28.0235 29.3367 28.1804 29.5314 28.3306C28.7873 28.7922 28 29.1879 27.1803 29.5087C27.6107 30.3956 28.1082 31.2417 28.6705 32.0354C30.9417 31.3076 33.2517 30.1955 35.6331 28.3624C36.2042 22.1376 34.6576 16.7406 31.5451 11.9554ZM17.4318 25.0601C16.0734 25.0601 14.9595 23.7546 14.9595 22.1648C14.9595 20.5751 16.0496 19.2674 17.4318 19.2674C18.8139 19.2674 19.9278 20.5728 19.904 22.1648C19.9062 23.7546 18.8139 25.0601 17.4318 25.0601ZM26.5681 25.0601C25.2098 25.0601 24.0959 23.7546 24.0959 22.1648C24.0959 20.5751 25.186 19.2674 26.5681 19.2674C27.9503 19.2674 29.0642 20.5728 29.0404 22.1648C29.0404 23.7546 27.9503 25.0601 26.5681 25.0601Z"
-                        fill="white"
-                      />
-                    </svg>
-                  </div>
+                    className="w-1/2 px6"
+                  />
                   <div
-                    className="flex-child-grow"
+                    className="w-1/2 px6"
                   >
-                    <span>
-                      Join the Mapbox Developers Discord Community
-                      <span
-                        className="ml6"
+                    <a
+                      className="dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
+                      href="https://discord.gg/uMpcC5RmJh"
+                      rel="noopener noreferrer"
+                      style={
+                        Object {
+                          "backgroundColor": "#ECF1FD",
+                        }
+                      }
+                      target="_blank"
+                    >
+                      <div
+                        className="mt6 mr18"
                       >
                         <svg
-                          aria-hidden="true"
-                          className="events-none icon inline-block align-t"
-                          data-testid="icon-arrow-right"
-                          focusable="false"
-                          style={
-                            Object {
-                              "height": 18,
-                              "width": 18,
-                            }
-                          }
+                          fill="none"
+                          height="46"
+                          viewBox="0 0 44 46"
+                          width="44"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <use
-                            xlinkHref="#icon-arrow-right"
-                            xmlnsXlink="http://www.w3.org/1999/xlink"
+                          <path
+                            d="M0 3.68C0 1.64759 1.64162 0 3.66667 0H40.3333C42.3584 0 44 1.64759 44 3.68V46C40.1176 44.2642 36.6667 42.5283 32.7843 37.3208L34.8265 42.1145C35.0851 42.7215 34.6414 43.3962 33.9837 43.3962H3.66667C1.64162 43.3962 0 41.7486 0 39.7162V3.68Z"
+                            fill="#4164FB"
+                          />
+                          <path
+                            d="M31.5451 11.9554C29.765 11.098 27.8616 10.4748 25.8717 10.12C25.6273 10.5749 25.3417 11.1867 25.1449 11.6734C23.0295 11.3459 20.9336 11.3459 18.8572 11.6734C18.6603 11.1867 18.3683 10.5749 18.1218 10.12C16.1297 10.4748 14.2241 11.1003 12.444 11.96C8.85345 17.5457 7.88011 22.9927 8.36678 28.3624C10.7482 30.1932 13.0561 31.3054 15.325 32.0332C15.8852 31.2394 16.3849 30.3956 16.8153 29.5064C15.9956 29.1857 15.2104 28.79 14.4685 28.3306C14.6653 28.1804 14.8579 28.0235 15.0439 27.862C19.5688 30.0408 24.4852 30.0408 28.9561 27.862C29.1442 28.0235 29.3367 28.1804 29.5314 28.3306C28.7873 28.7922 28 29.1879 27.1803 29.5087C27.6107 30.3956 28.1082 31.2417 28.6705 32.0354C30.9417 31.3076 33.2517 30.1955 35.6331 28.3624C36.2042 22.1376 34.6576 16.7406 31.5451 11.9554ZM17.4318 25.0601C16.0734 25.0601 14.9595 23.7546 14.9595 22.1648C14.9595 20.5751 16.0496 19.2674 17.4318 19.2674C18.8139 19.2674 19.9278 20.5728 19.904 22.1648C19.9062 23.7546 18.8139 25.0601 17.4318 25.0601ZM26.5681 25.0601C25.2098 25.0601 24.0959 23.7546 24.0959 22.1648C24.0959 20.5751 25.186 19.2674 26.5681 19.2674C27.9503 19.2674 29.0642 20.5728 29.0404 22.1648C29.0404 23.7546 27.9503 25.0601 26.5681 25.0601Z"
+                            fill="white"
                           />
                         </svg>
-                        <span
-                          style={
-                            Object {
-                              "border": 0,
-                              "clip": "rect(0, 0, 0, 0)",
-                              "height": 1,
-                              "margin": -1,
-                              "overflow": "hidden",
-                              "padding": 0,
-                              "position": "absolute",
-                              "whiteSpace": "nowrap",
-                              "width": 1,
-                              "wordWrap": "normal",
-                            }
-                          }
-                        >
-                          arrow-right
+                      </div>
+                      <div
+                        className="flex-child-grow"
+                      >
+                        <span>
+                          Join the Mapbox Developers Discord Community
+                          <span
+                            className="ml6"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              className="events-none icon inline-block align-t"
+                              data-testid="icon-arrow-right"
+                              focusable="false"
+                              style={
+                                Object {
+                                  "height": 18,
+                                  "width": 18,
+                                }
+                              }
+                            >
+                              <use
+                                xlinkHref="#icon-arrow-right"
+                                xmlnsXlink="http://www.w3.org/1999/xlink"
+                              />
+                            </svg>
+                            <span
+                              style={
+                                Object {
+                                  "border": 0,
+                                  "clip": "rect(0, 0, 0, 0)",
+                                  "height": 1,
+                                  "margin": -1,
+                                  "overflow": "hidden",
+                                  "padding": 0,
+                                  "position": "absolute",
+                                  "whiteSpace": "nowrap",
+                                  "width": 1,
+                                  "wordWrap": "normal",
+                                }
+                              }
+                            >
+                              arrow-right
+                            </span>
+                          </span>
                         </span>
-                      </span>
-                    </span>
+                      </div>
+                    </a>
                   </div>
-                </a>
+                </div>
                 <button
                   className="btn btn--gray btn--stroke"
                   onClick={[Function]}

--- a/src/components/page-layout/components/content.js
+++ b/src/components/page-layout/components/content.js
@@ -161,8 +161,14 @@ export class ContentWrapper extends React.PureComponent {
                   'block none-mxl': layout !== 'full' // hide feedback at bottom of page on larger screens unless layout is full (always show it on the bottom)
                 })}
               >
-                <SignupBanner />
-                <DiscordCTA />
+                <div className="flex mx-neg12">
+                  <div className="w-1/2 px6">
+                    <SignupBanner />
+                  </div>
+                  <div className="w-1/2 px6">
+                    <DiscordCTA />
+                  </div>
+                </div>
                 {this.renderFeedback()}
               </div>
             )}

--- a/src/components/page-layout/components/signup-banner.js
+++ b/src/components/page-layout/components/signup-banner.js
@@ -30,7 +30,7 @@ export default class SignupBanner extends React.PureComponent {
       <div
         className={`dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 ${background} ${color}`}
       >
-        <div className="w-full prose flex flex--column-mxl">
+        <div className="w-full prose flex flex--wrap">
           <div className="flex-child-grow">
             <div className="txt-bold mb6">Ready to get started?</div>
             <div className="txt-ms mb18-mxl">


### PR DESCRIPTION
Merge after #555 

- Adds some additional markup to create a better layout for the two CTA buttons (Sign up and Discord) when appearing at the bottom of a wide layout.
- Instead of showing up stacked, with lots of empty space, they now appear as 50% width tiles with gutter.

<img width="1251" alt="image" src="https://user-images.githubusercontent.com/1833820/225339910-6315478e-b4b3-4bcd-bf45-246c8fe1d976.png">
