### PR TITLE
restore theme color classnames

### DIFF
--- a/src/components/error-boundary/__tests__/__snapshots__/error-boundary.test.js.snap
+++ b/src/components/error-boundary/__tests__/__snapshots__/error-boundary.test.js.snap
@@ -4,7 +4,7 @@ exports[`error-boundary Basic renders as expected 1`] = `"This content does not 
 
 exports[`error-boundary Trigger error renders as expected 1`] = `
 <div
-  className="dr-ui--note py18 px18 round flex mb18 bg-red-faint undefined"
+  className="dr-ui--note py18 px18 round flex mb18 bg-red-faint color-red-dark"
 >
   <div
     className="mr18 none block-mm pt3"
@@ -84,7 +84,7 @@ exports[`error-boundary Trigger error renders as expected 1`] = `
 
 exports[`error-boundary Trigger error with custom title and note contents renders as expected 1`] = `
 <div
-  className="dr-ui--note py18 px18 round flex mb18 bg-red-faint undefined"
+  className="dr-ui--note py18 px18 round flex mb18 bg-red-faint color-red-dark"
 >
   <div
     className="mr18 none block-mm pt3"

--- a/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
+++ b/src/components/navigation-accordion/__tests__/__snapshots__/navigation-accordion.test.js.snap
@@ -221,7 +221,7 @@ exports[`navigation-accordion Titles with tags renders as expected 1`] = `
             }
           >
             <div
-              className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-xs"
+              className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-blue-faint color-blue-dark txt-xs"
               data-state="closed"
               onBlur={[Function]}
               onClick={[Function]}
@@ -231,7 +231,6 @@ exports[`navigation-accordion Titles with tags renders as expected 1`] = `
               onPointerMove={[Function]}
               style={
                 Object {
-                  "backgroundColor": "#CBE4FF",
                   "paddingTop": 1,
                 }
               }

--- a/src/components/note/__tests__/__snapshots__/note.test.js.snap
+++ b/src/components/note/__tests__/__snapshots__/note.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`note A note to display an error with steps or links on how to troubleshoot. renders as expected 1`] = `
 <div
-  className="dr-ui--note py18 px18 round flex mb18 bg-red-faint undefined"
+  className="dr-ui--note py18 px18 round flex mb18 bg-red-faint color-red-dark"
 >
   <div
     className="mr18 none block-mm pt3"
@@ -181,7 +181,7 @@ exports[`note A note to display an error with steps or links on how to troublesh
 
 exports[`note A note to display with a message about new products or features. renders as expected 1`] = `
 <div
-  className="dr-ui--note py18 px18 round flex mb18 undefined undefined"
+  className="dr-ui--note py18 px18 round flex mb18 bg-green-faint color-green-dark"
 >
   <div
     className="mr18 none block-mm pt3"
@@ -360,7 +360,7 @@ exports[`note A note to display with a message about new products or features. r
 
 exports[`note A note to flag information about a beta release/product renders as expected 1`] = `
 <div
-  className="dr-ui--note py18 px18 round flex mb18 undefined undefined"
+  className="dr-ui--note py18 px18 round flex mb18 bg-blue-faint color-blue-dark"
 >
   <div
     className="mr18 none block-mm pt3"
@@ -897,7 +897,7 @@ exports[`note A warning note to let the user know something has changed or will 
 
 exports[`note Default note renders as expected 1`] = `
 <div
-  className="dr-ui--note py18 px18 round flex mb18 bg-gray-faint undefined"
+  className="dr-ui--note py18 px18 round flex mb18 bg-gray-faint color-text"
 >
   <div
     className="mr18 none block-mm pt3"
@@ -965,7 +965,7 @@ exports[`note Default note renders as expected 1`] = `
 
 exports[`note Note with custom title. renders as expected 1`] = `
 <div
-  className="dr-ui--note py18 px18 round flex mb18 bg-gray-faint undefined"
+  className="dr-ui--note py18 px18 round flex mb18 bg-gray-faint color-text"
 >
   <div
     className="mr18 none block-mm pt3"
@@ -1144,7 +1144,7 @@ exports[`note Note with custom title. renders as expected 1`] = `
 
 exports[`note download renders as expected 1`] = `
 <div
-  className="dr-ui--note py18 px18 round flex mb18 bg-purple-faint undefined"
+  className="dr-ui--note py18 px18 round flex mb18 bg-purple-faint color-purple-dark"
 >
   <div
     className="mr18 none block-mm pt3"

--- a/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
+++ b/src/components/overview-header/__tests__/__snapshots__/overview-header.test.js.snap
@@ -748,7 +748,7 @@ exports[`overview-header Beta product renders as expected 1`] = `
           }
         >
           <div
-            className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-s px6"
+            className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-blue-faint color-blue-dark txt-s px6"
             data-state="closed"
             onBlur={[Function]}
             onClick={[Function]}
@@ -758,7 +758,6 @@ exports[`overview-header Beta product renders as expected 1`] = `
             onPointerMove={[Function]}
             style={
               Object {
-                "backgroundColor": "#CBE4FF",
                 "paddingTop": 1,
               }
             }

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -3640,7 +3640,7 @@ Array [
                   className="ml-neg3"
                 >
                   <div
-                    className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-xs px6"
+                    className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-blue-faint color-blue-dark txt-xs px6"
                     data-state="closed"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -3650,7 +3650,6 @@ Array [
                     onPointerMove={[Function]}
                     style={
                       Object {
-                        "backgroundColor": "#CBE4FF",
                         "paddingTop": 1,
                       }
                     }

--- a/src/components/product-menu/__tests__/__snapshots__/product-menu.test.js.snap
+++ b/src/components/product-menu/__tests__/__snapshots__/product-menu.test.js.snap
@@ -21,7 +21,7 @@ exports[`product-menu Beta product renders as expected 1`] = `
     className="ml-neg3"
   >
     <div
-      className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-xs px6"
+      className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-blue-faint color-blue-dark txt-xs px6"
       data-state="closed"
       onBlur={[Function]}
       onClick={[Function]}
@@ -31,7 +31,6 @@ exports[`product-menu Beta product renders as expected 1`] = `
       onPointerMove={[Function]}
       style={
         Object {
-          "backgroundColor": "#CBE4FF",
           "paddingTop": 1,
         }
       }
@@ -56,7 +55,7 @@ exports[`product-menu Beta product renders as expected 2`] = `
     className="ml-neg3"
   >
     <div
-      className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-xs px6"
+      className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-blue-faint color-blue-dark txt-xs px6"
       data-state="closed"
       onBlur={[Function]}
       onClick={[Function]}
@@ -66,7 +65,6 @@ exports[`product-menu Beta product renders as expected 2`] = `
       onPointerMove={[Function]}
       style={
         Object {
-          "backgroundColor": "#CBE4FF",
           "paddingTop": 1,
         }
       }

--- a/src/components/tag/__tests__/__snapshots__/tag.test.js.snap
+++ b/src/components/tag/__tests__/__snapshots__/tag.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`tag Beta tag renders as expected 1`] = `
 <div
-  className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-s px6"
+  className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-blue-faint color-blue-dark txt-s px6"
   data-state="closed"
   onBlur={[Function]}
   onClick={[Function]}
@@ -12,7 +12,6 @@ exports[`tag Beta tag renders as expected 1`] = `
   onPointerMove={[Function]}
   style={
     Object {
-      "backgroundColor": "#CBE4FF",
       "paddingTop": 1,
     }
   }
@@ -23,7 +22,7 @@ exports[`tag Beta tag renders as expected 1`] = `
 
 exports[`tag Custom tag renders as expected 1`] = `
 <div
-  className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-s px6 bg-red-light"
+  className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-red-light color-red-dark txt-s px6"
   data-state="closed"
   onBlur={[Function]}
   onClick={[Function]}
@@ -43,7 +42,7 @@ exports[`tag Custom tag renders as expected 1`] = `
 
 exports[`tag small variant renders as expected 1`] = `
 <div
-  className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-xs px6"
+  className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-blue-faint color-blue-dark txt-xs px6"
   data-state="closed"
   onBlur={[Function]}
   onClick={[Function]}
@@ -53,7 +52,6 @@ exports[`tag small variant renders as expected 1`] = `
   onPointerMove={[Function]}
   style={
     Object {
-      "backgroundColor": "#CBE4FF",
       "paddingTop": 1,
     }
   }

--- a/src/components/tag/tag.js
+++ b/src/components/tag/tag.js
@@ -23,13 +23,12 @@ export default class Tag extends React.PureComponent {
             paddingTop: 1
           }}
           className={classnames(
-            `round inline-block cursor-default txt-fancy-medium color-gray-dark`,
+            `txt-fancy-medium round inline-block cursor-default color-gray-dark ${theme.background} ${theme.color}`,
             {
               'txt-s': !this.props.small,
               'txt-xs': this.props.small,
               px6: !this.props.icon
-            },
-            theme.background
+            }
           )}
         >
           {this.props.icon ? (

--- a/src/components/themes/__tests__/__snapshots__/themes.test.js.snap
+++ b/src/components/themes/__tests__/__snapshots__/themes.test.js.snap
@@ -3,7 +3,7 @@
 exports[`themes Custom tag renders as expected 1`] = `
 <div>
   <div
-    className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-s px6 bg-red-light"
+    className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-red-light color-red-dark txt-s px6"
     data-state="closed"
     onBlur={[Function]}
     onClick={[Function]}
@@ -20,7 +20,7 @@ exports[`themes Custom tag renders as expected 1`] = `
     Limited access
   </div>
   <div
-    className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-xs px6 bg-red-light"
+    className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-red-light color-red-dark txt-xs px6"
     data-state="closed"
     onBlur={[Function]}
     onClick={[Function]}
@@ -37,7 +37,7 @@ exports[`themes Custom tag renders as expected 1`] = `
     Limited access
   </div>
   <div
-    className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-s bg-red-light"
+    className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-red-light color-red-dark txt-s"
     data-state="closed"
     onBlur={[Function]}
     onClick={[Function]}
@@ -88,7 +88,7 @@ exports[`themes Custom tag renders as expected 1`] = `
     </span>
   </div>
   <div
-    className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-xs bg-red-light"
+    className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-red-light color-red-dark txt-xs"
     data-state="closed"
     onBlur={[Function]}
     onClick={[Function]}
@@ -143,7 +143,7 @@ exports[`themes Custom tag renders as expected 1`] = `
 
 exports[`themes Default renders as expected 1`] = `
 <div
-  className="dr-ui--note py18 px18 round flex mb18 bg-gray-faint undefined"
+  className="dr-ui--note py18 px18 round flex mb18 bg-gray-faint color-text"
 >
   <div
     className="mr18 none block-mm pt3"
@@ -210,7 +210,7 @@ exports[`themes Default renders as expected 1`] = `
 exports[`themes beta renders as expected 1`] = `
 <div>
   <div
-    className="dr-ui--note py18 px18 round flex mb18 undefined undefined"
+    className="dr-ui--note py18 px18 round flex mb18 bg-blue-faint color-blue-dark"
   >
     <div
       className="mr18 none block-mm pt3"
@@ -273,7 +273,7 @@ exports[`themes beta renders as expected 1`] = `
     </div>
   </div>
   <div
-    className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-s px6"
+    className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-blue-faint color-blue-dark txt-s px6"
     data-state="closed"
     onBlur={[Function]}
     onClick={[Function]}
@@ -283,7 +283,6 @@ exports[`themes beta renders as expected 1`] = `
     onPointerMove={[Function]}
     style={
       Object {
-        "backgroundColor": "#CBE4FF",
         "paddingTop": 1,
       }
     }
@@ -291,7 +290,7 @@ exports[`themes beta renders as expected 1`] = `
     BETA
   </div>
   <div
-    className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-xs px6"
+    className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-blue-faint color-blue-dark txt-xs px6"
     data-state="closed"
     onBlur={[Function]}
     onClick={[Function]}
@@ -301,7 +300,6 @@ exports[`themes beta renders as expected 1`] = `
     onPointerMove={[Function]}
     style={
       Object {
-        "backgroundColor": "#CBE4FF",
         "paddingTop": 1,
       }
     }
@@ -309,7 +307,7 @@ exports[`themes beta renders as expected 1`] = `
     BETA
   </div>
   <div
-    className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-s"
+    className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-blue-faint color-blue-dark txt-s"
     data-state="closed"
     onBlur={[Function]}
     onClick={[Function]}
@@ -319,7 +317,6 @@ exports[`themes beta renders as expected 1`] = `
     onPointerMove={[Function]}
     style={
       Object {
-        "backgroundColor": "#CBE4FF",
         "paddingTop": 1,
       }
     }
@@ -361,7 +358,7 @@ exports[`themes beta renders as expected 1`] = `
     </span>
   </div>
   <div
-    className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-xs"
+    className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-blue-faint color-blue-dark txt-xs"
     data-state="closed"
     onBlur={[Function]}
     onClick={[Function]}
@@ -371,7 +368,6 @@ exports[`themes beta renders as expected 1`] = `
     onPointerMove={[Function]}
     style={
       Object {
-        "backgroundColor": "#CBE4FF",
         "paddingTop": 1,
       }
     }
@@ -417,7 +413,7 @@ exports[`themes beta renders as expected 1`] = `
 
 exports[`themes download renders as expected 1`] = `
 <div
-  className="dr-ui--note py18 px18 round flex mb18 bg-purple-faint undefined"
+  className="dr-ui--note py18 px18 round flex mb18 bg-purple-faint color-purple-dark"
 >
   <div
     className="mr18 none block-mm pt3"
@@ -483,7 +479,7 @@ exports[`themes download renders as expected 1`] = `
 
 exports[`themes error renders as expected 1`] = `
 <div
-  className="dr-ui--note py18 px18 round flex mb18 bg-red-faint undefined"
+  className="dr-ui--note py18 px18 round flex mb18 bg-red-faint color-red-dark"
 >
   <div
     className="mr18 none block-mm pt3"
@@ -550,7 +546,7 @@ exports[`themes error renders as expected 1`] = `
 exports[`themes fundamentals renders as expected 1`] = `
 <div>
   <div
-    className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-s px6 bg-pink-faint"
+    className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-pink-faint color-pink-dark txt-s px6"
     data-state="closed"
     onBlur={[Function]}
     onClick={[Function]}
@@ -567,7 +563,7 @@ exports[`themes fundamentals renders as expected 1`] = `
     FUNDAMENTALS
   </div>
   <div
-    className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-xs px6 bg-pink-faint"
+    className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-pink-faint color-pink-dark txt-xs px6"
     data-state="closed"
     onBlur={[Function]}
     onClick={[Function]}
@@ -584,7 +580,7 @@ exports[`themes fundamentals renders as expected 1`] = `
     FUNDAMENTALS
   </div>
   <div
-    className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-s bg-pink-faint"
+    className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-pink-faint color-pink-dark txt-s"
     data-state="closed"
     onBlur={[Function]}
     onClick={[Function]}
@@ -635,7 +631,7 @@ exports[`themes fundamentals renders as expected 1`] = `
     </span>
   </div>
   <div
-    className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-xs bg-pink-faint"
+    className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-pink-faint color-pink-dark txt-xs"
     data-state="closed"
     onBlur={[Function]}
     onClick={[Function]}
@@ -754,7 +750,7 @@ exports[`themes legacy or warning renders as expected 1`] = `
     </div>
   </div>
   <div
-    className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-s px6 bg-orange-faint"
+    className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-orange-faint color-orange-dark txt-s px6"
     data-state="closed"
     onBlur={[Function]}
     onClick={[Function]}
@@ -771,7 +767,7 @@ exports[`themes legacy or warning renders as expected 1`] = `
     LEGACY
   </div>
   <div
-    className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-xs px6 bg-orange-faint"
+    className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-orange-faint color-orange-dark txt-xs px6"
     data-state="closed"
     onBlur={[Function]}
     onClick={[Function]}
@@ -788,7 +784,7 @@ exports[`themes legacy or warning renders as expected 1`] = `
     LEGACY
   </div>
   <div
-    className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-s bg-orange-faint"
+    className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-orange-faint color-orange-dark txt-s"
     data-state="closed"
     onBlur={[Function]}
     onClick={[Function]}
@@ -839,7 +835,7 @@ exports[`themes legacy or warning renders as expected 1`] = `
     </span>
   </div>
   <div
-    className="round inline-block cursor-default txt-fancy-medium color-gray-dark txt-xs bg-orange-faint"
+    className="txt-fancy-medium round inline-block cursor-default color-gray-dark bg-orange-faint color-orange-dark txt-xs"
     data-state="closed"
     onBlur={[Function]}
     onClick={[Function]}

--- a/src/components/themes/themes.js
+++ b/src/components/themes/themes.js
@@ -35,6 +35,7 @@ const themes = {
     image: <Image icon="book" color="gray" />,
     label: 'NOTE',
     icon: 'book',
+    color: 'color-text',
     background: 'bg-gray-faint'
   },
   warning: {
@@ -49,44 +50,50 @@ const themes = {
     image: <Image icon="alert" color="red" />,
     label: 'ERROR',
     icon: 'alert',
-    background: 'bg-red-faint'
+    background: 'bg-red-faint',
+    color: 'color-red-dark'
   },
   beta: {
     image: <Image icon="lightning" color="blue" />,
     label: 'BETA',
     icon: 'lightning',
     tooltipText: 'This feature is in public beta and is subject to changes.',
-    styles: {
-      backgroundColor: '#CBE4FF'
-    }
+    background: 'bg-blue-faint',
+    color: 'color-blue-dark',
+    border: 'border--blue-dark'
   },
   new: {
     image: <Image icon="plus" color="green" />,
     label: 'NEW',
     icon: 'plus',
     tooltipText: 'This feature was released recently.',
-    styles: {
-      backgroundColor: '#C9F2DD'
-    }
+    background: 'bg-green-faint',
+    color: 'color-green-dark',
+    border: 'border--green-dark'
   },
   download: {
     image: <Image icon="arrow-down" color="purple" />,
     label: 'DOWNLOAD',
     icon: 'arrow-down',
-    background: 'bg-purple-faint'
+    background: 'bg-purple-faint',
+    color: 'color-purple-dark'
   },
   fundamentals: {
     label: 'FUNDAMENTALS',
     icon: 'bookmark',
     tooltipText:
       'The concepts described here are fundamental to using this product.',
-    background: 'bg-pink-faint'
+    background: 'bg-pink-faint',
+    color: 'color-pink-dark',
+    border: 'border--pink-dark'
   },
   pricing: {
     image: <Image icon="creditcard" color="green" />,
     label: 'PRICING',
     tooltipText: 'This contains information about product pricing.',
-    background: 'bg-green-faint'
+    background: 'bg-green-faint',
+    color: 'color-green-dark',
+    border: 'border--green-dark'
   }
 };
 /* duplicate themes */


### PR DESCRIPTION
Restores `theme` color and background color classnames which were lost in the recent redesign. The component was refactored before the decision to use `mbx-assembly-docs` for custom colors, but was never reset.  `theme.js` colors are used by both `Note` and `Tag` This was causing some `Note` components to show up with no background.

<img width="608" alt="image" src="https://github.com/mapbox/dr-ui/assets/1833820/46207f1c-1571-45c8-aaa0-1672ea21ff39">
<img width="648" alt="image" src="https://github.com/mapbox/dr-ui/assets/1833820/ab9132c0-6340-4860-b378-3eefc0d78a15">
