### PR TITLE
Add tag support to index card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## main
+
+- Add a way to display tags for links in `src/components/index-card.js`.
+
 ## 6.5.0
 
 - Added new FAQ content type to `helpers/help-card-data.js`, separated help icons into `helpers/icons` and upgraded `src/components/card.js` to have hover styles and a RightArrow icon for the card

--- a/src/components/index-card/index-card.js
+++ b/src/components/index-card/index-card.js
@@ -141,6 +141,14 @@ const CardContent = ({
                   }}
                 >
                   {link.title}
+                  {link.tag && (
+                    <div
+                      className="inline-block ml6 relative txt-nowrap"
+                      style={{ top: -1 }}
+                    >
+                      {link.tag}
+                    </div>
+                  )}
                 </Button>
               </div>
             );


### PR DESCRIPTION
This PR adds a way to display tags for links in `IndexCard`.

<img width="304" alt="Screenshot 2024-01-09 at 9 36 51" src="https://github.com/mapbox/dr-ui/assets/1478430/da6fe83f-f227-4731-8fab-7ac908f83027">
