### PR TITLE
export cardboxshadow from index-card

### DIFF
--- a/src/components/index-card/index.js
+++ b/src/components/index-card/index.js
@@ -1,3 +1,5 @@
-import main from './index-card';
+import main, { cardBoxShadow, renderDocLink } from './index-card';
 
 export default main;
+
+export { cardBoxShadow, renderDocLink };


### PR DESCRIPTION
Exports `cardBoxShadow` for use in other components and consuming docs sites.
