### PR TITLE
update search modal background to match mr-ui/modal

### DIFF
--- a/src/components/search/search-modal.js
+++ b/src/components/search/search-modal.js
@@ -47,8 +47,7 @@ export default class Modal extends React.PureComponent {
       underlayClass: 'px60 py120 ',
       underlayStyle: {
         zIndex: 10,
-        backdropFilter: 'blur(4px)',
-        backgroundColor: 'rgba(0,0,0,.2)'
+        backgroundColor: 'rgba(14,33,39,.5)'
       }
     };
 


### PR DESCRIPTION
Updates the search modal to use the same styling as `mr-ui/modal` for 
consist UX across the site. (e.g. `VideoModal` uses `mr-ui/modal` and we 
don't want two different modal experiences)
