### PR TITLE
Andrew/add playground type To Feedback Component

### DIFF
--- a/src/components/feedback/feedback.js
+++ b/src/components/feedback/feedback.js
@@ -27,6 +27,7 @@ FeedbackWrapper.propTypes = {
 };
 
 const Feedback = (props) => {
+  console.log('props are', props);
   const { type } = props;
 
   const [user, setUser] = useState(undefined);

--- a/src/components/feedback/feedback.js
+++ b/src/components/feedback/feedback.js
@@ -27,7 +27,6 @@ FeedbackWrapper.propTypes = {
 };
 
 const Feedback = (props) => {
-  console.log('props are', props);
   const { type } = props;
 
   const [user, setUser] = useState(undefined);

--- a/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
+++ b/src/components/page-layout/__tests__/__snapshots__/page-layout.test.js.snap
@@ -1375,7 +1375,7 @@ Array [
                   className="txt-fancy txt-m flex flex--center-cross"
                 >
                   Was this 
-                  example
+                  page
                    helpful?
                   <span
                     className="ml18"

--- a/src/components/page-layout/components/content.js
+++ b/src/components/page-layout/components/content.js
@@ -54,7 +54,11 @@ Content.propTypes = {
 export class ContentWrapper extends React.PureComponent {
   renderFeedback = () => {
     const { location, section, layoutConfig } = this.props;
-    const { layout } = layoutConfig;
+    // Check contentType to see if it's 'playground'
+    const { layout, contentType } = layoutConfig;
+    // Adapt conditional below to set Type as needed.
+    console.log(contentType);
+    // TODO check contentType when layout === example
 
     const { SITE, FORWARD_EVENT_WEBHOOK } = this.props.constants;
     return (
@@ -210,6 +214,7 @@ ContentWrapper.propTypes = {
   }).isRequired,
   layoutConfig: PropTypes.shape({
     layout: PropTypes.string,
+    contentType: PropTypes.string,
     hideTitle: PropTypes.bool,
     showCards: PropTypes.bool,
     hideFeedback: PropTypes.bool,

--- a/src/components/page-layout/components/content.js
+++ b/src/components/page-layout/components/content.js
@@ -213,7 +213,6 @@ ContentWrapper.propTypes = {
     }).isRequired
   }).isRequired,
   layoutConfig: PropTypes.shape({
-    layout: PropTypes.string,
     contentType: PropTypes.string,
     hideTitle: PropTypes.bool,
     showCards: PropTypes.bool,

--- a/src/components/page-layout/components/content.js
+++ b/src/components/page-layout/components/content.js
@@ -54,15 +54,11 @@ Content.propTypes = {
 export class ContentWrapper extends React.PureComponent {
   renderFeedback = () => {
     const { location, section, layoutConfig } = this.props;
-    // Check contentType to see if it's 'playground' or 'example'
     const { contentType } = layoutConfig;
     let feedbackType = '';
     if (contentType === 'example' || contentType === 'playground') {
       feedbackType = contentType;
     }
-    // Adapt conditional below to set Type as needed.
-    console.log(contentType);
-    // TODO check contentType when layout === example
 
     const { SITE, FORWARD_EVENT_WEBHOOK } = this.props.constants;
     return (

--- a/src/components/page-layout/components/content.js
+++ b/src/components/page-layout/components/content.js
@@ -54,8 +54,12 @@ Content.propTypes = {
 export class ContentWrapper extends React.PureComponent {
   renderFeedback = () => {
     const { location, section, layoutConfig } = this.props;
-    // Check contentType to see if it's 'playground'
-    const { layout, contentType } = layoutConfig;
+    // Check contentType to see if it's 'playground' or 'example'
+    const { contentType } = layoutConfig;
+    let feedbackType = '';
+    if (contentType === 'example' || contentType === 'playground') {
+      feedbackType = contentType;
+    }
     // Adapt conditional below to set Type as needed.
     console.log(contentType);
     // TODO check contentType when layout === example
@@ -64,7 +68,7 @@ export class ContentWrapper extends React.PureComponent {
     return (
       <Feedback
         {...this.props}
-        type={layout === 'example' ? 'example' : undefined}
+        type={feedbackType ? feedbackType : undefined}
         site={SITE}
         location={location}
         section={section}


### PR DESCRIPTION
<!-- List what changes this PR introduces. -->

- This change adds some intelligence to the `<ContentWrapper>` component to check props for the `layoutConfig.contentType` to determine if the location in which the component is being rendered is an example page or a playground page.
- If it is either of these types, the value is passed into the `type` prop of the `<Feedback>` component.  If it's not either of these values, an undefined value is passed into the type and `<Feedback>`'s default prop type of `page` is used.  

## How to test

- Ensure that your local Dr-UI repo is connected (via `npx link`) to the playgrounds repo, and the GL-JS-docs repo.  
- Pull down this branch, run `npm run build` in dr-ui
- Start the connected playground repo and check the output of the feedback module on a playground page to ensure it reads 'Was this playground helpful?`.  
- Start the connected  gl-js-docs repo and load an example page to ensure the output on the feedback module is ' Was this example helpful?'
- Check other locations in gl-js-docs live preview to ensure 'Was this page helpful?' and 'Was this section on ______ helpful?' are also returned in the appropriate places.  

