### PR TITLE
update mbx-assembly-docs peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "uuid": "^9.0.0"
   },
   "peerDependencies": {
-    "@mapbox/mbx-assembly-docs": "^0.1.0",
+    "@mapbox/mbx-assembly-docs": ">=0",
     "react": "^16.14.0",
     "react-dom": "^16.14.0"
   },


### PR DESCRIPTION
`@mapbox/mbx-assembly-docs@"^0.1.0` caused a dependency resolution issue due to the way npm treads 0 major versions.  