### PR TITLE
remove calls to mr-ui getWindow util

### DIFF
--- a/src/components/search/search-modal.js
+++ b/src/components/search/search-modal.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import AriaModal from 'react-aria-modal';
-import getWindow from '@mapbox/mr-ui/utils/get-window';
 
 export default class Modal extends React.PureComponent {
   constructor(props) {
@@ -11,7 +10,7 @@ export default class Modal extends React.PureComponent {
 
   componentDidMount() {
     if (!this.dialogEl || typeof window === 'undefined') return;
-    this.scrollTimeout = getWindow().setTimeout(() => {
+    this.scrollTimeout = window.setTimeout(() => {
       const offsetParent = this.dialogEl.offsetParent;
       if (offsetParent.tagName === 'BODY' || offsetParent.tagName === 'HTML') {
         return;
@@ -22,7 +21,7 @@ export default class Modal extends React.PureComponent {
 
   componentWillUnmount() {
     if (typeof window === 'undefined') return;
-    getWindow().clearTimeout(this.scrollTimeout);
+    window.clearTimeout(this.scrollTimeout);
   }
 
   setDialogEl(el) {


### PR DESCRIPTION
Removes calls to `mr-ui` `getWindow()` util which causes issues when rendering SSR pages and is being removed from `mr-ui` in https://github.com/mapbox/mr-ui/pull/216