### PR TITLE
css and layout tweaks for the CTA buttons

### DIFF
--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -476,10 +476,13 @@ Array [
                   </div>
                 </div>
                 <div
-                  className="my18 color-text none block-mxl"
+                  className="mb18"
+                />
+                <div
+                  className="my18 color-text none block-mxl mb-18"
                 >
                   <a
-                    className="dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
+                    className="dr-ui--discord-banner py18 px18 round-bold flex color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
                     href="https://discord.gg/uMpcC5RmJh"
                     rel="noopener noreferrer"
                     style={
@@ -1277,10 +1280,13 @@ Array [
                 }
               >
                 <div
-                  className="my18 color-text none block-mxl"
+                  className="mb18"
+                />
+                <div
+                  className="my18 color-text none block-mxl mb-18"
                 >
                   <a
-                    className="dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
+                    className="dr-ui--discord-banner py18 px18 round-bold flex color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
                     href="https://discord.gg/uMpcC5RmJh"
                     rel="noopener noreferrer"
                     style={
@@ -1381,16 +1387,16 @@ Array [
                 className="my36 color-text block none-mxl"
               >
                 <div
-                  className="flex mx-neg12"
+                  className="flex mx-neg6 flex--wrap"
                 >
                   <div
-                    className="w-1/2 px6"
+                    className="w-full w-1/2-ml px6 flex-child-no-shrink mb18"
                   />
                   <div
-                    className="w-1/2 px6"
+                    className="w-full w-1/2-ml px6 flex-child-no-shrink mb18"
                   >
                     <a
-                      className="dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
+                      className="dr-ui--discord-banner py18 px18 round-bold flex color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
                       href="https://discord.gg/uMpcC5RmJh"
                       rel="noopener noreferrer"
                       style={
@@ -1732,16 +1738,16 @@ Array [
                 className="my36 color-text"
               >
                 <div
-                  className="flex mx-neg12"
+                  className="flex mx-neg6 flex--wrap"
                 >
                   <div
-                    className="w-1/2 px6"
+                    className="w-full w-1/2-ml px6 flex-child-no-shrink mb18"
                   />
                   <div
-                    className="w-1/2 px6"
+                    className="w-full w-1/2-ml px6 flex-child-no-shrink mb18"
                   >
                     <a
-                      className="dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
+                      className="dr-ui--discord-banner py18 px18 round-bold flex color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
                       href="https://discord.gg/uMpcC5RmJh"
                       rel="noopener noreferrer"
                       style={
@@ -2404,10 +2410,13 @@ Array [
                   </ul>
                 </nav>
                 <div
-                  className="my18 color-text none block-mxl"
+                  className="mb18"
+                />
+                <div
+                  className="my18 color-text none block-mxl mb-18"
                 >
                   <a
-                    className="dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
+                    className="dr-ui--discord-banner py18 px18 round-bold flex color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
                     href="https://discord.gg/uMpcC5RmJh"
                     rel="noopener noreferrer"
                     style={
@@ -2614,16 +2623,16 @@ Array [
                 className="my36 color-text block none-mxl"
               >
                 <div
-                  className="flex mx-neg12"
+                  className="flex mx-neg6 flex--wrap"
                 >
                   <div
-                    className="w-1/2 px6"
+                    className="w-full w-1/2-ml px6 flex-child-no-shrink mb18"
                   />
                   <div
-                    className="w-1/2 px6"
+                    className="w-full w-1/2-ml px6 flex-child-no-shrink mb18"
                   >
                     <a
-                      className="dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
+                      className="dr-ui--discord-banner py18 px18 round-bold flex color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
                       href="https://discord.gg/uMpcC5RmJh"
                       rel="noopener noreferrer"
                       style={
@@ -3255,10 +3264,13 @@ Array [
                 }
               >
                 <div
-                  className="my18 color-text none block-mxl"
+                  className="mb18"
+                />
+                <div
+                  className="my18 color-text none block-mxl mb-18"
                 >
                   <a
-                    className="dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
+                    className="dr-ui--discord-banner py18 px18 round-bold flex color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
                     href="https://discord.gg/uMpcC5RmJh"
                     rel="noopener noreferrer"
                     style={
@@ -3430,16 +3442,16 @@ Array [
                 className="my36 color-text block none-mxl"
               >
                 <div
-                  className="flex mx-neg12"
+                  className="flex mx-neg6 flex--wrap"
                 >
                   <div
-                    className="w-1/2 px6"
+                    className="w-full w-1/2-ml px6 flex-child-no-shrink mb18"
                   />
                   <div
-                    className="w-1/2 px6"
+                    className="w-full w-1/2-ml px6 flex-child-no-shrink mb18"
                   >
                     <a
-                      className="dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
+                      className="dr-ui--discord-banner py18 px18 round-bold flex color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
                       href="https://discord.gg/uMpcC5RmJh"
                       rel="noopener noreferrer"
                       style={
@@ -3909,16 +3921,16 @@ Array [
                 className="my36 color-text"
               >
                 <div
-                  className="flex mx-neg12"
+                  className="flex mx-neg6 flex--wrap"
                 >
                   <div
-                    className="w-1/2 px6"
+                    className="w-full w-1/2-ml px6 flex-child-no-shrink mb18"
                   />
                   <div
-                    className="w-1/2 px6"
+                    className="w-full w-1/2-ml px6 flex-child-no-shrink mb18"
                   >
                     <a
-                      className="dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
+                      className="dr-ui--discord-banner py18 px18 round-bold flex color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
                       href="https://discord.gg/uMpcC5RmJh"
                       rel="noopener noreferrer"
                       style={

--- a/src/components/page-layout/components/content.js
+++ b/src/components/page-layout/components/content.js
@@ -87,8 +87,11 @@ export class ContentWrapper extends React.PureComponent {
         {showToc && headings && headings.length > 0 && (
           <OnThisPage headings={headings} themeWrapper="mb24-mxl mb18" />
         )}
-        <SignupBanner />
-        <div className={'my18 color-text none block-mxl'}>
+        <div className="mb18">
+          <SignupBanner />
+        </div>
+
+        <div className="my18 color-text none block-mxl mb-18">
           <DiscordCTA />
         </div>
         {showFeedback && (
@@ -161,11 +164,11 @@ export class ContentWrapper extends React.PureComponent {
                   'block none-mxl': layout !== 'full' // hide feedback at bottom of page on larger screens unless layout is full (always show it on the bottom)
                 })}
               >
-                <div className="flex mx-neg12">
-                  <div className="w-1/2 px6">
+                <div className="flex mx-neg6 flex--wrap">
+                  <div className="w-full w-1/2-ml px6 flex-child-no-shrink mb18">
                     <SignupBanner />
                   </div>
-                  <div className="w-1/2 px6">
+                  <div className="w-full w-1/2-ml px6 flex-child-no-shrink mb18">
                     <DiscordCTA />
                   </div>
                 </div>

--- a/src/components/page-layout/components/discord-cta.js
+++ b/src/components/page-layout/components/discord-cta.js
@@ -5,7 +5,7 @@ export default class DiscordCTA extends React.PureComponent {
   render() {
     return (
       <a
-        className="dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
+        className="dr-ui--discord-banner py18 px18 round-bold flex color-blue txt-ms flex flex--center-cross link bg-blue-lighter-on-hover transition"
         style={{
           backgroundColor: '#ECF1FD'
         }}

--- a/src/components/page-layout/components/signup-banner.js
+++ b/src/components/page-layout/components/signup-banner.js
@@ -28,10 +28,10 @@ export default class SignupBanner extends React.PureComponent {
     const { background, color } = themes['default'];
     return (
       <div
-        className={`dr-ui--signup-banner py18 px18 round-bold flex mt18 mb18 ${background} ${color}`}
+        className={`dr-ui--signup-banner py18 px18 round-bold flex ${background} ${color}`}
       >
-        <div className="w-full prose flex flex--wrap">
-          <div className="flex-child-grow">
+        <div className="w-full prose flex flex--wrap" style={{ rowGap: 10 }}>
+          <div className="flex-child-grow mr12">
             <div className="txt-bold mb6">Ready to get started?</div>
             <div className="txt-ms mb18-mxl">
               Create a free account to start building with Mapbox.


### PR DESCRIPTION
CSS and Layout Tweaks to fix the CTA buttons.

Mostly fixes the layout where they are showing as 1/2 width on small screens, but also fixes some bad spacing going on in other areas.

<img width="497" alt="Geocoding_v6_API_Playground___Developer_Playgrounds___Mapbox" src="https://user-images.githubusercontent.com/1833820/233199842-d077cd6d-b858-4dde-a40e-5d4aebac1d65.png">
