### PR TITLE
adjust onthispage topoffset to account for sticky header

### DIFF
--- a/src/components/on-this-page/on-this-page.js
+++ b/src/components/on-this-page/on-this-page.js
@@ -146,6 +146,6 @@ OnThisPage.propTypes = {
 };
 
 OnThisPage.defaultProps = {
-  topOffset: 50,
+  topOffset: 120,
   themeWrapper: ''
 };


### PR DESCRIPTION
- adjusts the default `topOffset` prop of `OnThisPage` to account for an additional 70px caused by the sticky header.
- this fixes a bug where the "current" section of a docs page was not highlighted at the correct time in the right sidebar when deep linking or scrolling through a page.
