### PR TITLE
restore index card icons

### DIFF
--- a/src/components/index-card/__tests__/__snapshots__/index-card.test.js.snap
+++ b/src/components/index-card/__tests__/__snapshots__/index-card.test.js.snap
@@ -86,18 +86,25 @@ exports[`index-card Basic use as a product card with links renders as expected 1
           >
             <a
               aria-label="Mapbox GL JS"
-              className="btn btn--stroke round-full pb6 txt-xs txt-nowrap color-gray-deep px12 color-white-on-hover shadow-white-on-hover txt-fancy-regular bg-green-light-on-hover"
+              className="btn btn--stroke round-full pb6 txt-xs txt-nowrap color-gray-deep px12 color-white-on-hover shadow-white-on-hover txt-fancy-regular flex bg-green-light-on-hover"
               href="https://docs.mapbox.com/mapbox-gl-js/"
               style={
                 Object {
                   "fontSize": 14,
                   "fontWeight": 500,
                   "lineHeight": "17px",
-                  "paddingTop": "7px",
                 }
               }
             >
-              GL JS Docs
+              <div
+                style={
+                  Object {
+                    "paddingTop": 1,
+                  }
+                }
+              >
+                GL JS Docs
+              </div>
             </a>
           </div>
           <div
@@ -105,18 +112,25 @@ exports[`index-card Basic use as a product card with links renders as expected 1
           >
             <a
               aria-label="Mapbox GL JS"
-              className="btn btn--stroke round-full pb6 txt-xs txt-nowrap color-gray-deep px12 color-white-on-hover shadow-white-on-hover txt-fancy-regular bg-green-light-on-hover"
+              className="btn btn--stroke round-full pb6 txt-xs txt-nowrap color-gray-deep px12 color-white-on-hover shadow-white-on-hover txt-fancy-regular flex bg-green-light-on-hover"
               href="https://docs.mapbox.com/mapbox-gl-js/plugins/#framework-integrations"
               style={
                 Object {
                   "fontSize": 14,
                   "fontWeight": 500,
                   "lineHeight": "17px",
-                  "paddingTop": "7px",
                 }
               }
             >
-              JS Frameworks
+              <div
+                style={
+                  Object {
+                    "paddingTop": 1,
+                  }
+                }
+              >
+                JS Frameworks
+              </div>
             </a>
           </div>
         </div>

--- a/src/components/index-card/index-card.js
+++ b/src/components/index-card/index-card.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Button from '@mapbox/mr-ui/button';
+import Icon from '@mapbox/mr-ui/icon';
 
 export const cardBoxShadow = '0px 2px 5px 0px #5F7E9B59';
 
@@ -129,18 +130,22 @@ const CardContent = ({
                   passthroughProps={{
                     'aria-label': link.tooltip,
                     className: classnames(
-                      'btn btn--stroke round-full pb6 txt-xs txt-nowrap color-gray-deep px12 color-white-on-hover shadow-white-on-hover txt-fancy-regular',
+                      'btn btn--stroke round-full pb6 txt-xs txt-nowrap color-gray-deep px12 color-white-on-hover shadow-white-on-hover txt-fancy-regular flex',
                       `bg-${sectionColor}-on-hover`
                     ),
                     style: {
                       fontSize: 14,
                       fontWeight: 500,
-                      lineHeight: '17px',
-                      paddingTop: '7px'
+                      lineHeight: '17px'
                     }
                   }}
                 >
-                  {link.title}
+                  {link.icon && (
+                    <div className="mr3">
+                      <Icon name={link.icon} />
+                    </div>
+                  )}
+                  <div style={{ paddingTop: 1 }}>{link.title}</div>
                 </Button>
               </div>
             );


### PR DESCRIPTION
<img width="913" alt="Documentation___Mapbox" src="https://github.com/mapbox/dr-ui/assets/1833820/83692374-6cb4-42c1-b37f-0464a617ee2a">

Restores `link.icon` use in `IndexCard`, rendering an icon. within the buttons
