### PR TITLE
fix breadcrumb key

### DIFF
--- a/src/components/breadcrumb/breadcrumb.js
+++ b/src/components/breadcrumb/breadcrumb.js
@@ -37,11 +37,11 @@ export default class Breadcrumb extends React.PureComponent {
       >
         {links.map((link, index) => {
           return link.path !== location.pathname ? (
-            <Link key={link.title} href={link.path} index={index}>
+            <Link key={index} href={link.path} index={index}>
               {link.title}
             </Link>
           ) : (
-            <span key={link.title} className="color-gray none inline-block-mm">
+            <span key={index} className="color-gray none inline-block-mm">
               {link.title}
             </span>
           );

--- a/src/components/overview-header/__tests__/overview-header-test-cases.js
+++ b/src/components/overview-header/__tests__/overview-header-test-cases.js
@@ -164,7 +164,7 @@ testCases.card = {
     description: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.',
     title: 'Mapbox SDK for Breakfast',
     highlightColor: 'blue',
-    titleIcon: GettingStartedIcon,
+    titleIcon: <GettingStartedIcon />,
     card: true
   }
 };


### PR DESCRIPTION
In `Breadcrumb`, uses the `index` as the react element key instead of `link.title` which could be 
undefined.

This fix will prevent unique key warnings from appearing in the console during builds if there are 
pages with no title (e.g. when building the docs for mr-ui, as changelog.md generates a page but 
has no title)y

