### PR TITLE
restore babel present-env options

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -3,9 +3,7 @@
     [
       "@babel/preset-env",
       {
-        "modules": false,
-        "useBuiltIns": "usage",
-        "corejs": "2"
+        "modules": false
       }
     ],
     "@babel/preset-react"


### PR DESCRIPTION
The updates were causing an esm-style import statement to be added to the top of a cjs file