### PR TITLE
Pass in GettingStartedIcon instance to OverviewHeader test case

### DIFF
--- a/src/components/overview-header/__tests__/overview-header-test-cases.js
+++ b/src/components/overview-header/__tests__/overview-header-test-cases.js
@@ -164,7 +164,7 @@ testCases.card = {
     description: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.',
     title: 'Mapbox SDK for Breakfast',
     highlightColor: 'blue',
-    titleIcon: GettingStartedIcon,
+    titleIcon: <GettingStartedIcon />,
     card: true
   }
 };


### PR DESCRIPTION
In the test cases for OverviewHeader, we were passing in 
GettingStartedIcon instead of <GettingStartedIcon/> causing a console 
error and the `titleIcon` to not show.
