### PR TITLE
style index card title/tag for proper vertical spacing when wrapped

### DIFF
--- a/src/components/index-card/__tests__/__snapshots__/index-card.test.js.snap
+++ b/src/components/index-card/__tests__/__snapshots__/index-card.test.js.snap
@@ -27,7 +27,7 @@ exports[`index-card Basic use as a product card with links renders as expected 1
           className="flex flex--center-cross"
         >
           <h3
-            className="txt-fancy txt-l mb12"
+            className="txt-fancy txt-l mb-neg6 flex flex--wrap flex--center-cross mb12"
             style={
               Object {
                 "fontSize": 18,
@@ -35,13 +35,13 @@ exports[`index-card Basic use as a product card with links renders as expected 1
               }
             }
           >
-            <span
-              className="mr6"
+            <div
+              className="mr6 mb6 txt-nowrap"
             >
               Mapbox GL JS
-            </span>
+            </div>
             <div
-              className="inline-block mr6 relative"
+              className="inline-block mr6 mb6 relative txt-nowrap"
               style={
                 Object {
                   "top": -2,
@@ -192,7 +192,7 @@ exports[`index-card Use as a help section card renders as expected 1`] = `
               </svg>
             </div>
             <h3
-              className="txt-fancy txt-l"
+              className="txt-fancy txt-l mb-neg6 flex flex--wrap flex--center-cross"
               style={
                 Object {
                   "fontSize": 18,
@@ -200,11 +200,11 @@ exports[`index-card Use as a help section card renders as expected 1`] = `
                 }
               }
             >
-              <span
-                className="mr6"
+              <div
+                className="mr6 mb6 txt-nowrap"
               >
                 Tutorials
-              </span>
+              </div>
             </h3>
           </div>
           <p

--- a/src/components/index-card/index-card.js
+++ b/src/components/index-card/index-card.js
@@ -72,17 +72,23 @@ const CardContent = ({
           </div>
         )}
         <h3
-          className={classnames('txt-fancy txt-l', {
-            mb12: !icon
-          })}
+          className={classnames(
+            'txt-fancy txt-l mb-neg6 flex flex--wrap flex--center-cross',
+            {
+              mb12: !icon
+            }
+          )}
           style={{
             fontSize: 18,
             lineHeight: '18px'
           }}
         >
-          <span className="mr6">{title}</span>
+          <div className="mr6 mb6 txt-nowrap">{title}</div>
           {tag && (
-            <div className="inline-block mr6 relative" style={{ top: -2 }}>
+            <div
+              className="inline-block mr6 mb6 relative txt-nowrap"
+              style={{ top: -2 }}
+            >
               {tag}
             </div>
           )}


### PR DESCRIPTION
Updates the assembly classes used on the title in `IndexCard`, adding 6 
pixels of spacing when the content wraps to mutliple lines.
Before

<img width="279" alt="image" src="https://github.com/mapbox/dr-ui/assets/1833820/f5286b7a-5c7c-4ae5-9a80-09426ca54ba3">


After
<img width="287" alt="image" src="https://github.com/mapbox/dr-ui/assets/1833820/b889981e-2885-4144-98b5-7185309da4c1">
