### PR TITLE
Update index card

### DIFF
--- a/src/components/index-card/index-card.js
+++ b/src/components/index-card/index-card.js
@@ -151,16 +151,23 @@ const CardContent = ({
 );
 
 const IndexCard = (props) => {
-  const { title, link, isLinkList } = props;
+  const { title, link, isLinkList, colSize } = props;
+  // Col size defaults to w-1/4-mxl if no prop is specified
+  const cols = colSize ? colSize : '1/4';
+  const colsMed = cols.slice(0, -1) + (parseInt(cols.slice(-1), 10) - 1);
+
   return (
     <div
       key={title}
       style={{
         marginBottom: isLinkList && 40
       }}
-      className={classnames('col w-full w-1/2-mm w-1/3-ml w-1/4-mxl', {
-        mb18: !isLinkList
-      })}
+      className={classnames(
+        `col w-full w-1/2-mm w-${colsMed}-ml w-${cols}-mxl`,
+        {
+          mb18: !isLinkList
+        }
+      )}
     >
       <div className="h-full">
         {link ? (

--- a/src/components/index-card/index-card.js
+++ b/src/components/index-card/index-card.js
@@ -154,7 +154,7 @@ const IndexCard = (props) => {
   const { title, link, isLinkList, colSize } = props;
   // Col size defaults to w-1/4-mxl if no prop is specified
   const cols = colSize ? colSize : '1/4';
-  const colsMed = cols.slice(0, -1) + (parseInt(cols.slice(-1), 10) - 1);
+  const colsMed = cols.slice(0, -1) + (parseInt(cols.slice(-1)) - 1);
 
   return (
     <div


### PR DESCRIPTION
This PR introduces the `colSize` prop for `<IndexCard>` which gives the opportunity to set custom col layouts with the index card component.  `colSize` is a fraction based on [Assembly grid classes](https://labs.mapbox.com/assembly/documentation/#Grid).  The component consumes the fraction (for example `1/3`) and will set the width of the indexCard on medium to xl screens to 1/3.  Medium screen sizes (`colsMed`) get a fraction with the denominator - 1.  If no `colSize` is set, layout of IndexCards defaults to 1/4. 

## How to test

Create a component in a consuming site that looks like this.. 

```
          <IndexCard
              key={3}
              colSize={'1/3'}
              title={'Ticket Portal'}
              text={'Support Plan subscribers can submit and view their technical support tickets here.'}
              links={[
                { title: 'See your open tickets', link: 'https://support.mapbox.com/hc/en-us' }
              ]}
              sectionColor={'blue'}
            />
```

The `<div>` for that indexCard should have a class of `col w-full w-1/2-mm w-1/2-ml w-1/3-mxl mb18`


## Before merge

- [ ] Add entry to CHANGELOG.md to describe changes.

