### PR TITLE
update video modal

### DIFF
--- a/src/components/video-modal/video-modal.js
+++ b/src/components/video-modal/video-modal.js
@@ -15,10 +15,11 @@ export default class VideoModal extends React.PureComponent {
       >
         <div
           style={{
-            width: '80vw',
-            height: '45vw',
+            width: '65vw',
             maxWidth: '1140px',
-            maxHeight: '641px'
+            // 62.5% === 16:9 aspect ratio
+            padding: '62.5% 0 0 0',
+            position: 'relative'
           }}
         >
           <iframe
@@ -31,7 +32,13 @@ export default class VideoModal extends React.PureComponent {
             frameBorder="0"
             allow="autoplay; fullscreen"
             allowFullScreen
-            style={{ display: 'block' }}
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              height: '100%'
+            }}
           />
         </div>
       </Modal>

--- a/src/components/video-modal/video-modal.js
+++ b/src/components/video-modal/video-modal.js
@@ -17,8 +17,8 @@ export default class VideoModal extends React.PureComponent {
           style={{
             width: '65vw',
             maxWidth: '1140px',
-            // 62.5% === 16:9 aspect ratio
-            padding: '62.5% 0 0 0',
+            // 56.25% === 16:9 aspect ratio
+            padding: '56.25% 0 0 0',
             position: 'relative'
           }}
         >


### PR DESCRIPTION
- Reduces the modal width to 65vw instead of 80, which is more reasonable to keep the video in view when viewing the docs on a laptop.
- Refactors the styling to use the previous approach to maintaining the aspect ratio (uses % based padding so that the height does not need to be defined anywhere)